### PR TITLE
Fix stack overflow caused by the WQuadtree

### DIFF
--- a/examples3d/debug_boxes3.rs
+++ b/examples3d/debug_boxes3.rs
@@ -17,22 +17,26 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_size = 100.1;
     let ground_height = 0.1;
 
-    let rigid_body = RigidBodyBuilder::new_static()
-        .translation(0.0, -ground_height, 0.0)
-        .build();
-    let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size).build();
-    colliders.insert(collider, handle, &mut bodies);
+    for _ in 0..6 {
+        let rigid_body = RigidBodyBuilder::new_static()
+            .translation(0.0, -ground_height, 0.0)
+            .build();
+        let handle = bodies.insert(rigid_body);
+        let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size).build();
+        colliders.insert(collider, handle, &mut bodies);
+    }
 
     // Build the dynamic box rigid body.
-    let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(1.1, 0.0, 0.0)
-        .rotation(Vector3::new(0.8, 0.2, 0.1))
-        .can_sleep(false)
-        .build();
-    let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(2.0, 0.1, 1.0).build();
-    colliders.insert(collider, handle, &mut bodies);
+    for _ in 0..6 {
+        let rigid_body = RigidBodyBuilder::new_dynamic()
+            .translation(1.1, 0.0, 0.0)
+            .rotation(Vector3::new(0.8, 0.2, 0.1))
+            .can_sleep(false)
+            .build();
+        let handle = bodies.insert(rigid_body);
+        let collider = ColliderBuilder::cuboid(2.0, 0.1, 1.0).build();
+        colliders.insert(collider, handle, &mut bodies);
+    }
 
     /*
      * Set up the testbed.


### PR DESCRIPTION
The WQuadtree construction function would overflow the stack whenever more than 4 AABBs with the same center are provided. Moreover, this same configuration would cause a subtraction underflow.

This PR fixes both bugs.