### PR TITLE
Add collision filtering based in bit masks

### DIFF
--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -49,6 +49,7 @@ erased-serde = { version = "0.3", optional = true }
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
+bitflags = "1"
 
 [dev-dependencies]
 bincode = "1"

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -49,7 +49,7 @@ erased-serde = { version = "0.3", optional = true }
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
-
+bitflags = "1"
 
 [dev-dependencies]
 bincode = "1"

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -11,6 +11,7 @@ use rapier_testbed2d::Testbed;
 use std::cmp::Ordering;
 
 mod add_remove2;
+mod collision_groups2;
 mod debug_box_ball2;
 mod heightfield2;
 mod joints2;
@@ -52,6 +53,7 @@ pub fn main() {
 
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
         ("Add remove", add_remove2::init_world),
+        ("Collision groups", collision_groups2::init_world),
         ("Heightfield", heightfield2::init_world),
         ("Joints", joints2::init_world),
         ("Platform", platform2::init_world),

--- a/examples2d/collision_groups2.rs
+++ b/examples2d/collision_groups2.rs
@@ -1,0 +1,98 @@
+use na::{Point2, Point3};
+use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::geometry::{ColliderBuilder, ColliderSet, InteractionGroups};
+use rapier_testbed2d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+
+    /*
+     * Ground
+     */
+    let ground_size = 5.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height)
+        .build();
+    let floor_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height).build();
+    colliders.insert(collider, floor_handle, &mut bodies);
+
+    /*
+     * Setup groups
+     */
+    const GREEN_GROUP: InteractionGroups = InteractionGroups::new(0b01, 0b01);
+    const BLUE_GROUP: InteractionGroups = InteractionGroups::new(0b10, 0b10);
+
+    /*
+     * A green floor that will collide with the GREEN group only.
+     */
+    let green_floor = ColliderBuilder::cuboid(1.0, 0.1)
+        .translation(0.0, 1.0)
+        .collision_groups(GREEN_GROUP)
+        .build();
+    let green_collider_handle = colliders.insert(green_floor, floor_handle, &mut bodies);
+
+    testbed.set_collider_initial_color(green_collider_handle, Point3::new(0.0, 1.0, 0.0));
+
+    /*
+     * A blue floor that will collide with the BLUE group only.
+     */
+    let blue_floor = ColliderBuilder::cuboid(1.0, 0.1)
+        .translation(0.0, 2.0)
+        .collision_groups(BLUE_GROUP)
+        .build();
+    let blue_collider_handle = colliders.insert(blue_floor, floor_handle, &mut bodies);
+
+    testbed.set_collider_initial_color(blue_collider_handle, Point3::new(0.0, 0.0, 1.0));
+
+    /*
+     * Create the cubes
+     */
+    let num = 8;
+    let rad = 0.1;
+
+    let shift = rad * 2.0;
+    let centerx = shift * (num / 2) as f32;
+    let centery = 2.5;
+
+    for j in 0usize..4 {
+        for i in 0..num {
+            let x = i as f32 * shift - centerx;
+            let y = j as f32 * shift + centery;
+
+            // Alternate between the green and blue groups.
+            let (group, color) = if i % 2 == 0 {
+                (GREEN_GROUP, Point3::new(0.0, 1.0, 0.0))
+            } else {
+                (BLUE_GROUP, Point3::new(0.0, 0.0, 1.0))
+            };
+
+            let rigid_body = RigidBodyBuilder::new_dynamic().translation(x, y).build();
+            let handle = bodies.insert(rigid_body);
+            let collider = ColliderBuilder::cuboid(rad, rad)
+                .collision_groups(group)
+                .build();
+            colliders.insert(collider, handle, &mut bodies);
+
+            testbed.set_body_color(handle, color);
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point2::new(0.0, 1.0), 100.0);
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -11,6 +11,7 @@ use rapier_testbed3d::Testbed;
 use std::cmp::Ordering;
 
 mod add_remove3;
+mod collision_groups3;
 mod compound3;
 mod debug_boxes3;
 mod debug_cylinder3;
@@ -65,6 +66,7 @@ pub fn main() {
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
         ("Add remove", add_remove3::init_world),
         ("Primitives", primitives3::init_world),
+        ("Collision groups", collision_groups3::init_world),
         ("Compound", compound3::init_world),
         ("Domino", domino3::init_world),
         ("Heightfield", heightfield3::init_world),

--- a/examples3d/collision_groups3.rs
+++ b/examples3d/collision_groups3.rs
@@ -1,0 +1,102 @@
+use na::Point3;
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet, InteractionGroups};
+use rapier_testbed3d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+
+    /*
+     * Ground
+     */
+    let ground_size = 5.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height, 0.0)
+        .build();
+    let floor_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size).build();
+    colliders.insert(collider, floor_handle, &mut bodies);
+
+    /*
+     * Setup groups
+     */
+    const GREEN_GROUP: InteractionGroups = InteractionGroups::new(0b01, 0b01);
+    const BLUE_GROUP: InteractionGroups = InteractionGroups::new(0b10, 0b10);
+
+    /*
+     * A green floor that will collide with the GREEN group only.
+     */
+    let green_floor = ColliderBuilder::cuboid(1.0, 0.1, 1.0)
+        .translation(0.0, 1.0, 0.0)
+        .collision_groups(GREEN_GROUP)
+        .build();
+    let green_collider_handle = colliders.insert(green_floor, floor_handle, &mut bodies);
+
+    testbed.set_collider_initial_color(green_collider_handle, Point3::new(0.0, 1.0, 0.0));
+
+    /*
+     * A blue floor that will collide with the BLUE group only.
+     */
+    let blue_floor = ColliderBuilder::cuboid(1.0, 0.1, 1.0)
+        .translation(0.0, 2.0, 0.0)
+        .collision_groups(BLUE_GROUP)
+        .build();
+    let blue_collider_handle = colliders.insert(blue_floor, floor_handle, &mut bodies);
+
+    testbed.set_collider_initial_color(blue_collider_handle, Point3::new(0.0, 0.0, 1.0));
+
+    /*
+     * Create the cubes
+     */
+    let num = 8;
+    let rad = 0.1;
+
+    let shift = rad * 2.0;
+    let centerx = shift * (num / 2) as f32;
+    let centery = 2.5;
+    let centerz = shift * (num / 2) as f32;
+
+    for j in 0usize..4 {
+        for i in 0..num {
+            for k in 0usize..num {
+                let x = i as f32 * shift - centerx;
+                let y = j as f32 * shift + centery;
+                let z = k as f32 * shift - centerz;
+
+                // Alternate between the green and blue groups.
+                let (group, color) = if k % 2 == 0 {
+                    (GREEN_GROUP, Point3::new(0.0, 1.0, 0.0))
+                } else {
+                    (BLUE_GROUP, Point3::new(0.0, 0.0, 1.0))
+                };
+
+                let rigid_body = RigidBodyBuilder::new_dynamic().translation(x, y, z).build();
+                let handle = bodies.insert(rigid_body);
+                let collider = ColliderBuilder::cuboid(rad, rad, rad)
+                    .collision_groups(group)
+                    .build();
+                colliders.insert(collider, handle, &mut bodies);
+
+                testbed.set_body_color(handle, color);
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point3::new(10.0, 10.0, 10.0), Point3::origin());
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -204,6 +204,7 @@ pub struct Collider {
     /// The restitution coefficient of this collider.
     pub restitution: f32,
     pub(crate) collision_groups: InteractionGroups,
+    pub(crate) solver_groups: InteractionGroups,
     pub(crate) contact_graph_index: ColliderGraphIndex,
     pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
@@ -261,6 +262,11 @@ impl Collider {
         self.collision_groups
     }
 
+    /// The solver groups used by this collider.
+    pub fn solver_groups(&self) -> InteractionGroups {
+        self.solver_groups
+    }
+
     /// The density of this collider.
     pub fn density(&self) -> f32 {
         self.density
@@ -304,10 +310,12 @@ pub struct ColliderBuilder {
     pub delta: Isometry<f32>,
     /// Is this collider a sensor?
     pub is_sensor: bool,
-    /// The user-data of the collider beind built.
+    /// The user-data of the collider being built.
     pub user_data: u128,
     /// The collision groups for the collider being built.
     pub collision_groups: InteractionGroups,
+    /// The solver groups for the collider being built.
+    pub solver_groups: InteractionGroups,
 }
 
 impl ColliderBuilder {
@@ -322,6 +330,7 @@ impl ColliderBuilder {
             is_sensor: false,
             user_data: 0,
             collision_groups: InteractionGroups::all(),
+            solver_groups: InteractionGroups::all(),
         }
     }
 
@@ -442,6 +451,15 @@ impl ColliderBuilder {
         self
     }
 
+    /// Sets the solver groups used by this collider.
+    ///
+    /// Forces between two colliders in contact will be computed iff their solver groups are
+    /// compatible. See [InteractionGroups::test] for details.
+    pub fn solver_groups(mut self, groups: InteractionGroups) -> Self {
+        self.solver_groups = groups;
+        self
+    }
+
     /// Sets whether or not the collider built by this builder is a sensor.
     pub fn sensor(mut self, is_sensor: bool) -> Self {
         self.is_sensor = is_sensor;
@@ -523,6 +541,8 @@ impl ColliderBuilder {
             contact_graph_index: InteractionGraph::<Contact>::invalid_graph_index(),
             proximity_graph_index: InteractionGraph::<Proximity>::invalid_graph_index(),
             proxy_index: crate::INVALID_USIZE,
+            collision_groups: self.collision_groups,
+            solver_groups: self.solver_groups,
             user_data: self.user_data,
         }
     }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,7 +1,7 @@
 use crate::dynamics::{MassProperties, RigidBodyHandle, RigidBodySet};
 use crate::geometry::{
-    Ball, Capsule, ColliderGraphIndex, Contact, Cuboid, HeightField, InteractionGraph, Proximity,
-    Segment, Shape, ShapeType, Triangle, Trimesh,
+    Ball, Capsule, ColliderGraphIndex, Contact, Cuboid, HeightField, InteractionGraph,
+    InteractionGroups, Proximity, Segment, Shape, ShapeType, Triangle, Trimesh,
 };
 #[cfg(feature = "dim3")]
 use crate::geometry::{Cone, Cylinder, RoundCylinder};
@@ -203,6 +203,7 @@ pub struct Collider {
     pub friction: f32,
     /// The restitution coefficient of this collider.
     pub restitution: f32,
+    pub(crate) collision_groups: InteractionGroups,
     pub(crate) contact_graph_index: ColliderGraphIndex,
     pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
@@ -255,6 +256,11 @@ impl Collider {
         &self.delta
     }
 
+    /// The collision groups used by this collider.
+    pub fn collision_groups(&self) -> InteractionGroups {
+        self.collision_groups
+    }
+
     /// The density of this collider.
     pub fn density(&self) -> f32 {
         self.density
@@ -300,6 +306,8 @@ pub struct ColliderBuilder {
     pub is_sensor: bool,
     /// The user-data of the collider beind built.
     pub user_data: u128,
+    /// The collision groups for the collider being built.
+    pub collision_groups: InteractionGroups,
 }
 
 impl ColliderBuilder {
@@ -313,6 +321,7 @@ impl ColliderBuilder {
             delta: Isometry::identity(),
             is_sensor: false,
             user_data: 0,
+            collision_groups: InteractionGroups::all(),
         }
     }
 
@@ -418,9 +427,18 @@ impl ColliderBuilder {
         0.5
     }
 
-    /// An arbitrary user-defined 128-bit integer associated to the colliders built by this builder.
+    /// Sets an arbitrary user-defined 128-bit integer associated to the colliders built by this builder.
     pub fn user_data(mut self, data: u128) -> Self {
         self.user_data = data;
+        self
+    }
+
+    /// Sets the collision groups used by this collider.
+    ///
+    /// Two colliders will interact iff. their collision groups are compatible.
+    /// See [InteractionGroups::test] for details.
+    pub fn collision_groups(mut self, groups: InteractionGroups) -> Self {
+        self.collision_groups = groups;
         self
     }
 

--- a/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
@@ -104,6 +104,7 @@ fn do_generate_contacts(
     let manifolds = &mut ctxt.pair.manifolds;
     let prediction_distance = ctxt.prediction_distance;
     let dispatcher = ctxt.dispatcher;
+    let solver_flags = ctxt.solver_flags;
     let shape_type2 = collider2.shape().shape_type();
 
     heightfield1.map_elements_in_local_aabb(&ls_aabb2, &mut |i, part1, _| {
@@ -131,8 +132,14 @@ fn do_generate_contacts(
                     timestamp: new_timestamp,
                     workspace: workspace2,
                 };
-                let manifold =
-                    ContactManifold::with_subshape_indices(coll_pair, collider1, collider2, i, 0);
+                let manifold = ContactManifold::with_subshape_indices(
+                    coll_pair,
+                    collider1,
+                    collider2,
+                    i,
+                    0,
+                    solver_flags,
+                );
                 manifolds.push(manifold);
 
                 entry.insert(sub_detector)

--- a/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
@@ -149,6 +149,7 @@ fn do_generate_contacts(
                     collider2,
                     *triangle_id,
                     0,
+                    ctxt.solver_flags,
                 )
             } else {
                 // We already have a manifold for this triangle.

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -18,23 +18,28 @@
 pub struct InteractionGroups(pub u32);
 
 impl InteractionGroups {
+    /// Initializes with the given interaction groups and interaction mask.
+    pub const fn new(groups: u16, masks: u16) -> Self {
+        Self::none().with_groups(groups).with_mask(masks)
+    }
+
     /// Allow interaction with everything.
-    pub fn all() -> Self {
+    pub const fn all() -> Self {
         Self(u32::MAX)
     }
 
     /// Prevent all interactions.
-    pub fn none() -> Self {
+    pub const fn none() -> Self {
         Self(0)
     }
 
     /// Sets the group this filter is part of.
-    pub fn with_groups(self, groups: u16) -> Self {
+    pub const fn with_groups(self, groups: u16) -> Self {
         Self((self.0 & 0x0000ffff) | ((groups as u32) << 16))
     }
 
     /// Sets the interaction mask of this filter.
-    pub fn with_mask(self, mask: u16) -> Self {
+    pub const fn with_mask(self, mask: u16) -> Self {
         Self((self.0 & 0xffff0000) | (mask as u32))
     }
 
@@ -42,7 +47,8 @@ impl InteractionGroups {
     ///
     /// An interaction is allowed iff. the groups of `self` contain at least one bit set to 1 in common
     /// with the mask of `rhs`, and vice-versa.
-    pub fn test(self, rhs: Self) -> bool {
+    #[inline]
+    pub const fn test(self, rhs: Self) -> bool {
         ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
     }
 }

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -12,7 +12,7 @@
 /// - The interaction groups of `a` has at least one bit set to `1` in common with the interaction mask of `b`.
 /// - The interaction groups of `b` has at least one bit set to `1` in common with the interaction mask of `a`.
 /// In other words, interactions are allowed between two filter iff. the following condition is met:
-/// ```rust
+/// ```ignore
 /// ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
 /// ```
 pub struct InteractionGroups(pub u32);

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -1,0 +1,54 @@
+#[repr(transparent)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+/// Pairwise filtering using bit masks.
+///
+/// This filtering method is based on two 16-bit values:
+/// - The interaction groups (the 16 left-most bits of `self.0`).
+/// - The interaction mask (the 16 right-most bits of `self.0`).
+///
+/// An interaction is allowed between two filters `a` and `b` two conditions
+/// are met simultaneously:
+/// - The interaction groups of `a` has at least one bit set to `1` in common with the interaction mask of `b`.
+/// - The interaction groups of `b` has at least one bit set to `1` in common with the interaction mask of `a`.
+/// In other words, interactions are allowed between two filter iff. the following condition is met:
+/// ```rust
+/// ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
+/// ```
+pub struct InteractionGroups(pub u32);
+
+impl InteractionGroups {
+    /// Allow interaction with everything.
+    pub fn all() -> Self {
+        Self(u32::MAX)
+    }
+
+    /// Prevent all interactions.
+    pub fn none() -> Self {
+        Self(0)
+    }
+
+    /// Sets the group this filter is part of.
+    pub fn with_groups(self, groups: u16) -> Self {
+        Self((self.0 & 0x0000ffff) | ((groups as u32) << 16))
+    }
+
+    /// Sets the interaction mask of this filter.
+    pub fn with_mask(self, mask: u16) -> Self {
+        Self((self.0 & 0xffff0000) | (mask as u32))
+    }
+
+    /// Check if interactions should be allowed based on the interaction groups and mask.
+    ///
+    /// An interaction is allowed iff. the groups of `self` contain at least one bit set to 1 in common
+    /// with the mask of `rhs`, and vice-versa.
+    pub fn test(self, rhs: Self) -> bool {
+        ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
+    }
+}
+
+impl Default for InteractionGroups {
+    fn default() -> Self {
+        Self::all()
+    }
+}

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -5,7 +5,7 @@ pub use self::capsule::Capsule;
 pub use self::collider::{Collider, ColliderBuilder, ColliderShape};
 pub use self::collider_set::{ColliderHandle, ColliderSet};
 pub use self::contact::{
-    Contact, ContactKinematics, ContactManifold, ContactPair, KinematicsCategory,
+    Contact, ContactKinematics, ContactManifold, ContactPair, KinematicsCategory, SolverFlags,
 };
 pub use self::contact_generator::{ContactDispatcher, DefaultContactDispatcher};
 #[cfg(feature = "dim2")]

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -70,6 +70,7 @@ pub(crate) use self::polyhedron_feature3d::PolyhedronFace;
 pub(crate) use self::waabb::{WRay, WAABB};
 pub(crate) use self::wquadtree::WQuadtree;
 //pub(crate) use self::z_order::z_cmp_floats;
+pub use self::interaction_groups::InteractionGroups;
 pub use self::shape::{Shape, ShapeType};
 
 mod ball;
@@ -97,6 +98,7 @@ mod waabb;
 mod wquadtree;
 //mod z_order;
 mod capsule;
+mod interaction_groups;
 #[cfg(feature = "dim3")]
 mod polygonal_feature_map;
 #[cfg(feature = "dim3")]

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -413,7 +413,8 @@ impl NarrowPhase {
             for manifold in &mut inter.weight.manifolds {
                 let rb1 = &bodies[manifold.body_pair.body1];
                 let rb2 = &bodies[manifold.body_pair.body2];
-                if manifold.num_active_contacts() != 0
+                if manifold.solver_flags.contains(SolverFlags::COMPUTE_FORCES)
+                    && manifold.num_active_contacts() != 0
                     && (!rb1.is_dynamic() || !rb1.is_sleeping())
                     && (!rb2.is_dynamic() || !rb2.is_sleeping())
                 {

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -15,7 +15,7 @@ use crate::geometry::proximity_detector::{
 //};
 use crate::geometry::{
     BroadPhasePairEvent, ColliderGraphIndex, ColliderHandle, ContactEvent, ProximityEvent,
-    ProximityPair, RemovedCollider,
+    ProximityPair, RemovedCollider, SolverFlags,
 };
 use crate::geometry::{ColliderSet, ContactManifold, ContactPair, InteractionGraph};
 //#[cfg(feature = "simd-is-enabled")]
@@ -374,11 +374,18 @@ impl NarrowPhase {
                 pair.generator_workspace = workspace;
             }
 
+            let solver_flags = if co1.solver_groups.test(co2.solver_groups) {
+                SolverFlags::COMPUTE_FORCES
+            } else {
+                SolverFlags::empty()
+            };
+
             let context = ContactGenerationContext {
                 dispatcher: &dispatcher,
                 prediction_distance,
                 colliders,
                 pair,
+                solver_flags,
             };
 
             context

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -306,6 +306,11 @@ impl NarrowPhase {
                 return;
             }
 
+            if !co1.collision_groups.test(co2.collision_groups) {
+                // The collision is not allowed.
+                return;
+            }
+
             let dispatcher = DefaultProximityDispatcher;
             if pair.detector.is_none() {
                 // We need a redispatch for this detector.
@@ -329,69 +334,6 @@ impl NarrowPhase {
                 .unwrap()
                 .detect_proximity(context, events);
         });
-
-        /*
-        // First, group pairs.
-        // NOTE: the transmutes here are OK because the Vec are all cleared
-        // before we leave this method.
-        // We do this in order to avoid reallocating those vecs each time
-        // we compute the contacts. Unsafe is necessary because we can't just
-        // store a Vec<&mut ProximityPair> into the NarrowPhase struct without
-        // polluting the World with lifetimes.
-        let ball_ball_prox: &mut Vec<&mut ProximityPair> =
-            unsafe { std::mem::transmute(&mut self.ball_ball_prox) };
-        let shape_shape_prox: &mut Vec<&mut ProximityPair> =
-            unsafe { std::mem::transmute(&mut self.shape_shape_prox) };
-
-        let bodies = &bodies.bodies;
-
-        // FIXME: don't iterate through all the interactions.
-        for pair in &mut self.proximity_graph.interactions {
-            let co1 = &colliders[pair.pair.collider1];
-            let co2 = &colliders[pair.pair.collider2];
-
-            // FIXME: avoid lookup into bodies.
-            let rb1 = &bodies[co1.parent];
-            let rb2 = &bodies[co2.parent];
-
-            if (rb1.is_sleeping() || !rb1.is_dynamic()) && (rb2.is_sleeping() || !rb2.is_dynamic())
-            {
-                // No need to update this proximity because nothing moved.
-                continue;
-            }
-
-            match (co1.shape(), co2.shape()) {
-                (Shape::Ball(_), Shape::Ball(_)) => ball_ball_prox.push(pair),
-                _ => shape_shape_prox.push(pair),
-            }
-        }
-
-        par_chunks_mut!(ball_ball_prox, SIMD_WIDTH).for_each(|pairs| {
-            let context = ProximityDetectionContextSimd {
-                dispatcher: &DefaultProximityDispatcher,
-                prediction_distance,
-                colliders,
-                pairs,
-            };
-            context.pairs[0]
-                .detector
-                .detect_proximity_simd(context, events);
-        });
-
-        par_iter_mut!(shape_shape_prox).for_each(|pair| {
-            let context = ProximityDetectionContext {
-                dispatcher: &DefaultProximityDispatcher,
-                prediction_distance,
-                colliders,
-                pair,
-            };
-
-            context.pair.detector.detect_proximity(context, events);
-        });
-
-        ball_ball_prox.clear();
-        shape_shape_prox.clear();
-        */
     }
 
     pub(crate) fn compute_contacts(
@@ -414,6 +356,11 @@ impl NarrowPhase {
                 || (!rb1.is_dynamic() && !rb2.is_dynamic())
             {
                 // No need to update this contact because nothing moved.
+                return;
+            }
+
+            if !co1.collision_groups.test(co2.collision_groups) {
+                // The collision is not allowed.
                 return;
             }
 
@@ -440,69 +387,6 @@ impl NarrowPhase {
                 .unwrap()
                 .generate_contacts(context, events);
         });
-
-        /*
-        // First, group pairs.
-        // NOTE: the transmutes here are OK because the Vec are all cleared
-        // before we leave this method.
-        // We do this in order to avoid reallocating those vecs each time
-        // we compute the contacts. Unsafe is necessary because we can't just
-        // store a Vec<&mut ContactPair> into the NarrowPhase struct without
-        // polluting the World with lifetimes.
-        let ball_ball: &mut Vec<&mut ContactPair> =
-            unsafe { std::mem::transmute(&mut self.ball_ball) };
-        let shape_shape: &mut Vec<&mut ContactPair> =
-            unsafe { std::mem::transmute(&mut self.shape_shape) };
-
-        let bodies = &bodies.bodies;
-
-        // FIXME: don't iterate through all the interactions.
-        for pair in &mut self.contact_graph.interactions {
-            let co1 = &colliders[pair.pair.collider1];
-            let co2 = &colliders[pair.pair.collider2];
-
-            // FIXME: avoid lookup into bodies.
-            let rb1 = &bodies[co1.parent];
-            let rb2 = &bodies[co2.parent];
-
-            if (rb1.is_sleeping() || !rb1.is_dynamic()) && (rb2.is_sleeping() || !rb2.is_dynamic())
-            {
-                // No need to update this contact because nothing moved.
-                continue;
-            }
-
-            match (co1.shape(), co2.shape()) {
-                (Shape::Ball(_), Shape::Ball(_)) => ball_ball.push(pair),
-                _ => shape_shape.push(pair),
-            }
-        }
-
-        par_chunks_mut!(ball_ball, SIMD_WIDTH).for_each(|pairs| {
-            let context = ContactGenerationContextSimd {
-                dispatcher: &DefaultContactDispatcher,
-                prediction_distance,
-                colliders,
-                pairs,
-            };
-            context.pairs[0]
-                .generator
-                .generate_contacts_simd(context, events);
-        });
-
-        par_iter_mut!(shape_shape).for_each(|pair| {
-            let context = ContactGenerationContext {
-                dispatcher: &DefaultContactDispatcher,
-                prediction_distance,
-                colliders,
-                pair,
-            };
-
-            context.pair.generator.generate_contacts(context, events);
-        });
-
-        ball_ball.clear();
-        shape_shape.clear();
-        */
     }
 
     /// Retrieve all the interactions with at least one contact point, happening between two active bodies.

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -1,5 +1,7 @@
 use crate::dynamics::RigidBodySet;
-use crate::geometry::{Collider, ColliderHandle, ColliderSet, Ray, RayIntersection, WQuadtree};
+use crate::geometry::{
+    Collider, ColliderHandle, ColliderSet, InteractionGroups, Ray, RayIntersection, WQuadtree,
+};
 
 /// A pipeline for performing queries on all the colliders of a scene.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -59,6 +61,7 @@ impl QueryPipeline {
         colliders: &'a ColliderSet,
         ray: &Ray,
         max_toi: f32,
+        groups: InteractionGroups,
     ) -> Option<(ColliderHandle, &'a Collider, RayIntersection)> {
         // TODO: avoid allocation?
         let mut inter = Vec::new();
@@ -69,14 +72,17 @@ impl QueryPipeline {
 
         for handle in inter {
             let collider = &colliders[handle];
-            if let Some(inter) =
-                collider
-                    .shape()
-                    .toi_and_normal_with_ray(collider.position(), ray, max_toi, true)
-            {
-                if inter.toi < best {
-                    best = inter.toi;
-                    result = Some((handle, collider, inter));
+            if collider.collision_groups.test(groups) {
+                if let Some(inter) = collider.shape().toi_and_normal_with_ray(
+                    collider.position(),
+                    ray,
+                    max_toi,
+                    true,
+                ) {
+                    if inter.toi < best {
+                        best = inter.toi;
+                        result = Some((handle, collider, inter));
+                    }
                 }
             }
         }
@@ -99,6 +105,7 @@ impl QueryPipeline {
         colliders: &'a ColliderSet,
         ray: &Ray,
         max_toi: f32,
+        groups: InteractionGroups,
         mut callback: impl FnMut(ColliderHandle, &'a Collider, RayIntersection) -> bool,
     ) {
         // TODO: avoid allocation?
@@ -107,13 +114,17 @@ impl QueryPipeline {
 
         for handle in inter {
             let collider = &colliders[handle];
-            if let Some(inter) =
-                collider
-                    .shape()
-                    .toi_and_normal_with_ray(collider.position(), ray, max_toi, true)
-            {
-                if !callback(handle, collider, inter) {
-                    return;
+
+            if collider.collision_groups.test(groups) {
+                if let Some(inter) = collider.shape().toi_and_normal_with_ray(
+                    collider.position(),
+                    ray,
+                    max_toi,
+                    true,
+                ) {
+                    if !callback(handle, collider, inter) {
+                        return;
+                    }
                 }
             }
         }

--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -63,6 +63,7 @@ pub struct GraphicsManager {
     #[cfg(feature = "fluids")]
     boundary2sn: HashMap<BoundaryHandle, FluidNode>,
     b2color: HashMap<RigidBodyHandle, Point3<f32>>,
+    c2color: HashMap<ColliderHandle, Point3<f32>>,
     b2wireframe: HashMap<RigidBodyHandle, bool>,
     #[cfg(feature = "fluids")]
     f2color: HashMap<FluidHandle, Point3<f32>>,
@@ -100,6 +101,7 @@ impl GraphicsManager {
             #[cfg(feature = "fluids")]
             boundary2sn: HashMap::new(),
             b2color: HashMap::new(),
+            c2color: HashMap::new(),
             #[cfg(feature = "fluids")]
             f2color: HashMap::new(),
             ground_color: Point3::new(0.5, 0.5, 0.5),
@@ -184,6 +186,10 @@ impl GraphicsManager {
                 n.set_color(color)
             }
         }
+    }
+
+    pub fn set_collider_initial_color(&mut self, c: ColliderHandle, color: Point3<f32>) {
+        self.c2color.insert(c, color);
     }
 
     pub fn set_body_wireframe(&mut self, b: RigidBodyHandle, enabled: bool) {
@@ -324,6 +330,7 @@ impl GraphicsManager {
         let mut new_nodes = Vec::new();
 
         for collider_handle in bodies[handle].colliders() {
+            let color = self.c2color.get(collider_handle).copied().unwrap_or(color);
             let collider = &colliders[*collider_handle];
             self.add_collider(window, *collider_handle, collider, color, &mut new_nodes);
         }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -23,7 +23,9 @@ use rapier::dynamics::{
 };
 #[cfg(feature = "dim3")]
 use rapier::geometry::Ray;
-use rapier::geometry::{BroadPhase, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent};
+use rapier::geometry::{
+    BroadPhase, ColliderHandle, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent,
+};
 use rapier::math::Vector;
 use rapier::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
 #[cfg(feature = "fluids")]
@@ -495,6 +497,10 @@ impl Testbed {
 
     pub fn set_body_color(&mut self, body: RigidBodyHandle, color: Point3<f32>) {
         self.graphics.set_body_color(body, color);
+    }
+
+    pub fn set_collider_initial_color(&mut self, collider: ColliderHandle, color: Point3<f32>) {
+        self.graphics.set_collider_initial_color(collider, color);
     }
 
     #[cfg(feature = "fluids")]

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -24,7 +24,8 @@ use rapier::dynamics::{
 #[cfg(feature = "dim3")]
 use rapier::geometry::Ray;
 use rapier::geometry::{
-    BroadPhase, ColliderHandle, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent,
+    BroadPhase, ColliderHandle, ColliderSet, ContactEvent, InteractionGroups, NarrowPhase,
+    ProximityEvent,
 };
 use rapier::math::Vector;
 use rapier::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
@@ -1188,10 +1189,12 @@ impl Testbed {
             .camera()
             .unproject(&self.cursor_pos, &na::convert(size));
         let ray = Ray::new(pos, dir);
-        let hit = self
-            .physics
-            .query_pipeline
-            .cast_ray(&self.physics.colliders, &ray, f32::MAX);
+        let hit = self.physics.query_pipeline.cast_ray(
+            &self.physics.colliders,
+            &ray,
+            f32::MAX,
+            InteractionGroups::all(),
+        );
 
         if let Some((_, collider, _)) = hit {
             if self.physics.bodies[collider.parent()].is_dynamic() {


### PR DESCRIPTION
Fix #2 

This add the support for collision filtering based on bit masks (often known as collision groups, collision masks, or collision layers in other physics engines). Each collider has two groups:
- The `collision_groups` for filtering what pair of colliders should have their contacts computed by the narrow-phase. This filtering happens right after the broad-phase, before the narrow phase.
- The `solver_groups` for filtering what pair of colliders should have their contact forces computed. This filtering happens right after the narrow-phase, before the constraints solver

The `collision_groups` is what will probably be used most of the time as it allows preventing some specific pairs of collisions from being in contact at all.

The `solver_groups` is a bit different because it will allow some contacts to be computed, but ignored by the constraints solver (this is similar to things we discussed in #15 but here it applies to contacts involving at least one dynamic rigid-body). This is useful if the user wants the detailed contact information, but needs to apply their own logic instead of relying on the constraints solver.

This collision filtering can also be used by the query pipeline to cast rays that hit only colliders part of specific groups.

Note that this PR does **not** allow contacts between static/kinematic bodies #15. This will be be the subject for another PR.