### PR TITLE
Allow access to contact information

### DIFF
--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -10,7 +10,6 @@ use inflector::Inflector;
 use rapier_testbed3d::Testbed;
 use std::cmp::Ordering;
 
-mod add_remove3;
 mod collision_groups3;
 mod compound3;
 mod damping3;
@@ -20,6 +19,7 @@ mod debug_infinite_fall3;
 mod debug_triangle3;
 mod debug_trimesh3;
 mod domino3;
+mod fountain3;
 mod heightfield3;
 mod joints3;
 mod keva3;
@@ -67,7 +67,7 @@ pub fn main() {
         .to_camel_case();
 
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
-        ("Add remove", add_remove3::init_world),
+        ("Fountain", fountain3::init_world),
         ("Primitives", primitives3::init_world),
         ("Collision groups", collision_groups3::init_world),
         ("Compound", compound3::init_world),

--- a/examples3d/fountain3.rs
+++ b/examples3d/fountain3.rs
@@ -70,8 +70,6 @@ pub fn init_world(testbed: &mut Testbed) {
                 graphics.remove_body_nodes(window, *handle);
             }
         }
-
-        println!("Num bodies: {}", physics.bodies.len());
     });
 
     /*

--- a/examples3d/heightfield3.rs
+++ b/examples3d/heightfield3.rs
@@ -27,7 +27,7 @@ pub fn init_world(testbed: &mut Testbed) {
             // NOTE: make sure we use the sin/cos from simba to ensure
             // cross-platform determinism of the example when the
             // enhanced_determinism feature is enabled.
-            (<f32 as ComplexField>::sin(x) + <f32 as ComplexField>::cos(z))
+            <f32 as ComplexField>::sin(x) + <f32 as ComplexField>::cos(z)
         }
     });
 

--- a/examples3d/joints3.rs
+++ b/examples3d/joints3.rs
@@ -25,14 +25,11 @@ fn create_prismatic_joints(
 
     for i in 0..num {
         let z = origin.z + (i + 1) as f32 * shift;
-        let density = 1.0;
         let rigid_body = RigidBodyBuilder::new_dynamic()
             .translation(origin.x, origin.y, z)
             .build();
         let curr_child = bodies.insert(rigid_body);
-        let collider = ColliderBuilder::cuboid(rad, rad, rad)
-            .density(density)
-            .build();
+        let collider = ColliderBuilder::cuboid(rad, rad, rad).build();
         colliders.insert(collider, curr_child, bodies);
 
         let axis = if i % 2 == 0 {
@@ -88,14 +85,11 @@ fn create_revolute_joints(
 
         let mut handles = [curr_parent; 4];
         for k in 0..4 {
-            let density = 1.0;
             let rigid_body = RigidBodyBuilder::new_dynamic()
                 .position(positions[k])
                 .build();
             handles[k] = bodies.insert(rigid_body);
-            let collider = ColliderBuilder::cuboid(rad, rad, rad)
-                .density(density)
-                .build();
+            let collider = ColliderBuilder::cuboid(rad, rad, rad).build();
             colliders.insert(collider, handles[k], bodies);
         }
 

--- a/src/data/coarena.rs
+++ b/src/data/coarena.rs
@@ -1,0 +1,71 @@
+use crate::data::arena::Index;
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+/// A container for data associated to item existing into another Arena.
+pub struct Coarena<T> {
+    data: Vec<(u64, T)>,
+}
+
+impl<T> Coarena<T> {
+    /// A coarena with no element.
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    /// Gets a specific element from the coarena, if it exists.
+    pub fn get(&self, index: Index) -> Option<&T> {
+        let (i, g) = index.into_raw_parts();
+        self.data
+            .get(i)
+            .and_then(|(gg, t)| if g == *gg { Some(t) } else { None })
+    }
+
+    /// Gets a mutable reference to a specific element from the coarena, if it exists.
+    pub fn get_mut(&mut self, index: Index) -> Option<&mut T> {
+        let (i, g) = index.into_raw_parts();
+        self.data
+            .get_mut(i)
+            .and_then(|(gg, t)| if g == *gg { Some(t) } else { None })
+    }
+
+    /// Ensure that elements at the two given indices exist in this coarena, and return their reference.
+    ///
+    /// Missing elements are created automatically and initialized with the `default` value.
+    pub fn ensure_pair_exists(&mut self, a: Index, b: Index, default: T) -> (&mut T, &mut T)
+    where
+        T: Clone,
+    {
+        let (i1, g1) = a.into_raw_parts();
+        let (i2, g2) = b.into_raw_parts();
+
+        assert_ne!(i1, i2, "Cannot index the same object twice.");
+
+        let (elt1, elt2) = if i1 > i2 {
+            if self.data.len() <= i1 {
+                self.data.resize(i1 + 1, (u32::MAX as u64, default.clone()));
+            }
+
+            let (left, right) = self.data.split_at_mut(i1);
+            (&mut right[0], &mut left[i2])
+        } else {
+            // i2 > i1
+            if self.data.len() <= i2 {
+                self.data.resize(i2 + 1, (u32::MAX as u64, default.clone()));
+            }
+
+            let (left, right) = self.data.split_at_mut(i2);
+            (&mut left[i1], &mut right[0])
+        };
+
+        if elt1.0 != g1 {
+            *elt1 = (g1, default.clone());
+        }
+
+        if elt2.0 != g2 {
+            *elt2 = (g2, default);
+        }
+
+        (&mut elt1.1, &mut elt2.1)
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,8 +1,10 @@
 //! Data structures modified with guaranteed deterministic behavior after deserialization.
 
+pub use self::coarena::Coarena;
 pub use self::maybe_serializable_data::MaybeSerializableData;
 
 pub mod arena;
+mod coarena;
 pub(crate) mod graph;
 pub(crate) mod hashmap;
 mod maybe_serializable_data;

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -11,6 +11,7 @@ use ncollide::bounding_volume::AABB;
 use std::ops::Deref;
 use std::sync::Arc;
 
+// TODO: move this to its own file.
 /// The shape of a collider.
 #[derive(Clone)]
 pub struct ColliderShape(pub Arc<dyn Shape>);
@@ -206,8 +207,6 @@ pub struct Collider {
     pub restitution: f32,
     pub(crate) collision_groups: InteractionGroups,
     pub(crate) solver_groups: InteractionGroups,
-    pub(crate) contact_graph_index: ColliderGraphIndex,
-    pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
     /// User-defined data associated to this rigid-body.
     pub user_data: u128,
@@ -216,8 +215,6 @@ pub struct Collider {
 impl Collider {
     pub(crate) fn reset_internal_references(&mut self) {
         self.parent = RigidBodySet::invalid_handle();
-        self.contact_graph_index = InteractionGraph::<Contact>::invalid_graph_index();
-        self.proximity_graph_index = InteractionGraph::<Proximity>::invalid_graph_index();
         self.proxy_index = crate::INVALID_USIZE;
     }
 
@@ -533,8 +530,6 @@ impl ColliderBuilder {
             parent: RigidBodySet::invalid_handle(),
             position: Isometry::identity(),
             predicted_position: Isometry::identity(),
-            contact_graph_index: InteractionGraph::<Contact>::invalid_graph_index(),
-            proximity_graph_index: InteractionGraph::<Proximity>::invalid_graph_index(),
             proxy_index: crate::INVALID_USIZE,
             collision_groups: self.collision_groups,
             solver_groups: self.solver_groups,

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -11,8 +11,6 @@ pub type ColliderHandle = crate::data::arena::Index;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub(crate) struct RemovedCollider {
     pub handle: ColliderHandle,
-    pub(crate) contact_graph_index: ColliderGraphIndex,
-    pub(crate) proximity_graph_index: ColliderGraphIndex,
     pub(crate) proxy_index: usize,
 }
 
@@ -105,8 +103,6 @@ impl ColliderSet {
          */
         let message = RemovedCollider {
             handle,
-            contact_graph_index: collider.contact_graph_index,
-            proximity_graph_index: collider.proximity_graph_index,
             proxy_index: collider.proxy_index,
         };
 

