### PR TITLE
Add a 128-bits user-data attached to colliders and rigid-bodies.

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -54,6 +54,8 @@ pub struct RigidBody {
     pub(crate) active_set_timestamp: u32,
     /// The status of the body, governing how it is affected by external forces.
     pub body_status: BodyStatus,
+    /// User-defined associated to this rigid-body.
+    pub user_data: u128,
 }
 
 impl Clone for RigidBody {
@@ -90,6 +92,7 @@ impl RigidBody {
             active_set_offset: 0,
             active_set_timestamp: 0,
             body_status: BodyStatus::Dynamic,
+            user_data: 0,
         }
     }
 
@@ -342,6 +345,7 @@ pub struct RigidBodyBuilder {
     angvel: AngVector<f32>,
     body_status: BodyStatus,
     can_sleep: bool,
+    user_data: u128,
 }
 
 impl RigidBodyBuilder {
@@ -353,6 +357,7 @@ impl RigidBodyBuilder {
             angvel: na::zero(),
             body_status,
             can_sleep: true,
+            user_data: 0,
         }
     }
 
@@ -400,6 +405,12 @@ impl RigidBodyBuilder {
         self
     }
 
+    /// An arbitrary user-defined 128-bit integer associated to the rigid-bodies built by this builder.
+    pub fn user_data(mut self, data: u128) -> Self {
+        self.user_data = data;
+        self
+    }
+
     /// Sets the initial linear velocity of the rigid-body to be created.
     #[cfg(feature = "dim2")]
     pub fn linvel(mut self, x: f32, y: f32) -> Self {
@@ -434,6 +445,7 @@ impl RigidBodyBuilder {
         rb.linvel = self.linvel;
         rb.angvel = self.angvel;
         rb.body_status = self.body_status;
+        rb.user_data = self.user_data;
 
         if !self.can_sleep {
             rb.activation.threshold = -1.0;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -54,7 +54,7 @@ pub struct RigidBody {
     pub(crate) active_set_timestamp: u32,
     /// The status of the body, governing how it is affected by external forces.
     pub body_status: BodyStatus,
-    /// User-defined associated to this rigid-body.
+    /// User-defined data associated to this rigid-body.
     pub user_data: u128,
 }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -206,6 +206,7 @@ pub struct Collider {
     pub(crate) contact_graph_index: ColliderGraphIndex,
     pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
+    /// User-defined data associated to this rigid-body.
     pub user_data: u128,
 }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -206,6 +206,7 @@ pub struct Collider {
     pub(crate) contact_graph_index: ColliderGraphIndex,
     pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
+    pub user_data: u128,
 }
 
 impl Clone for Collider {
@@ -296,6 +297,8 @@ pub struct ColliderBuilder {
     pub delta: Isometry<f32>,
     /// Is this collider a sensor?
     pub is_sensor: bool,
+    /// The user-data of the collider beind built.
+    pub user_data: u128,
 }
 
 impl ColliderBuilder {
@@ -308,6 +311,7 @@ impl ColliderBuilder {
             restitution: 0.0,
             delta: Isometry::identity(),
             is_sensor: false,
+            user_data: 0,
         }
     }
 
@@ -413,6 +417,12 @@ impl ColliderBuilder {
         0.5
     }
 
+    /// An arbitrary user-defined 128-bit integer associated to the colliders built by this builder.
+    pub fn user_data(mut self, data: u128) -> Self {
+        self.user_data = data;
+        self
+    }
+
     /// Sets whether or not the collider built by this builder is a sensor.
     pub fn sensor(mut self, is_sensor: bool) -> Self {
         self.is_sensor = is_sensor;
@@ -477,7 +487,7 @@ impl ColliderBuilder {
         self
     }
 
-    /// Buildes a new collider attached to the given rigid-body.
+    /// Builds a new collider attached to the given rigid-body.
     pub fn build(&self) -> Collider {
         let density = self.get_density();
 
@@ -494,6 +504,7 @@ impl ColliderBuilder {
             contact_graph_index: InteractionGraph::<Contact>::invalid_graph_index(),
             proximity_graph_index: InteractionGraph::<Proximity>::invalid_graph_index(),
             proxy_index: crate::INVALID_USIZE,
+            user_data: self.user_data,
         }
     }
 }


### PR DESCRIPTION
With this PR, we allow one user-defined `u128` integer to be associated to each collider and rigid-bodies. The typical use-case is to store an entity ID from an ECS-based game engine. More generally, it can store and index to an external data vector. In addition, this is serializable in case the user needs it.