### PR TITLE
Disable benchmark workflow for PRs from forks

### DIFF
--- a/.github/workflows/rapier-ci-bench.yml
+++ b/.github/workflows/rapier-ci-bench.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   send-bench-message:
+    if: secrets.BENCHBOT_AMQP_HOST != ''
     env:
       BENCHBOT_AMQP_USER: ${{ secrets.BENCHBOT_AMQP_USER }}
       BENCHBOT_AMQP_PASS: ${{ secrets.BENCHBOT_AMQP_PASS }}


### PR DESCRIPTION
This disables the send_benchmark_message job for PRs that do not have
access to secrets (including those from forks).

This should stop PRs from forks getting the error message for now until we figure out how we want this to work. For now, I believe that benchmarks could still be run manually for these PRs by maintainers.

I am unable to test this before making this PR due to the nature of the change. This could go wrong in one of two ways:
 1. ~~This might not actually work to disable benchmarks for PRs from forks. (We should be able to tell if this is the case from the run on this PR)~~
 1. This might cause benchmarks to be disabled everywhere. (We won't be able to tell until after this is merged in)

Feel free to close this PR if this is not the behavior that you want. Also, you could wait to merge this until you have time to experiment.