### PR TITLE
Add a more convenient way of locking the rotations (or translations) of a rigid-body

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,12 @@
   their corresponding getters/setters. For example: `rb.linvel()`, `rb.set_linvel(vel, true)`.
 - Add `RigidBodyBuilder::sleeping(true)` to allow the creation of a rigid-body that is asleep
   at initialization-time.
+- Add `RigidBodyBuilder::lock_rotations` to prevent a rigid-body from rotating because of forces.
+- Add `RigidBodyBuilder::lock_translations` to prevent a rigid-body from translating because of forces.
+- Add `RigidBodyBuilder::principal_inertia` for setting the principal inertia of a rigid-body, and/or
+  preventing the rigid-body from rotating along a specific axis.
+- Change `RigidBodyBuilder::mass` by adding a bool parameter indicating whether or not the collider
+  contributions should be taken into account in the future too.
 
 ## v0.3.2
 - Add linear and angular damping. The damping factor can be set with `RigidBodyBuilder::linear_damping` and

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -16,6 +16,7 @@ mod damping2;
 mod debug_box_ball2;
 mod heightfield2;
 mod joints2;
+mod locked_rotation2;
 mod platform2;
 mod pyramid2;
 mod restitution2;
@@ -59,6 +60,7 @@ pub fn main() {
         ("Damping", damping2::init_world),
         ("Heightfield", heightfield2::init_world),
         ("Joints", joints2::init_world),
+        ("Locked rotations", locked_rotation2::init_world),
         ("Platform", platform2::init_world),
         ("Pyramid", pyramid2::init_world),
         ("Restitution", restitution2::init_world),

--- a/examples2d/locked_rotation2.rs
+++ b/examples2d/locked_rotation2.rs
@@ -1,7 +1,7 @@
-use na::{Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
-use rapier3d::geometry::{ColliderBuilder, ColliderSet};
-use rapier_testbed3d::Testbed;
+use na::Point2;
+use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed2d::Testbed;
 
 // This shows a bug when a cylinder is in contact with a very large
 // but very thin cuboid. In this case the EPA returns an incorrect
@@ -21,30 +21,29 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_height = 0.1;
 
     let rigid_body = RigidBodyBuilder::new_static()
-        .translation(0.0, -ground_height, 0.0)
+        .translation(0.0, -ground_height)
         .build();
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size).build();
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height).build();
     colliders.insert(collider, handle, &mut bodies);
 
     /*
-     * A rectangle that only rotates along the `x` axis.
+     * A rectangle that only rotate.
      */
     let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(0.0, 3.0, 0.0)
+        .translation(0.0, 3.0)
         .lock_translations()
-        .principal_inertia(Vector3::zeros(), Vector3::new(true, false, false))
         .build();
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0).build();
+    let collider = ColliderBuilder::cuboid(2.0, 0.6).build();
     colliders.insert(collider, handle, &mut bodies);
 
     /*
      * A tilted capsule that cannot rotate.
      */
     let rigid_body = RigidBodyBuilder::new_dynamic()
-        .translation(0.0, 5.0, 0.0)
-        .rotation(Vector3::x() * 1.0)
+        .translation(0.0, 5.0)
+        .rotation(1.0)
         .lock_rotations()
         .build();
     let handle = bodies.insert(rigid_body);
