### PR TITLE
Track some user-initiated rigid-body modifications

### DIFF
--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -16,6 +16,7 @@ mod damping3;
 mod debug_boxes3;
 mod debug_cylinder3;
 mod debug_infinite_fall3;
+mod debug_rollback3;
 mod debug_triangle3;
 mod debug_trimesh3;
 mod domino3;
@@ -86,6 +87,7 @@ pub fn main() {
         ("(Debug) trimesh", debug_trimesh3::init_world),
         ("(Debug) cylinder", debug_cylinder3::init_world),
         ("(Debug) infinite fall", debug_infinite_fall3::init_world),
+        ("(Debug) rollback", debug_rollback3::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -13,8 +13,10 @@ use std::cmp::Ordering;
 mod collision_groups3;
 mod compound3;
 mod damping3;
+mod debug_add_remove_collider3;
 mod debug_boxes3;
 mod debug_cylinder3;
+mod debug_dynamic_collider_add3;
 mod debug_infinite_fall3;
 mod debug_rollback3;
 mod debug_triangle3;
@@ -82,7 +84,15 @@ pub fn main() {
         ("Sensor", sensor3::init_world),
         ("Trimesh", trimesh3::init_world),
         ("Keva tower", keva3::init_world),
+        (
+            "(Debug) add/rm collider",
+            debug_add_remove_collider3::init_world,
+        ),
         ("(Debug) boxes", debug_boxes3::init_world),
+        (
+            "(Debug) dyn. coll. add",
+            debug_dynamic_collider_add3::init_world,
+        ),
         ("(Debug) triangle", debug_triangle3::init_world),
         ("(Debug) trimesh", debug_trimesh3::init_world),
         ("(Debug) cylinder", debug_cylinder3::init_world),

--- a/examples3d/debug_add_remove_collider3.rs
+++ b/examples3d/debug_add_remove_collider3.rs
@@ -1,0 +1,110 @@
+use na::{Isometry3, Point3, Vector3};
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed3d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+    /*
+     * Ground.
+     */
+    let ground_size = 20.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height, 0.0)
+        .build();
+    let ground_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 0.4)
+        .friction(0.15)
+        // .restitution(0.5)
+        .build();
+    let mut ground_collider_handle = colliders.insert(collider, ground_handle, &mut bodies);
+
+    /*
+     * Rolling ball
+     */
+    let ball_rad = 0.1;
+    let rb = RigidBodyBuilder::new_dynamic()
+        .translation(0.0, 0.2, 0.0)
+        .linvel(10.0, 0.0, 0.0)
+        .build();
+    let ball_handle = bodies.insert(rb);
+    let collider = ColliderBuilder::ball(ball_rad).density(100.0).build();
+    colliders.insert(collider, ball_handle, &mut bodies);
+
+    let mut linvel = Vector3::zeros();
+    let mut angvel = Vector3::zeros();
+    let mut pos = Isometry3::identity();
+    let mut step = 0;
+    let mut extra_balls = Vec::new();
+    let snapped_frame = 51;
+
+    testbed.add_callback(move |window, physics, _, graphics, _| {
+        step += 1;
+
+        // Add a bigger ball collider
+        let collider = ColliderBuilder::ball(ball_rad + 0.01 * (step as f32))
+            .density(100.0)
+            .build();
+        let new_ball_collider_handle =
+            physics
+                .colliders
+                .insert(collider, ball_handle, &mut physics.bodies);
+        graphics.add_collider(window, new_ball_collider_handle, &physics.colliders);
+        extra_balls.push(new_ball_collider_handle);
+
+        // Snap the ball velocity or restore it.
+        let mut ball = physics.bodies.get_mut(ball_handle).unwrap();
+
+        if step == snapped_frame {
+            linvel = *ball.linvel();
+            angvel = *ball.angvel();
+            pos = *ball.position();
+        }
+
+        if step == 100 {
+            ball.set_linvel(linvel, true);
+            ball.set_angvel(angvel, true);
+            ball.set_position(pos, true);
+            step = snapped_frame;
+
+            for ball in &extra_balls {
+                physics.colliders.remove(*ball, &mut physics.bodies, true);
+            }
+
+            extra_balls.clear();
+        }
+
+        // Remove then re-add the ground collider.
+        // let ground = physics.bodies.get_mut(ground_handle).unwrap();
+        // ground.set_position(Isometry3::translation(0.0, step as f32 * 0.001, 0.0), false);
+        // let coll = physics
+        //     .colliders
+        //     .remove(ground_collider_handle, &mut physics.bodies, true)
+        //     .unwrap();
+        let coll = ColliderBuilder::cuboid(ground_size, ground_height + step as f32 * 0.01, 0.4)
+            .friction(0.15)
+            .build();
+        ground_collider_handle = physics
+            .colliders
+            .insert(coll, ground_handle, &mut physics.bodies);
+        graphics.add_collider(window, ground_collider_handle, &physics.colliders);
+    });
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point3::new(10.0, 10.0, 10.0), Point3::origin());
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/examples3d/debug_add_remove_collider3.rs
+++ b/examples3d/debug_add_remove_collider3.rs
@@ -13,17 +13,14 @@ pub fn init_world(testbed: &mut Testbed) {
     /*
      * Ground.
      */
-    let ground_size = 20.0;
+    let ground_size = 3.0;
     let ground_height = 0.1;
 
     let rigid_body = RigidBodyBuilder::new_static()
         .translation(0.0, -ground_height, 0.0)
         .build();
     let ground_handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 0.4)
