### PR TITLE
fix panic from usize being set to -1

### DIFF
--- a/src/geometry/wquadtree.rs
+++ b/src/geometry/wquadtree.rs
@@ -539,7 +539,7 @@ fn split_indices_wrt_dim<'a>(
     dim: usize,
 ) -> (&'a mut [usize], &'a mut [usize]) {
     let mut icurr = 0;
-    let mut ilast = indices.len() - 1;
+    let mut ilast = indices.len();
 
     // The loop condition we can just do 0..indices.len()
     // instead of the test icurr < ilast because we know
@@ -549,10 +549,7 @@ fn split_indices_wrt_dim<'a>(
         let center = aabbs[i].center();
 
         if center[dim] > split_point[dim] {
-            indices.swap(icurr, ilast);
-            if ilast == 0 {
-                break;
-            }
+            indices.swap(icurr, ilast - 1);
             ilast -= 1;
         } else {
             icurr += 1;

--- a/src/geometry/wquadtree.rs
+++ b/src/geometry/wquadtree.rs
@@ -550,6 +550,9 @@ fn split_indices_wrt_dim<'a>(
 
         if center[dim] > split_point[dim] {
             indices.swap(icurr, ilast);
+            if ilast == 0 {
+                break;
+            }
             ilast -= 1;
         } else {
             icurr += 1;


### PR DESCRIPTION
When center[dim] > split_point[dim] is true for all indices, at the end of the last iteration ilast is set to -1 which causes a panic because it is unsigned. This PR fixes that issue.