--- a/src/geometry/interaction_graph.rs
+++ b/src/geometry/interaction_graph.rs
@@ -74,15 +74,9 @@ impl<T> InteractionGraph<T> {
         self.graph.node_weight(id).cloned()
     }
 
-    /// All the interactions pairs on this graph.
-    pub fn interaction_pairs(&self) -> impl Iterator<Item = (ColliderHandle, ColliderHandle, &T)> {
-        self.graph.raw_edges().iter().map(move |edge| {
-            (
-                self.graph[edge.source()],
-                self.graph[edge.target()],
-                &edge.weight,
-            )
-        })
+    /// All the interactions on this graph.
+    pub fn interactions(&self) -> impl Iterator<Item = &T> {
+        self.graph.raw_edges().iter().map(move |edge| &edge.weight)
     }
 
     /// The interaction between the two collision objects identified by their graph index.

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -137,25 +137,27 @@ impl NarrowPhase {
         let mut i = 0;
 
         while let Some(collider) = colliders.removed_colliders.read_ith(&cursor, i) {
-            let graph_idx = self.graph_indices.get(collider.handle).unwrap();
+            // NOTE: if the collider does not have any graph indices currently, there is nothing
+            // to remove in the narrow-phase for this collider.
+            if let Some(graph_idx) = self.graph_indices.get(collider.handle) {
+                let proximity_graph_id = prox_id_remap
+                    .get(&collider.handle)
+                    .copied()
+                    .unwrap_or(graph_idx.proximity_graph_index);
+                let contact_graph_id = contact_id_remap
+                    .get(&collider.handle)
+                    .copied()
+                    .unwrap_or(graph_idx.contact_graph_index);
 
-            let proximity_graph_id = prox_id_remap
-                .get(&collider.handle)
-                .copied()
-                .unwrap_or(graph_idx.proximity_graph_index);
-            let contact_graph_id = contact_id_remap
-                .get(&collider.handle)
-                .copied()
-                .unwrap_or(graph_idx.contact_graph_index);
-
-            self.remove_collider(
-                proximity_graph_id,
-                contact_graph_id,
-                colliders,
-                bodies,
-                &mut prox_id_remap,
-                &mut contact_id_remap,
-            );
+                self.remove_collider(
+                    proximity_graph_id,
+                    contact_graph_id,
+                    colliders,
+                    bodies,
+                    &mut prox_id_remap,
+                    &mut contact_id_remap,
+                );
+            }
 
             i += 1;
         }

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -106,14 +106,39 @@ impl NarrowPhase {
         )
     }
 
-    // #[cfg(feature = "parallel")]
-    // pub fn contact_pairs(&self) -> &[ContactPair] {
-    //     &self.contact_graph.interactions
-    // }
+    /// The contact pair involving two specific colliders.
+    ///
+    /// If this returns `None`, there is no contact between the two colliders.
+    /// If this returns `Some`, then there may be a contact between the two colliders. Check the
+    /// result [`ContactPair::has_any_active_collider`] method to see if there is an actual contact.
+    pub fn contact_pair(
+        &self,
+        collider1: ColliderHandle,
+        collider2: ColliderHandle,
+    ) -> Option<&ContactPair> {
+        let id1 = self.graph_indices.get(collider1)?;
+        let id2 = self.graph_indices.get(collider2)?;
+        self.contact_graph
+            .interaction_pair(id1.contact_graph_index, id2.contact_graph_index)
+            .map(|c| c.2)
+    }
 
-    // pub fn contact_pairs_mut(&mut self) -> &mut [ContactPair] {
-    //     &mut self.contact_graph.interactions
-    // }
+    /// The proximity pair involving two specific colliders.
+    ///
+    /// If this returns `None`, there is no intersection between the two colliders.
+    /// If this returns `Some`, then there may be an intersection between the two colliders. Check the
+    /// value of [`ProximityPair::proximity`] method to see if there is an actual intersection.
+    pub fn proximity_pair(
+        &self,
+        collider1: ColliderHandle,
+        collider2: ColliderHandle,
+    ) -> Option<&ProximityPair> {
+        let id1 = self.graph_indices.get(collider1)?;
+        let id2 = self.graph_indices.get(collider2)?;
+        self.proximity_graph
+            .interaction_pair(id1.proximity_graph_index, id2.proximity_graph_index)
+            .map(|c| c.2)
+    }
 
     // #[cfg(feature = "parallel")]
     // pub(crate) fn contact_pairs_vec_mut(&mut self) -> &mut Vec<ContactPair> {

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -140,6 +140,16 @@ impl NarrowPhase {
             .map(|c| c.2)
     }
 
+    /// All the contact pairs maintained by this narrow-phase.
+    pub fn contact_pairs(&self) -> impl Iterator<Item = &ContactPair> {
+        self.contact_graph.interactions()
+    }
+
+    /// All the proximity pairs maintained by this narrow-phase.
+    pub fn proximity_pairs(&self) -> impl Iterator<Item = &ProximityPair> {
+        self.proximity_graph.interactions()
+    }
+
     // #[cfg(feature = "parallel")]
     // pub(crate) fn contact_pairs_vec_mut(&mut self) -> &mut Vec<ContactPair> {
     //     &mut self.contact_graph.interactions

--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -74,7 +74,7 @@ impl CollisionPipeline {
 
         bodies.update_active_set_with_contacts(
             colliders,
-            narrow_phase.contact_graph(),
+            narrow_phase,
             self.empty_joints.joint_graph(),
             0,
         );

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -130,7 +130,7 @@ impl PhysicsPipeline {
         self.counters.stages.island_construction_time.start();
         bodies.update_active_set_with_contacts(
             colliders,
-            narrow_phase.contact_graph(),
+            narrow_phase,
             joints.joint_graph(),
             integration_parameters.min_island_size,
         );

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1618,7 +1618,7 @@ Hashes at frame: {}
 }
 
 fn draw_contacts(window: &mut Window, nf: &NarrowPhase, colliders: &ColliderSet) {
-    for (_, _, pair) in nf.contact_graph().interaction_pairs() {
+    for pair in nf.contact_pairs() {
         for manifold in &pair.manifolds {
             for pt in manifold.all_contacts() {
                 let color = if pt.dist > 0.0 {


### PR DESCRIPTION
Fix #56 

This PRs will allow the user to retrieve:
- All the contacts/proximities involving one specific collider handle.
- The contacts/proximity information for one specific pair of collider handles.

In order to achieve this, one significant internal change was made: the interaction graph IDs are no longer stored in the `Collider`. Instead, they are stored by the narrow-phase directly. This is great because it decouples things a little more. However this adds a few indirection at some places when browsing the contact graph in needed. So we need to see if this has any notable effect on performance.