-        .friction(0.15)
-        // .restitution(0.5)
-        .build();
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 0.4).build();
     let mut ground_collider_handle = colliders.insert(collider, ground_handle, &mut bodies);
 
     /*
@@ -32,65 +29,17 @@ pub fn init_world(testbed: &mut Testbed) {
     let ball_rad = 0.1;
     let rb = RigidBodyBuilder::new_dynamic()
         .translation(0.0, 0.2, 0.0)
-        .linvel(10.0, 0.0, 0.0)
         .build();
     let ball_handle = bodies.insert(rb);
     let collider = ColliderBuilder::ball(ball_rad).density(100.0).build();
     colliders.insert(collider, ball_handle, &mut bodies);
 
-    let mut linvel = Vector3::zeros();
-    let mut angvel = Vector3::zeros();
-    let mut pos = Isometry3::identity();
-    let mut step = 0;
-    let mut extra_balls = Vec::new();
-    let snapped_frame = 51;
-
     testbed.add_callback(move |window, physics, _, graphics, _| {
-        step += 1;
-
-        // Add a bigger ball collider
-        let collider = ColliderBuilder::ball(ball_rad + 0.01 * (step as f32))
-            .density(100.0)
-            .build();
-        let new_ball_collider_handle =
-            physics
-                .colliders
-                .insert(collider, ball_handle, &mut physics.bodies);
-        graphics.add_collider(window, new_ball_collider_handle, &physics.colliders);
-        extra_balls.push(new_ball_collider_handle);
-
-        // Snap the ball velocity or restore it.
-        let mut ball = physics.bodies.get_mut(ball_handle).unwrap();
-
-        if step == snapped_frame {
-            linvel = *ball.linvel();
-            angvel = *ball.angvel();
-            pos = *ball.position();
-        }
-
-        if step == 100 {
-            ball.set_linvel(linvel, true);
-            ball.set_angvel(angvel, true);
-            ball.set_position(pos, true);
-            step = snapped_frame;
-
-            for ball in &extra_balls {
-                physics.colliders.remove(*ball, &mut physics.bodies, true);
-            }
-
-            extra_balls.clear();
-        }
-
         // Remove then re-add the ground collider.
-        // let ground = physics.bodies.get_mut(ground_handle).unwrap();
-        // ground.set_position(Isometry3::translation(0.0, step as f32 * 0.001, 0.0), false);
-        // let coll = physics
-        //     .colliders
-        //     .remove(ground_collider_handle, &mut physics.bodies, true)
-        //     .unwrap();
-        let coll = ColliderBuilder::cuboid(ground_size, ground_height + step as f32 * 0.01, 0.4)
-            .friction(0.15)
-            .build();
+        let coll = physics
+            .colliders
+            .remove(ground_collider_handle, &mut physics.bodies, true)
+            .unwrap();
         ground_collider_handle = physics
             .colliders
             .insert(coll, ground_handle, &mut physics.bodies);

--- a/examples3d/debug_dynamic_collider_add3.rs
+++ b/examples3d/debug_dynamic_collider_add3.rs
@@ -91,7 +91,7 @@ pub fn init_world(testbed: &mut Testbed) {
         let coll = ColliderBuilder::cuboid(ground_size, ground_height + step as f32 * 0.01, 0.4)
             .friction(0.15)
             .build();
-        new_ground_collider_handle =
+        let new_ground_collider_handle =
             physics
                 .colliders
                 .insert(coll, ground_handle, &mut physics.bodies);

--- a/examples3d/debug_dynamic_collider_add3.rs
+++ b/examples3d/debug_dynamic_collider_add3.rs
@@ -1,0 +1,112 @@
+use na::{Isometry3, Point3, Vector3};
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed3d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+    /*
+     * Ground.
+     */
+    let ground_size = 20.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height, 0.0)
+        .build();
+    let ground_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 0.4)
+        .friction(0.15)
+        // .restitution(0.5)
+        .build();
+    let mut ground_collider_handle = colliders.insert(collider, ground_handle, &mut bodies);
+
+    /*
+     * Rolling ball
+     */
+    let ball_rad = 0.1;
+    let rb = RigidBodyBuilder::new_dynamic()
+        .translation(0.0, 0.2, 0.0)
+        .linvel(10.0, 0.0, 0.0)
+        .build();
+    let ball_handle = bodies.insert(rb);
+    let collider = ColliderBuilder::ball(ball_rad).density(100.0).build();
+    colliders.insert(collider, ball_handle, &mut bodies);
+
+    let mut linvel = Vector3::zeros();
+    let mut angvel = Vector3::zeros();
+    let mut pos = Isometry3::identity();
+    let mut step = 0;
+    let mut extra_colliders = Vec::new();
+    let snapped_frame = 51;
+
+    testbed.add_callback(move |window, physics, _, graphics, _| {
+        step += 1;
+
+        // Add a bigger ball collider
+        let collider = ColliderBuilder::ball(ball_rad + 0.01 * (step as f32))
+            .density(100.0)
+            .build();
+        let new_ball_collider_handle =
+            physics
+                .colliders
+                .insert(collider, ball_handle, &mut physics.bodies);
+        graphics.add_collider(window, new_ball_collider_handle, &physics.colliders);
+        extra_colliders.push(new_ball_collider_handle);
+
+        // Snap the ball velocity or restore it.
+        let mut ball = physics.bodies.get_mut(ball_handle).unwrap();
+
+        if step == snapped_frame {
+            linvel = *ball.linvel();
+            angvel = *ball.angvel();
+            pos = *ball.position();
+        }
+
+        if step == 100 {
+            ball.set_linvel(linvel, true);
+            ball.set_angvel(angvel, true);
+            ball.set_position(pos, true);
+            step = snapped_frame;
+
+            for handle in &extra_colliders {
+                physics.colliders.remove(*handle, &mut physics.bodies, true);
+            }
+
+            extra_colliders.clear();
+        }
+
+        // Remove then re-add the ground collider.
+        // let ground = physics.bodies.get_mut(ground_handle).unwrap();
+        // ground.set_position(Isometry3::translation(0.0, step as f32 * 0.001, 0.0), false);
+        // let coll = physics
+        //     .colliders
+        //     .remove(ground_collider_handle, &mut physics.bodies, true)
+        //     .unwrap();
+        let coll = ColliderBuilder::cuboid(ground_size, ground_height + step as f32 * 0.01, 0.4)
+            .friction(0.15)
+            .build();
+        new_ground_collider_handle =
+            physics
+                .colliders
+                .insert(coll, ground_handle, &mut physics.bodies);
+        graphics.add_collider(window, new_ground_collider_handle, &physics.colliders);
+        extra_colliders.push(new_ground_collider_handle);
+    });
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point3::new(10.0, 10.0, 10.0), Point3::origin());
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/examples3d/debug_rollback3.rs
+++ b/examples3d/debug_rollback3.rs
@@ -1,0 +1,77 @@
+use na::{Isometry3, Point3, Vector3};
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed3d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+    /*
+     * Ground.
+     */
+    let ground_size = 20.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height, 0.0)
+        .build();
+    let ground_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 0.4)
+        .friction(0.15)
+        // .restitution(0.5)
+        .build();
+    colliders.insert(collider, ground_handle, &mut bodies);
+
+    /*
+     * Rolling ball
+     */
+    let rb = RigidBodyBuilder::new_dynamic()
+        .translation(0.0, 0.2, 0.0)
+        .linvel(10.0, 0.0, 0.0)
+        .build();
+    let ball_handle = bodies.insert(rb);
+    let collider = ColliderBuilder::ball(0.1).density(100.0).build();
+    colliders.insert(collider, ball_handle, &mut bodies);
+
+    let mut linvel = Vector3::zeros();
+    let mut angvel = Vector3::zeros();
+    let mut pos = Isometry3::identity();
+    let mut step = 0;
+    let snapped_frame = 51;
+
+    testbed.add_callback(move |_, physics, _, _, _| {
+        step += 1;
+        let mut ball = physics.bodies.get_mut(ball_handle).unwrap();
+
+        if step == snapped_frame {
+            linvel = *ball.linvel();
+            angvel = *ball.angvel();
+            pos = *ball.position();
+        }
+
+        if step == 100 {
+            ball.set_linvel(linvel, true);
+            ball.set_angvel(angvel, true);
+            ball.set_position(pos, true);
+            step = snapped_frame;
+        }
+
+        let ground = physics.bodies.get_mut(ground_handle).unwrap();
+        ground.set_position(Isometry3::translation(0.0, step as f32 * 0.001, 0.0), false);
+    });
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point3::new(10.0, 10.0, 10.0), Point3::origin());
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/examples3d/debug_rollback3.rs
+++ b/examples3d/debug_rollback3.rs
@@ -24,17 +24,18 @@ pub fn init_world(testbed: &mut Testbed) {
         .friction(0.15)
         // .restitution(0.5)
         .build();
-    colliders.insert(collider, ground_handle, &mut bodies);
+    let mut ground_collider_handle = colliders.insert(collider, ground_handle, &mut bodies);
 
     /*
      * Rolling ball
      */
+    let ball_rad = 0.1;
     let rb = RigidBodyBuilder::new_dynamic()
         .translation(0.0, 0.2, 0.0)
         .linvel(10.0, 0.0, 0.0)
         .build();
     let ball_handle = bodies.insert(rb);
-    let collider = ColliderBuilder::ball(0.1).density(100.0).build();
+    let collider = ColliderBuilder::ball(ball_rad).density(100.0).build();
     colliders.insert(collider, ball_handle, &mut bodies);
 
     let mut linvel = Vector3::zeros();
@@ -43,8 +44,10 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut step = 0;
     let snapped_frame = 51;
 
-    testbed.add_callback(move |_, physics, _, _, _| {
+    testbed.add_callback(move |window, physics, _, graphics, _| {
         step += 1;
+
+        // Snap the ball velocity or restore it.
         let mut ball = physics.bodies.get_mut(ball_handle).unwrap();
 
         if step == snapped_frame {
@@ -59,9 +62,6 @@ pub fn init_world(testbed: &mut Testbed) {
             ball.set_position(pos, true);
             step = snapped_frame;
         }
-
-        let ground = physics.bodies.get_mut(ground_handle).unwrap();
-        ground.set_position(Isometry3::translation(0.0, step as f32 * 0.001, 0.0), false);
     });
 
     /*

--- a/examples3d/platform3.rs
+++ b/examples3d/platform3.rs
@@ -71,7 +71,7 @@ pub fn init_world(testbed: &mut Testbed) {
             return;
         }
 
-        if let Some(mut platform) = physics.bodies.get_mut(platform_handle) {
+        if let Some(platform) = physics.bodies.get_mut(platform_handle) {
             let mut next_pos = *platform.position();
 
             let dt = 0.016;

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -9,9 +9,10 @@ pub use self::joint::{
 };
 pub use self::mass_properties::MassProperties;
 pub use self::rigid_body::{ActivationStatus, BodyStatus, RigidBody, RigidBodyBuilder};
-pub use self::rigid_body_set::{BodyPair, RigidBodyHandle, RigidBodyMut, RigidBodySet};
+pub use self::rigid_body_set::{BodyPair, RigidBodyHandle, RigidBodySet};
 // #[cfg(not(feature = "parallel"))]
 pub(crate) use self::joint::JointGraphEdge;
+pub(crate) use self::rigid_body::RigidBodyChanges;
 #[cfg(not(feature = "parallel"))]
 pub(crate) use self::solver::IslandSolver;
 #[cfg(feature = "parallel")]

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -167,12 +167,10 @@ impl RigidBody {
 
     /// Adds a collider to this rigid-body.
     pub(crate) fn add_collider(&mut self, handle: ColliderHandle, coll: &Collider) {
-        if !self.changes.contains(RigidBodyChanges::MODIFIED) {
-            self.changes.set(
-                RigidBodyChanges::MODIFIED | RigidBodyChanges::COLLIDERS,
-                true,
-            );
-        }
+        self.changes.set(
+            RigidBodyChanges::MODIFIED | RigidBodyChanges::COLLIDERS,
+            true,
+        );
 
         let mass_properties = coll
             .mass_properties()
@@ -193,6 +191,7 @@ impl RigidBody {
     /// Removes a collider from this rigid-body.
     pub(crate) fn remove_collider_internal(&mut self, handle: ColliderHandle, coll: &Collider) {
         if let Some(i) = self.colliders.iter().position(|e| *e == handle) {
+            self.changes.set(RigidBodyChanges::COLLIDERS, true);
             self.colliders.swap_remove(i);
             let mass_properties = coll
                 .mass_properties()

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1,5 +1,7 @@
 use crate::dynamics::MassProperties;
-use crate::geometry::{Collider, ColliderHandle, InteractionGraph, RigidBodyGraphIndex};
+use crate::geometry::{
+    Collider, ColliderHandle, ColliderSet, InteractionGraph, RigidBodyGraphIndex,
+};
 use crate::math::{AngVector, AngularInertia, Isometry, Point, Rotation, Translation, Vector};
 use crate::utils::{WCross, WDot};
 use num::Zero;
@@ -21,6 +23,17 @@ pub enum BodyStatus {
     Kinematic,
     // Semikinematic, // A kinematic that performs automatic CCD with the static environment toi avoid traversing it?
     // Disabled,
+}
+
+bitflags::bitflags! {
+    #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+    /// Flags affecting the behavior of the constraints solver for a given contact manifold.
+    pub(crate) struct RigidBodyChanges: u32 {
+        const MODIFIED = 0b001;
+        const POSITION = 0b010;
+        const SLEEP = 0b100;
+        const COLLIDERS = 0b1000;
+    }
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -56,6 +69,7 @@ pub struct RigidBody {
     pub(crate) active_set_id: usize,
     pub(crate) active_set_offset: usize,
     pub(crate) active_set_timestamp: u32,
+    pub(crate) changes: RigidBodyChanges,
     /// The status of the body, governing how it is affected by external forces.
     pub body_status: BodyStatus,
     /// User-defined data associated to this rigid-body.
@@ -83,6 +97,7 @@ impl RigidBody {
             active_set_id: 0,
             active_set_offset: 0,
             active_set_timestamp: 0,
+            changes: RigidBodyChanges::all(),
             body_status: BodyStatus::Dynamic,
             user_data: 0,
         }
@@ -151,13 +166,28 @@ impl RigidBody {
     }
 
     /// Adds a collider to this rigid-body.
-    pub(crate) fn add_collider_internal(&mut self, handle: ColliderHandle, coll: &Collider) {
+    pub(crate) fn add_collider(&mut self, handle: ColliderHandle, coll: &Collider) {
+        if !self.changes.contains(RigidBodyChanges::MODIFIED) {
+            self.changes.set(
+                RigidBodyChanges::MODIFIED | RigidBodyChanges::COLLIDERS,
+                true,
+            );
+        }
+
         let mass_properties = coll
             .mass_properties()
             .transform_by(coll.position_wrt_parent());
         self.colliders.push(handle);
         self.mass_properties += mass_properties;
         self.update_world_mass_properties();
+    }
+
+    pub(crate) fn update_colliders_positions(&mut self, colliders: &mut ColliderSet) {
+        for handle in &self.colliders {
+            let collider = &mut colliders[*handle];
+            collider.position = self.position * collider.delta;
+            collider.predicted_position = self.predicted_position * collider.delta;
+        }
     }
 
     /// Removes a collider from this rigid-body.
@@ -189,7 +219,10 @@ impl RigidBody {
     /// If `strong` is `true` then it is assured that the rigid-body will
     /// remain awake during multiple subsequent timesteps.
     pub fn wake_up(&mut self, strong: bool) {
-        self.activation.sleeping = false;
+        if self.activation.sleeping {
+            self.changes.insert(RigidBodyChanges::SLEEP);
+            self.activation.sleeping = false;
+        }
 
         if (strong || self.activation.energy == 0.0) && self.is_dynamic() {
             self.activation.energy = self.activation.threshold.abs() * 2.0;
@@ -301,14 +334,21 @@ impl RigidBody {
     /// If `wake_up` is `true` then the rigid-body will be woken up if it was
     /// put to sleep because it did not move for a while.
     pub fn set_position(&mut self, pos: Isometry<f32>, wake_up: bool) {
+        self.changes.insert(RigidBodyChanges::POSITION);
+        self.set_position_internal(pos);
+
+        // TODO: Do we really need to check that the body isn't dynamic?
+        if wake_up && self.is_dynamic() {
+            self.wake_up(true)
+        }
+    }
+
+    pub(crate) fn set_position_internal(&mut self, pos: Isometry<f32>) {
         self.position = pos;
 
         // TODO: update the predicted position for dynamic bodies too?
         if self.is_static() || self.is_kinematic() {
             self.predicted_position = pos;
-        } else if wake_up {
-            // wake_up is true and the rigid-body is dynamic.
-            self.wake_up(true);
         }
     }
 
@@ -609,7 +649,7 @@ impl RigidBodyBuilder {
     pub fn build(&self) -> RigidBody {
         let mut rb = RigidBody::new();
         rb.predicted_position = self.position; // FIXME: compute the correct value?
-        rb.set_position(self.position, false);
+        rb.set_position_internal(self.position);
         rb.linvel = self.linvel;
         rb.angvel = self.angvel;
         rb.body_status = self.body_status;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -29,10 +29,10 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the behavior of the constraints solver for a given contact manifold.
     pub(crate) struct RigidBodyChanges: u32 {
-        const MODIFIED = 0b001;
-        const POSITION = 0b010;
-        const SLEEP = 0b100;
-        const COLLIDERS = 0b1000;
+        const MODIFIED  = 1 << 0;
+        const POSITION  = 1 << 1;
+        const SLEEP     = 1 << 2;
+        const COLLIDERS = 1 << 3;
     }
 }
 

--- a/src/dynamics/solver/parallel_island_solver.rs
+++ b/src/dynamics/solver/parallel_island_solver.rs
@@ -250,7 +250,7 @@ impl ParallelIslandSolver {
                     let batch_size = thread.batch_size;
                     for handle in active_bodies[thread.position_writeback_index] {
                         let rb = &mut bodies[*handle];
-                        rb.set_position(positions[rb.active_set_offset], false);
+                        rb.set_position_internal(positions[rb.active_set_offset]);
                     }
                 }
             })

--- a/src/dynamics/solver/position_solver.rs
+++ b/src/dynamics/solver/position_solver.rs
@@ -120,7 +120,7 @@ impl PositionSolver {
         }
 
         bodies.foreach_active_island_body_mut_internal(island_id, |_, rb| {
-            rb.set_position(self.positions[rb.active_set_offset], false)
+            rb.set_position_internal(self.positions[rb.active_set_offset])
         });
     }
 }

--- a/src/geometry/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap.rs
@@ -631,10 +631,10 @@ impl BroadPhase {
         self.complete_removals();
 
         for body_handle in bodies
-            .active_dynamic_set
+            .modified_inactive_set
             .iter()
+            .chain(bodies.active_dynamic_set.iter())
             .chain(bodies.active_kinematic_set.iter())
-            .chain(bodies.modified_inactive_set.iter())
         {
             for handle in &bodies[*body_handle].colliders {
                 let collider = &mut colliders[*handle];

--- a/src/geometry/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap.rs
@@ -634,6 +634,7 @@ impl BroadPhase {
             .active_dynamic_set
             .iter()
             .chain(bodies.active_kinematic_set.iter())
+            .chain(bodies.modified_inactive_set.iter())
         {
             for handle in &bodies[*body_handle].colliders {
                 let collider = &mut colliders[*handle];

--- a/src/geometry/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap.rs
@@ -586,9 +586,6 @@ impl BroadPhase {
 
         let proxy = &mut self.proxies[proxy_index];
 
-        // Push the proxy to infinity, but not beyond the sentinels.
-        proxy.aabb.mins.coords.fill(SENTINEL_VALUE / 2.0);
-        proxy.aabb.maxs.coords.fill(SENTINEL_VALUE / 2.0);
         // Discretize the AABB to find the regions that need to be invalidated.
         let start = point_key(proxy.aabb.mins);
         let end = point_key(proxy.aabb.maxs);
@@ -615,6 +612,9 @@ impl BroadPhase {
             }
         }
 
+        // Push the proxy to infinity, but not beyond the sentinels.
+        proxy.aabb.mins.coords.fill(SENTINEL_VALUE / 2.0);
+        proxy.aabb.maxs.coords.fill(SENTINEL_VALUE / 2.0);
         self.proxies.remove(proxy_index);
     }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,7 +1,7 @@
 use crate::dynamics::{MassProperties, RigidBodyHandle, RigidBodySet};
 use crate::geometry::{
-    Ball, Capsule, ColliderGraphIndex, Contact, Cuboid, HeightField, InteractionGraph,
-    InteractionGroups, Proximity, Segment, Shape, ShapeType, Triangle, Trimesh,
+    Ball, Capsule, Cuboid, HeightField, InteractionGroups, Segment, Shape, ShapeType, Triangle,
+    Trimesh,
 };
 #[cfg(feature = "dim3")]
 use crate::geometry::{Cone, Cylinder, RoundCylinder};

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -1,7 +1,7 @@
 use crate::data::arena::Arena;
 use crate::data::pubsub::PubSub;
 use crate::dynamics::{RigidBodyHandle, RigidBodySet};
-use crate::geometry::{Collider, ColliderGraphIndex};
+use crate::geometry::Collider;
 use std::ops::{Index, IndexMut};
 
 /// The unique identifier of a collider added to a collider set.
@@ -70,8 +70,7 @@ impl ColliderSet {
         coll.predicted_position = parent.predicted_position * coll.delta;
         let handle = self.colliders.insert(coll);
         let coll = self.colliders.get(handle).unwrap();
-        parent.add_collider_internal(handle, &coll);
-        bodies.activate(parent_handle);
+        parent.add_collider(handle, &coll);
         handle
     }
 
@@ -147,13 +146,13 @@ impl ColliderSet {
         self.colliders.get_mut(handle)
     }
 
-    pub(crate) fn get2_mut_internal(
-        &mut self,
-        h1: ColliderHandle,
-        h2: ColliderHandle,
-    ) -> (Option<&mut Collider>, Option<&mut Collider>) {
-        self.colliders.get2_mut(h1, h2)
-    }
+    // pub(crate) fn get2_mut_internal(
+    //     &mut self,
+    //     h1: ColliderHandle,
+    //     h2: ColliderHandle,
+    // ) -> (Option<&mut Collider>, Option<&mut Collider>) {
+    //     self.colliders.get2_mut(h1, h2)
+    // }
 
     // pub fn iter_mut(&mut self) -> impl Iterator<Item = (ColliderHandle, ColliderMut)> {
     //     //        let sender = &self.activation_channel_sender;

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -63,8 +63,11 @@ impl ColliderSet {
         coll.reset_internal_references();
 
         coll.parent = parent_handle;
+
+        // NOTE: we use `get_mut` instead of `get_mut_internal` so that the
+        // modification flag is updated properly.
         let parent = bodies
-            .get_mut_internal(parent_handle)
+            .get_mut(parent_handle)
             .expect("Parent rigid body not found.");
         coll.position = parent.position * coll.delta;
         coll.predicted_position = parent.predicted_position * coll.delta;
@@ -89,7 +92,9 @@ impl ColliderSet {
         /*
          * Delete the collider from its parent body.
          */
-        if let Some(parent) = bodies.get_mut_internal(collider.parent) {
+        // NOTE: we use `get_mut` instead of `get_mut_internal` so that the
+        // modification flag is updated properly.
+        if let Some(parent) = bodies.get_mut(collider.parent) {
             parent.remove_collider_internal(handle, &collider);
 
             if wake_up {

--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -47,7 +47,7 @@ impl CollisionPipeline {
         proximity_pair_filter: Option<&dyn ProximityPairFilter>,
         events: &dyn EventHandler,
     ) {
-        bodies.maintain_active_set();
+        bodies.maintain(colliders);
         self.broadphase_collider_pairs.clear();
 
         broad_phase.update_aabbs(prediction_distance, bodies, colliders);

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -74,9 +74,9 @@ impl PhysicsPipeline {
         events: &dyn EventHandler,
     ) {
         self.counters.step_started();
+        bodies.maintain(colliders);
         broad_phase.maintain(colliders);
         narrow_phase.maintain(colliders, bodies);
-        bodies.maintain_active_set();
 
         // Update kinematic bodies velocities.
         // TODO: what is the best place for this? It should at least be
@@ -242,11 +242,7 @@ impl PhysicsPipeline {
                 rb.update_predicted_position(integration_parameters.dt());
             }
 
-            for handle in &rb.colliders {
-                let collider = &mut colliders[*handle];
-                collider.position = rb.position * collider.delta;
-                collider.predicted_position = rb.predicted_position * collider.delta;
-            }
+            rb.update_colliders_positions(colliders);
         });
 
         self.counters.stages.solver_time.pause();

--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -237,7 +237,7 @@ impl GraphicsManager {
         for collider_handle in bodies[handle].colliders() {
             let color = self.c2color.get(collider_handle).copied().unwrap_or(color);
             let collider = &colliders[*collider_handle];
-            self.add_collider(window, *collider_handle, collider, color, &mut new_nodes);
+            self.do_add_collider(window, *collider_handle, collider, color, &mut new_nodes);
         }
 
         new_nodes.iter_mut().for_each(|n| n.update(colliders));
@@ -256,7 +256,22 @@ impl GraphicsManager {
         nodes.append(&mut new_nodes);
     }
 
-    fn add_collider(
+    pub fn add_collider(
+        &mut self,
+        window: &mut Window,
+        handle: ColliderHandle,
+        colliders: &ColliderSet,
+    ) {
+        let collider = &colliders[handle];
+        let color = *self.b2color.get(&collider.parent()).unwrap();
+        let color = self.c2color.get(&handle).copied().unwrap_or(color);
+        let mut nodes =
+            std::mem::replace(self.b2sn.get_mut(&collider.parent()).unwrap(), Vec::new());
+        self.do_add_collider(window, handle, collider, color, &mut nodes);
+        self.b2sn.insert(collider.parent(), nodes);
+    }
+
+    fn do_add_collider(
         &mut self,
         window: &mut Window,
         handle: ColliderHandle,

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -402,7 +402,7 @@ impl PhysxWorld {
 
     pub fn sync(&self, bodies: &mut RigidBodySet, colliders: &mut ColliderSet) {
         for (rapier_handle, physx_handle) in self.rapier2physx.iter() {
-            let mut rb = bodies.get_mut(*rapier_handle).unwrap();
+            let rb = bodies.get_mut(*rapier_handle).unwrap();
             let ra = self.scene.get_rigid_actor(*physx_handle).unwrap();
             let pos = ra.get_global_pose().into_na();
             let iso = na::convert_unchecked(pos);


### PR DESCRIPTION
With this PR we detect when the user modified the positions of rigid-bodies so we can update their collider at the beginning of the timestep. This will also update the position of static and kinematic bodies properly. This will likely fix https://github.com/dimforge/bevy_rapier/issues/14