### PR TITLE
Add more explicit parameters to wake-up a rigid-body

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## v0.4.0 - WIP
+- The rigid-body `linvel`, `angvel`, and `position` fields are no longer public. Access using
+  their corresponding getters/setters. For example: `rb.linvel()`, `rb.set_linvel(vel, true)`.
+- Add `RigidBodyBuilder::sleeping(true)` to allow the creation of a rigid-body that is asleep
+  at initialization-time.
+
 ## v0.3.2
 - Add linear and angular damping. The damping factor can be set with `RigidBodyBuilder::linear_damping` and
   `RigidBodyBuilder::angular_damping`.

--- a/examples2d/add_remove2.rs
+++ b/examples2d/add_remove2.rs
@@ -24,7 +24,7 @@ pub fn init_world(testbed: &mut Testbed) {
         let to_remove: Vec<_> = physics
             .bodies
             .iter()
-            .filter(|(_, b)| b.position.translation.vector.y < -10.0)
+            .filter(|(_, b)| b.position().translation.vector.y < -10.0)
             .map(|e| e.0)
             .collect();
         for handle in to_remove {

--- a/examples2d/platform2.rs
+++ b/examples2d/platform2.rs
@@ -62,7 +62,7 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     testbed.add_callback(move |_, physics, _, _, time| {
         let mut platform = physics.bodies.get_mut(platform_handle).unwrap();
-        let mut next_pos = platform.position;
+        let mut next_pos = *platform.position();
 
         let dt = 0.016;
         next_pos.translation.vector.y += (time * 5.0).sin() * dt;

--- a/examples3d/damping3.rs
+++ b/examples3d/damping3.rs
@@ -12,7 +12,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let joints = JointSet::new();
 
     /*
-     * Create the balls
+     * Create the cubes
      */
     let num = 10;
     let rad = 0.2;

--- a/examples3d/platform3.rs
+++ b/examples3d/platform3.rs
@@ -72,7 +72,7 @@ pub fn init_world(testbed: &mut Testbed) {
         }
 
         if let Some(mut platform) = physics.bodies.get_mut(platform_handle) {
-            let mut next_pos = platform.position;
+            let mut next_pos = *platform.position();
 
             let dt = 0.016;
             next_pos.translation.vector.y += (time * 5.0).sin() * dt;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -388,6 +388,7 @@ pub struct RigidBodyBuilder {
     body_status: BodyStatus,
     mass_properties: MassProperties,
     can_sleep: bool,
+    sleeping: bool,
     user_data: u128,
 }
 
@@ -403,6 +404,7 @@ impl RigidBodyBuilder {
             body_status,
             mass_properties: MassProperties::zero(),
             can_sleep: true,
+            sleeping: false,
             user_data: 0,
         }
     }
@@ -531,6 +533,12 @@ impl RigidBodyBuilder {
         self
     }
 
+    /// Sets whether or not the rigid-body is to be created asleep.
+    pub fn sleeping(mut self, sleeping: bool) -> Self {
+        self.sleeping = sleeping;
+        self
+    }
+
     /// Build a new rigid-body with the parameters configured with this builder.
     pub fn build(&self) -> RigidBody {
         let mut rb = RigidBody::new();
@@ -543,6 +551,10 @@ impl RigidBodyBuilder {
         rb.mass_properties = self.mass_properties;
         rb.linear_damping = self.linear_damping;
         rb.angular_damping = self.angular_damping;
+
+        if self.can_sleep && self.sleeping {
+            rb.sleep();
+        }
 
         if !self.can_sleep {
             rb.activation.threshold = -1.0;

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -207,7 +207,7 @@ impl RigidBodySet {
          * Remove colliders attached to this rigid-body.
          */
         for collider in &rb.colliders {
-            colliders.remove(*collider, self);
+            colliders.remove(*collider, self, false);
         }
 
         /*

--- a/src/dynamics/solver/parallel_island_solver.rs
+++ b/src/dynamics/solver/parallel_island_solver.rs
@@ -250,7 +250,7 @@ impl ParallelIslandSolver {
                     let batch_size = thread.batch_size;
                     for handle in active_bodies[thread.position_writeback_index] {
                         let rb = &mut bodies[*handle];
-                        rb.set_position(positions[rb.active_set_offset]);
+                        rb.set_position(positions[rb.active_set_offset], false);
                     }
                 }
             })

--- a/src/dynamics/solver/position_solver.rs
+++ b/src/dynamics/solver/position_solver.rs
@@ -120,7 +120,7 @@ impl PositionSolver {
         }
 
         bodies.foreach_active_island_body_mut_internal(island_id, |_, rb| {
-            rb.set_position(self.positions[rb.active_set_offset])
+            rb.set_position(self.positions[rb.active_set_offset], false)
         });
     }
 }

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -78,10 +78,14 @@ impl ColliderSet {
     }
 
     /// Remove a collider from this set and update its parent accordingly.
+    ///
+    /// If `wake_up` is `true`, the rigid-body the removed collider is attached to
+    /// will be woken up.
     pub fn remove(
         &mut self,
         handle: ColliderHandle,
         bodies: &mut RigidBodySet,
+        wake_up: bool,
     ) -> Option<Collider> {
         let collider = self.colliders.remove(handle)?;
 
@@ -90,7 +94,10 @@ impl ColliderSet {
          */
         if let Some(parent) = bodies.get_mut_internal(collider.parent) {
             parent.remove_collider_internal(handle, &collider);
-            bodies.wake_up(collider.parent, true);
+
+            if wake_up {
+                bodies.wake_up(collider.parent, true);
+            }
         }
 
         /*

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -18,7 +18,7 @@ use {
 /// Enum representing the type of a shape.
 pub enum ShapeType {
     /// A ball shape.
-    Ball = 1,
+    Ball = 0,
     /// A convex polygon shape.
     Polygon,
     /// A cuboid shape.

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -72,17 +72,18 @@ impl QueryPipeline {
         let mut result = None;
 
         for handle in inter {
-            let collider = &colliders[handle];
-            if collider.collision_groups.test(groups) {
-                if let Some(inter) = collider.shape().toi_and_normal_with_ray(
-                    collider.position(),
-                    ray,
-                    max_toi,
-                    true,
-                ) {
-                    if inter.toi < best {
-                        best = inter.toi;
-                        result = Some((handle, collider, inter));
+            if let Some(collider) = colliders.get(handle) {
+                if collider.collision_groups.test(groups) {
+                    if let Some(inter) = collider.shape().toi_and_normal_with_ray(
+                        collider.position(),
+                        ray,
+                        max_toi,
+                        true,
+                    ) {
+                        if inter.toi < best {
+                            best = inter.toi;
+                            result = Some((handle, collider, inter));
+                        }
                     }
                 }
             }

--- a/src_testbed/box2d_backend.rs
+++ b/src_testbed/box2d_backend.rs
@@ -71,10 +71,10 @@ impl Box2dWorld {
 
             let def = b2::BodyDef {
                 body_type,
-                position: na_vec_to_b2_vec(body.position.translation.vector),
-                angle: body.position.rotation.angle(),
-                linear_velocity: na_vec_to_b2_vec(body.linvel),
-                angular_velocity: body.angvel,
+                position: na_vec_to_b2_vec(body.position().translation.vector),
+                angle: body.position().rotation.angle(),
+                linear_velocity: na_vec_to_b2_vec(*body.linvel()),
+                angular_velocity: body.angvel(),
                 linear_damping,
                 angular_damping,
                 ..b2::BodyDef::new()
@@ -223,7 +223,7 @@ impl Box2dWorld {
             if let Some(pb2_handle) = self.rapier2box2d.get(&handle) {
                 let b2_body = self.world.body(*pb2_handle);
                 let pos = b2_transform_to_na_isometry(b2_body.transform().clone());
-                body.set_position(pos);
+                body.set_position(pos, false);
 
                 for coll_handle in body.colliders() {
                     let collider = &mut colliders[*coll_handle];

--- a/src_testbed/nphysics_backend.rs
+++ b/src_testbed/nphysics_backend.rs
@@ -46,7 +46,7 @@ impl NPhysicsWorld {
 
         for (rapier_handle, rb) in bodies.iter() {
             // let material = physics.create_material(rb.collider.friction, rb.collider.friction, 0.0);
-            let nphysics_rb = RigidBodyDesc::new().position(rb.position).build();
+            let nphysics_rb = RigidBodyDesc::new().position(*rb.position()).build();
             let nphysics_rb_handle = nphysics_bodies.insert(nphysics_rb);
 
             rapier2nphysics.insert(rapier_handle, nphysics_rb_handle);
@@ -161,7 +161,7 @@ impl NPhysicsWorld {
             let mut rb = bodies.get_mut(*rapier_handle).unwrap();
             let ra = self.bodies.rigid_body(*nphysics_handle).unwrap();
             let pos = *ra.position();
-            rb.set_position(pos);
+            rb.set_position(pos, false);
 
             for coll_handle in rb.colliders() {
                 let collider = &mut colliders[*coll_handle];

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -154,7 +154,7 @@ impl PhysxWorld {
             use physx::rigid_static::RigidStatic;
             use physx::transform;
 
-            let pos = transform::gl_to_px_tf(rb.position.to_homogeneous().into_glam());
+            let pos = transform::gl_to_px_tf(rb.position().to_homogeneous().into_glam());
             if rb.is_dynamic() {
                 let actor = unsafe {
                     physx_sys::PxPhysics_createRigidDynamic_mut(physics.get_raw_mut(), &pos)
@@ -406,7 +406,7 @@ impl PhysxWorld {
             let ra = self.scene.get_rigid_actor(*physx_handle).unwrap();
             let pos = ra.get_global_pose().into_na();
             let iso = na::convert_unchecked(pos);
-            rb.set_position(iso);
+            rb.set_position(iso, false);
 
             if rb.is_kinematic() {}
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -414,7 +414,7 @@ impl Testbed {
         {
             if self.state.selected_backend == BOX2D_BACKEND {
                 self.box2d = Some(Box2dWorld::from_rapier(
-                    self.gravity,
+                    self.physics.gravity,
                     &self.physics.bodies,
                     &self.physics.colliders,
                     &self.physics.joints,
@@ -647,7 +647,7 @@ impl Testbed {
                                 if self.state.selected_backend == BOX2D_BACKEND {
                                     self.box2d.as_mut().unwrap().step(
                                         &mut self.physics.pipeline.counters,
-                                        &self.integration_parameters,
+                                        &self.physics.integration_parameters,
                                     );
                                     self.box2d.as_mut().unwrap().sync(
                                         &mut self.physics.bodies,

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -758,7 +758,7 @@ impl Testbed {
                 for to_delete in &colliders[..num_to_delete] {
                     self.physics
                         .colliders
-                        .remove(to_delete[0], &mut self.physics.bodies);
+                        .remove(to_delete[0], &mut self.physics.bodies, true);
                 }
             }
             WindowEvent::Key(Key::D, Action::Release, _) => {
@@ -1576,11 +1576,13 @@ CCD: {:.2}ms
         }
 
         if self.state.flags.contains(TestbedStateFlags::DEBUG) {
+            let t = instant::now();
             let bf = bincode::serialize(&self.physics.broad_phase).unwrap();
             let nf = bincode::serialize(&self.physics.narrow_phase).unwrap();
             let bs = bincode::serialize(&self.physics.bodies).unwrap();
             let cs = bincode::serialize(&self.physics.colliders).unwrap();
             let js = bincode::serialize(&self.physics.joints).unwrap();
+            let serialization_time = instant::now() - t;
             let hash_bf = md5::compute(&bf);
             let hash_nf = md5::compute(&nf);
             let hash_bodies = md5::compute(&bs);
@@ -1588,6 +1590,7 @@ CCD: {:.2}ms
             let hash_joints = md5::compute(&js);
             profile = format!(
                 r#"{}
+Serialization time: {:.2}ms
 Hashes at frame: {}
 |_ Broad phase [{:.1}KB]: {:?}
 |_ Narrow phase [{:.1}KB]: {:?}
@@ -1595,6 +1598,7 @@ Hashes at frame: {}
 |_ Colliders [{:.1}KB]: {:?}
 |_ Joints [{:.1}KB]: {:?}"#,
                 profile,
+                serialization_time,
                 self.state.timestep_id,
                 bf.len() as f32 / 1000.0,
                 hash_bf,


### PR DESCRIPTION
This is inspired by the discussion we had in #5 

This adds a boolean as a parameter to the methods for:
- collider removal;
- setting the rigid-body velocity.
- setting the rigid-body position.

This also add the ability to create a rigid-body that is initialized asleep.

This is a breaking change because the `linvel, angvel` and `position` fields of `RigidBody` are no longer public (I added methods to access them instead).