@@ -55,7 +54,7 @@ pub fn init_world(testbed: &mut Testbed) {
      * Set up the testbed.
      */
     testbed.set_world(bodies, colliders, joints);
-    testbed.look_at(Point3::new(10.0, 3.0, 0.0), Point3::new(0.0, 3.0, 0.0));
+    testbed.look_at(Point2::new(0.0, 0.0), 40.0);
 }
 
 fn main() {

--- a/examples2d/platform2.rs
+++ b/examples2d/platform2.rs
@@ -61,7 +61,7 @@ pub fn init_world(testbed: &mut Testbed) {
      * Setup a callback to control the platform.
      */
     testbed.add_callback(move |_, physics, _, _, time| {
-        let mut platform = physics.bodies.get_mut(platform_handle).unwrap();
+        let platform = physics.bodies.get_mut(platform_handle).unwrap();
         let mut next_pos = *platform.position();
 
         let dt = 0.016;

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -26,6 +26,7 @@ mod fountain3;
 mod heightfield3;
 mod joints3;
 mod keva3;
+mod locked_rotation3;
 mod platform3;
 mod primitives3;
 mod restitution3;
@@ -78,6 +79,7 @@ pub fn main() {
         ("Domino", domino3::init_world),
         ("Heightfield", heightfield3::init_world),
         ("Joints", joints3::init_world),
+        ("Locked rotations", locked_rotation3::init_world),
         ("Platform", platform3::init_world),
         ("Restitution", restitution3::init_world),
         ("Stacks", stacks3::init_world),

--- a/examples3d/locked_rotation3.rs
+++ b/examples3d/locked_rotation3.rs
@@ -1,0 +1,66 @@
+use na::{Point3, Vector3};
+use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier_testbed3d::Testbed;
+
+// This shows a bug when a cylinder is in contact with a very large
+// but very thin cuboid. In this case the EPA returns an incorrect
+// contact normal, resulting in the cylinder falling through the floor.
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let joints = JointSet::new();
+
+    /*
+     * The ground
+     */
+    let ground_size = 5.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::new_static()
+        .translation(0.0, -ground_height, 0.0)
+        .build();
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size).build();
+    colliders.insert(collider, handle, &mut bodies);
+
+    /*
+     * A rectangle that only rotates along the `x` axis.
+     */
+    let rigid_body = RigidBodyBuilder::new_dynamic()
+        .translation(0.0, 3.0, 0.0)
+        .lock_translations()
+        .principal_inertia(Vector3::zeros(), Vector3::new(false, true, true))
+        .build();
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0).build();
+    colliders.insert(collider, handle, &mut bodies);
+
+    /*
+     * A capsule that cannot rotate.
+     * We initialize it in a tilted position to demonstrate the
+     * fact that is cannot rotate.
+     */
+    let rigid_body = RigidBodyBuilder::new_dynamic()
+        .translation(0.0, 5.0, 0.0)
+        .rotation(Vector3::x() * 1.0)
+        .lock_rotations()
+        .build();
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::capsule_y(0.6, 0.4).build();
+    colliders.insert(collider, handle, &mut bodies);
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, joints);
+    testbed.look_at(Point3::new(10.0, 3.0, 0.0), Point3::new(0.0, 3.0, 0.0));
+}
+
+fn main() {
+    let testbed = Testbed::from_builders(0, vec![("Boxes", init_world)]);
+    testbed.run()
+}

--- a/examples3d/locked_rotation3.rs
+++ b/examples3d/locked_rotation3.rs
@@ -33,7 +33,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let rigid_body = RigidBodyBuilder::new_dynamic()
         .translation(0.0, 3.0, 0.0)
         .lock_translations()
-        .principal_inertia(Vector3::zeros(), Vector3::new(false, true, true))
+        .principal_inertia(Vector3::zeros(), Vector3::new(true, false, false))
         .build();
     let handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0).build();

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -634,7 +634,7 @@ impl RigidBodyBuilder {
     ///
     /// This is equivalent to `self.mass(0.0, false)`. See the
     /// documentation of [`RigidBodyBuilder::mass`] for more details.
-    pub fn lock_translations(mut self) -> Self {
+    pub fn lock_translations(self) -> Self {
         self.mass(0.0, false)
     }
 
@@ -644,7 +644,7 @@ impl RigidBodyBuilder {
     /// `self.principal_inertia(Vector3::zeros(), Vector3::repeat(false))` (in 3D).
     ///
     /// See the documentation of [`RigidBodyBuilder::principal_inertia`] for more details.
-    pub fn lock_rotations(mut self) -> Self {
+    pub fn lock_rotations(self) -> Self {
         #[cfg(feature = "dim2")]
         return self.principal_inertia(0.0, false);
         #[cfg(feature = "dim3")]

--- a/src_testbed/box2d_backend.rs
+++ b/src_testbed/box2d_backend.rs
@@ -219,7 +219,7 @@ impl Box2dWorld {
     }
 
     pub fn sync(&self, bodies: &mut RigidBodySet, colliders: &mut ColliderSet) {
-        for (handle, mut body) in bodies.iter_mut() {
+        for (handle, body) in bodies.iter_mut() {
             if let Some(pb2_handle) = self.rapier2box2d.get(&handle) {
                 let b2_body = self.world.body(*pb2_handle);
                 let pos = b2_transform_to_na_isometry(b2_body.transform().clone());

--- a/src_testbed/nphysics_backend.rs
+++ b/src_testbed/nphysics_backend.rs
@@ -158,7 +158,7 @@ impl NPhysicsWorld {
 
     pub fn sync(&self, bodies: &mut RigidBodySet, colliders: &mut ColliderSet) {
         for (rapier_handle, nphysics_handle) in self.rapier2nphysics.iter() {
-            let mut rb = bodies.get_mut(*rapier_handle).unwrap();
+            let rb = bodies.get_mut(*rapier_handle).unwrap();
             let ra = self.bodies.rigid_body(*nphysics_handle).unwrap();
             let pos = *ra.position();
             rb.set_position(pos, false);

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -20,12 +20,11 @@ use na::{self, Point2, Point3, Vector3};
 use rapier::dynamics::{
     ActivationStatus, IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet,
 };
-#[cfg(feature = "dim3")]
-use rapier::geometry::Ray;
 use rapier::geometry::{
-    BroadPhase, ColliderHandle, ColliderSet, ContactEvent, InteractionGroups, NarrowPhase,
-    ProximityEvent,
+    BroadPhase, ColliderHandle, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent,
 };
+#[cfg(feature = "dim3")]
+use rapier::geometry::{InteractionGroups, Ray};
 use rapier::math::Vector;
 use rapier::pipeline::{ChannelEventCollector, PhysicsPipeline, QueryPipeline};
 


### PR DESCRIPTION
Locking rotations isn't so easy right now: one needs to set the principal inertia of the rigid-body to zero **after** all the colliders has been attached to it. This can be annoying to do, especially when using an ECS like Bevy's (see https://github.com/dimforge/bevy_rapier/issues/9).

This PR introduces a few changes to make this much easier: it allows the user to specify, at construction time, if a rigid-body should ignore some contributions a collider would make to its mass properties. This allows making rotations along some coordinate axes, or all translations, behave in a kinematic way (i.e. only controlled by the user, immune to forces).

For convenience, there are the new `RigidBodyBuilder::lock_rotations` and `RigidBodyBuilder::lock_translations` that hide these details from the user, for simplicity. 

This includes a breaking chanhge because `RigidBodyBuilder::mass` takes an additional parameter now.