### PR TITLE
Sap serialization: skip cache data

### DIFF
--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -14,7 +14,6 @@ mod add_remove2;
 mod collision_groups2;
 mod damping2;
 mod debug_box_ball2;
-mod debug_infinite_fall;
 mod heightfield2;
 mod joints2;
 mod platform2;
@@ -65,7 +64,6 @@ pub fn main() {
         ("Restitution", restitution2::init_world),
         ("Sensor", sensor2::init_world),
         ("(Debug) box ball", debug_box_ball2::init_world),
-        ("(Debug) infinite fall", debug_infinite_fall::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -16,6 +16,7 @@ mod compound3;
 mod damping3;
 mod debug_boxes3;
 mod debug_cylinder3;
+mod debug_infinite_fall3;
 mod debug_triangle3;
 mod debug_trimesh3;
 mod domino3;
@@ -84,6 +85,7 @@ pub fn main() {
         ("(Debug) triangle", debug_triangle3::init_world),
         ("(Debug) trimesh", debug_trimesh3::init_world),
         ("(Debug) cylinder", debug_cylinder3::init_world),
+        ("(Debug) infinite fall", debug_infinite_fall3::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/examples3d/debug_infinite_fall3.rs
+++ b/examples3d/debug_infinite_fall3.rs
@@ -1,6 +1,6 @@
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
-use rapier2d::geometry::{ColliderBuilder, ColliderSet};
-use rapier_testbed2d::Testbed;
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed3d::Testbed;
 
 pub fn init_world(testbed: &mut Testbed) {
     /*
@@ -13,7 +13,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let rad = 1.0;
     // Build the dynamic box rigid body.
     let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(0.0, 3.0 * rad)
+        .translation(0.0, 3.0 * rad, 0.0)
         .can_sleep(false)
         .build();
     let handle = bodies.insert(rigid_body);
@@ -24,7 +24,6 @@ pub fn init_world(testbed: &mut Testbed) {
      * Set up the testbed.
      */
     testbed.set_world(bodies, colliders, joints);
-    //    testbed.look_at(Point2::new(10.0, 10.0, 10.0), Point2::origin());
 }
 
 fn main() {

--- a/src/geometry/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap.rs
@@ -340,7 +340,7 @@ struct SAPRegion {
     existing_proxies: BitVec,
     #[cfg_attr(feature = "serde-serialize", serde(skip))]
     to_insert: Vec<usize>, // Workspace
-    update_count: usize,
+    update_count: u8,
     proxy_count: usize,
 }
 

--- a/src/geometry/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap.rs
@@ -376,9 +376,7 @@ impl SAPRegion {
         assert_eq!(old.proxy_count, 0);
         assert!(old.to_insert.is_empty());
         debug_assert!(!old.existing_proxies.any());
-        for axis in old.axes.iter() {
-            assert!(axis.endpoints.len() == 2); // Account for sentinels
-        }
+        assert!(old.axes.iter().all(|ax| ax.endpoints.len() == 2));
 
         old
     }
@@ -422,6 +420,7 @@ impl SAPRegion {
         if self.update_count > 0 {
             // Update endpoints.
             let mut deleted = 0;
+
             for dim in 0..DIM {
                 self.axes[dim].update_endpoints(dim, proxies, reporting);
                 deleted += self.axes[dim].delete_out_of_bounds_proxies(&mut self.existing_proxies);
@@ -460,8 +459,10 @@ pub struct BroadPhase {
     regions: HashMap<Point<i32>, SAPRegion>,
     removed_colliders: Option<Subscription<RemovedCollider>>,
     deleted_any: bool,
-    region_pool: Vec<SAPRegion>,
-    points_to_remove: Vec<Point<i32>>, // Workspace
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
+    region_pool: Vec<SAPRegion>, // To avoid repeated allocations.
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
+    regions_to_remove: Vec<Point<i32>>, // Workspace
     // We could think serializing this workspace is useless.
     // It turns out is is important to serialize at least its capacity
     // and restore this capacity when deserializing the hashmap.
@@ -555,7 +556,7 @@ impl BroadPhase {
             proxies: Proxies::new(),
             regions: HashMap::default(),
             region_pool: Vec::new(),
-            points_to_remove: Vec::new(),
+            regions_to_remove: Vec::new(),
             reporting: HashMap::default(),
             deleted_any: false,
         }
@@ -658,6 +659,7 @@ impl BroadPhase {
 
                 let regions = &mut self.regions;
                 let pool = &mut self.region_pool;
+
                 #[cfg(feature = "dim2")]
                 for i in start.x..=end.x {
                     for j in start.y..=end.y {
@@ -691,14 +693,14 @@ impl BroadPhase {
         for (point, region) in &mut self.regions {
             region.update(&self.proxies, &mut self.reporting);
             if region.proxy_count == 0 {
-                self.points_to_remove.push(*point);
+                self.regions_to_remove.push(*point);
             }
         }
 
         // Remove all the empty regions and store them in the region pool
         let regions = &mut self.regions;
         self.region_pool.extend(
-            self.points_to_remove
+            self.regions_to_remove
                 .drain(..)
                 .map(|p| regions.remove(&p).unwrap()),
         );


### PR DESCRIPTION
After the changes made by #30, some workspace data were serialized. This PR skips the serialization of these workspace data since this does not affect determinism.