### PR TITLE
Fix cross-platform determinism on the Apple M1 processor

### DIFF
--- a/examples3d/heightfield3.rs
+++ b/examples3d/heightfield3.rs
@@ -1,4 +1,4 @@
-use na::{DMatrix, Point3, Vector3};
+use na::{ComplexField, DMatrix, Point3, Vector3};
 use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed3d::Testbed;
@@ -23,7 +23,11 @@ pub fn init_world(testbed: &mut Testbed) {
         } else {
             let x = i as f32 * ground_size.x / (nsubdivs as f32);
             let z = j as f32 * ground_size.z / (nsubdivs as f32);
-            x.sin() + z.cos()
+
+            // NOTE: make sure we use the sin/cos from simba to ensure
+            // cross-platform determinism of the example when the
+            // enhanced_determinism feature is enabled.
+            (<f32 as ComplexField>::sin(x) + <f32 as ComplexField>::cos(z))
         }
     });
 

--- a/examples3d/trimesh3.rs
+++ b/examples3d/trimesh3.rs
@@ -1,4 +1,4 @@
-use na::Point3;
+use na::{ComplexField, Point3};
 use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed3d::Testbed;
@@ -30,7 +30,10 @@ pub fn init_world(testbed: &mut Testbed) {
     // so we switch z and y here and set a random altitude at each point.
     for p in vertices.iter_mut() {
         p.z = p.y;
-        p.y = (p.x.sin() + p.z.cos()) * ground_height;
+        // NOTE: make sure we use the sin/cos from simba to ensure
+        // cross-platform determinism of the example when the
+        // enhanced_determinism feature is enabled.
+        p.y = (<f32 as ComplexField>::sin(p.x) + <f32 as ComplexField>::cos(p.z)) * ground_height;
 
         if p.x.abs() == ground_size / 2.0 || p.z.abs() == ground_size / 2.0 {
             p.y = 10.0;


### PR DESCRIPTION
I tried to run Rapier on one of the new Mac Mini equipped with an Apple M1 processor. The physics engine itself builds and runs correctly, however the testbed needs some changes on winit and glutin in order to work properly (we just have to wait for the proper fixes to be released upstream).

Anyways, I ran the Rapier demos (with the `enhanced-determinism` feature enabled) on the Apple M1 and my desktop with an AMD Ryzen 9 3900X and found out there were some divergences between the states of the simulations when triangle meshed and heightfield were involved.

These divergences are fixed by this PR.

This means that once this PR lands, Rapier will be able to output the exact same simulation on two different machines where one of them is an ARM processor (Apple M1) and the other is an X86 processor (Ryzen 9).
(This doesn't prove that this determinism is valid for all the ARM processors out there, but this shows this is true with the most recent one.)