### PR TITLE
Replace the delta-position by the collider positions in the contact manifolds.

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -381,6 +381,7 @@ impl RigidBody {
     }
 
     /// The world-space position of this rigid-body.
+    #[inline]
     pub fn position(&self) -> &Isometry<f32> {
         &self.position
     }

--- a/src/dynamics/solver/position_constraint.rs
+++ b/src/dynamics/solver/position_constraint.rs
@@ -94,6 +94,8 @@ impl PositionConstraint {
         let shift2 = manifold.local_n2 * -manifold.kinematics.radius2;
         let radius =
             manifold.kinematics.radius1 + manifold.kinematics.radius2 /*- params.allowed_linear_error*/;
+        let delta1 = rb1.position.inverse() * manifold.position1;
+        let delta2 = rb2.position.inverse() * manifold.position2;
 
         for (l, manifold_points) in manifold
             .active_contacts()
@@ -104,8 +106,8 @@ impl PositionConstraint {
             let mut local_p2 = [Point::origin(); MAX_MANIFOLD_POINTS];
 
             for l in 0..manifold_points.len() {
-                local_p1[l] = manifold.delta1 * (manifold_points[l].local_p1 + shift1);
-                local_p2[l] = manifold.delta2 * (manifold_points[l].local_p2 + shift2);
+                local_p1[l] = delta1 * (manifold_points[l].local_p1 + shift1);
+                local_p2[l] = delta2 * (manifold_points[l].local_p2 + shift2);
             }
 
             let constraint = PositionConstraint {

--- a/src/dynamics/solver/position_constraint_wide.rs
+++ b/src/dynamics/solver/position_constraint_wide.rs
@@ -41,9 +41,12 @@ impl WPositionConstraint {
         let im1 = SimdFloat::from(array![|ii| rbs1[ii].mass_properties.inv_mass; SIMD_WIDTH]);
         let sqrt_ii1: AngularInertia<SimdFloat> =
             AngularInertia::from(array![|ii| rbs1[ii].world_inv_inertia_sqrt; SIMD_WIDTH]);
+        let rb_pos1 = Isometry::from(array![|ii| *rbs1[ii].position(); SIMD_WIDTH]);
+
         let im2 = SimdFloat::from(array![|ii| rbs2[ii].mass_properties.inv_mass; SIMD_WIDTH]);
         let sqrt_ii2: AngularInertia<SimdFloat> =
             AngularInertia::from(array![|ii| rbs2[ii].world_inv_inertia_sqrt; SIMD_WIDTH]);
+        let rb_pos2 = Isometry::from(array![|ii| *rbs2[ii].position(); SIMD_WIDTH]);
 
         let local_n1 = Vector::from(array![|ii| manifolds[ii].local_n1; SIMD_WIDTH]);
         let local_n2 = Vector::from(array![|ii| manifolds[ii].local_n2; SIMD_WIDTH]);
@@ -51,8 +54,11 @@ impl WPositionConstraint {
         let radius1 = SimdFloat::from(array![|ii| manifolds[ii].kinematics.radius1; SIMD_WIDTH]);
         let radius2 = SimdFloat::from(array![|ii| manifolds[ii].kinematics.radius2; SIMD_WIDTH]);
 
-        let delta1 = Isometry::from(array![|ii| manifolds[ii].delta1; SIMD_WIDTH]);
-        let delta2 = Isometry::from(array![|ii| manifolds[ii].delta2; SIMD_WIDTH]);
+        let coll_pos1 = Isometry::from(array![|ii| manifolds[ii].position1; SIMD_WIDTH]);
+        let coll_pos2 = Isometry::from(array![|ii| manifolds[ii].position2; SIMD_WIDTH]);
+
+        let delta1 = rb_pos1.inverse() * coll_pos1;
+        let delta2 = rb_pos2.inverse() * coll_pos2;
 
         let rb1 = array![|ii| rbs1[ii].active_set_offset; SIMD_WIDTH];
         let rb2 = array![|ii| rbs2[ii].active_set_offset; SIMD_WIDTH];

--- a/src/dynamics/solver/position_ground_constraint.rs
+++ b/src/dynamics/solver/position_ground_constraint.rs
@@ -42,7 +42,7 @@ impl PositionGroundConstraint {
             local_n1 = manifold.local_n2;
             local_n2 = manifold.local_n1;
             coll_pos1 = &manifold.position2;
-            delta2 = rb1.position() * manifold.position1;
+            delta2 = rb1.position().inverse() * manifold.position1;
         } else {
             local_n1 = manifold.local_n1;
             local_n2 = manifold.local_n2;

--- a/src/dynamics/solver/position_ground_constraint.rs
+++ b/src/dynamics/solver/position_ground_constraint.rs
@@ -34,23 +34,22 @@ impl PositionGroundConstraint {
 
         let local_n1;
         let local_n2;
-        let delta1;
+        let coll_pos1;
         let delta2;
 
         if flip {
             std::mem::swap(&mut rb1, &mut rb2);
             local_n1 = manifold.local_n2;
             local_n2 = manifold.local_n1;
-            delta1 = &manifold.delta2;
-            delta2 = &manifold.delta1;
+            coll_pos1 = &manifold.position2;
+            delta2 = rb1.position() * manifold.position1;
         } else {
             local_n1 = manifold.local_n1;
             local_n2 = manifold.local_n2;
-            delta1 = &manifold.delta1;
-            delta2 = &manifold.delta2;
+            coll_pos1 = &manifold.position1;
+            delta2 = rb2.position().inverse() * manifold.position2;
         };
 
-        let coll_pos1 = rb1.position * delta1;
         let shift1 = local_n1 * -manifold.kinematics.radius1;
         let shift2 = local_n2 * -manifold.kinematics.radius2;
         let n1 = coll_pos1 * local_n1;

--- a/src/dynamics/solver/position_ground_constraint_wide.rs
+++ b/src/dynamics/solver/position_ground_constraint_wide.rs
@@ -54,18 +54,18 @@ impl WPositionGroundConstraint {
             array![|ii| if flipped[ii] { manifolds[ii].local_n1 } else { manifolds[ii].local_n2 }; SIMD_WIDTH],
         );
 
-        let delta1 = Isometry::from(
-            array![|ii| if flipped[ii] { manifolds[ii].delta2 } else { manifolds[ii].delta1 }; SIMD_WIDTH],
+        let coll_pos1 = Isometry::from(
+            array![|ii| if flipped[ii] { manifolds[ii].position2 } else { manifolds[ii].position1 }; SIMD_WIDTH],
         );
-        let delta2 = Isometry::from(
-            array![|ii| if flipped[ii] { manifolds[ii].delta1 } else { manifolds[ii].delta2 }; SIMD_WIDTH],
+        let coll_pos2 = Isometry::from(
+            array![|ii| if flipped[ii] { manifolds[ii].position1 } else { manifolds[ii].position2 }; SIMD_WIDTH],
         );
 
         let radius1 = SimdFloat::from(array![|ii| manifolds[ii].kinematics.radius1; SIMD_WIDTH]);
         let radius2 = SimdFloat::from(array![|ii| manifolds[ii].kinematics.radius2; SIMD_WIDTH]);
 
-        let coll_pos1 =
-            delta1 * Isometry::from(array![|ii| rbs1[ii].predicted_position; SIMD_WIDTH]);
+        let delta2 = Isometry::from(array![|ii| rbs2[ii].predicted_position; SIMD_WIDTH]).inverse()
+            * coll_pos2;
 
         let rb2 = array![|ii| rbs2[ii].active_set_offset; SIMD_WIDTH];
 

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -148,9 +148,7 @@ impl VelocityConstraint {
         let rb2 = &bodies[manifold.body_pair.body2];
         let mj_lambda1 = rb1.active_set_offset;
         let mj_lambda2 = rb2.active_set_offset;
-        let pos_coll1 = rb1.position * manifold.delta1;
-        let pos_coll2 = rb2.position * manifold.delta2;
-        let force_dir1 = pos_coll1 * (-manifold.local_n1);
+        let force_dir1 = manifold.position1 * (-manifold.local_n1);
         let warmstart_coeff = manifold.warmstart_multiplier * params.warmstart_coeff;
 
         for (l, manifold_points) in manifold
@@ -217,8 +215,8 @@ impl VelocityConstraint {
 
             for k in 0..manifold_points.len() {
                 let manifold_point = &manifold_points[k];
-                let dp1 = (pos_coll1 * manifold_point.local_p1) - rb1.world_com;
-                let dp2 = (pos_coll2 * manifold_point.local_p2) - rb2.world_com;
+                let dp1 = (manifold.position1 * manifold_point.local_p1) - rb1.world_com;
+                let dp2 = (manifold.position2 * manifold_point.local_p2) - rb2.world_com;
 
                 let vel1 = rb1.linvel + rb1.angvel.gcross(dp1);
                 let vel2 = rb2.linvel + rb2.angvel.gcross(dp2);

--- a/src/dynamics/solver/velocity_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_constraint_wide.rs
@@ -72,17 +72,12 @@ impl WVelocityConstraint {
         let rbs1 = array![|ii| &bodies[manifolds[ii].body_pair.body1]; SIMD_WIDTH];
         let rbs2 = array![|ii| &bodies[manifolds[ii].body_pair.body2]; SIMD_WIDTH];
 
-        let delta1 = Isometry::from(array![|ii| manifolds[ii].delta1; SIMD_WIDTH]);
-        let delta2 = Isometry::from(array![|ii| manifolds[ii].delta2; SIMD_WIDTH]);
-
         let im1 = SimdFloat::from(array![|ii| rbs1[ii].mass_properties.inv_mass; SIMD_WIDTH]);
         let ii1: AngularInertia<SimdFloat> =
             AngularInertia::from(array![|ii| rbs1[ii].world_inv_inertia_sqrt; SIMD_WIDTH]);
 
         let linvel1 = Vector::from(array![|ii| rbs1[ii].linvel; SIMD_WIDTH]);
         let angvel1 = AngVector::<SimdFloat>::from(array![|ii| rbs1[ii].angvel; SIMD_WIDTH]);
-
-        let pos1 = Isometry::from(array![|ii| rbs1[ii].position; SIMD_WIDTH]);
         let world_com1 = Point::from(array![|ii| rbs1[ii].world_com; SIMD_WIDTH]);
 
         let im2 = SimdFloat::from(array![|ii| rbs2[ii].mass_properties.inv_mass; SIMD_WIDTH]);
@@ -91,13 +86,10 @@ impl WVelocityConstraint {
 
         let linvel2 = Vector::from(array![|ii| rbs2[ii].linvel; SIMD_WIDTH]);
         let angvel2 = AngVector::<SimdFloat>::from(array![|ii| rbs2[ii].angvel; SIMD_WIDTH]);
-
-        let pos2 = Isometry::from(array![|ii| rbs2[ii].position; SIMD_WIDTH]);
         let world_com2 = Point::from(array![|ii| rbs2[ii].world_com; SIMD_WIDTH]);
 
-        let coll_pos1 = pos1 * delta1;
-        let coll_pos2 = pos2 * delta2;
-
+        let coll_pos1 = Isometry::from(array![|ii| manifolds[ii].position1; SIMD_WIDTH]);
+        let coll_pos2 = Isometry::from(array![|ii| manifolds[ii].position2; SIMD_WIDTH]);
         let force_dir1 = coll_pos1 * -Vector::from(array![|ii| manifolds[ii].local_n1; SIMD_WIDTH]);
 
         let mj_lambda1 = array![|ii| rbs1[ii].active_set_offset; SIMD_WIDTH];

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -71,13 +71,13 @@ impl VelocityGroundConstraint {
         let coll_pos2;
 
         if flipped {
-            coll_pos1 = rb2.position * manifold.delta2;
-            coll_pos2 = rb1.position * manifold.delta1;
+            coll_pos1 = manifold.position2;
+            coll_pos2 = manifold.position1;
             force_dir1 = coll_pos1 * (-manifold.local_n2);
             std::mem::swap(&mut rb1, &mut rb2);
         } else {
-            coll_pos1 = rb1.position * manifold.delta1;
-            coll_pos2 = rb2.position * manifold.delta2;
+            coll_pos1 = manifold.position1;
+            coll_pos2 = manifold.position2;
             force_dir1 = coll_pos1 * (-manifold.local_n1);
         }
 

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -86,18 +86,12 @@ impl WVelocityGroundConstraint {
         let linvel2 = Vector::from(array![|ii| rbs2[ii].linvel; SIMD_WIDTH]);
         let angvel2 = AngVector::<SimdFloat>::from(array![|ii| rbs2[ii].angvel; SIMD_WIDTH]);
 
-        let pos1 = Isometry::from(array![|ii| rbs1[ii].position; SIMD_WIDTH]);
-        let pos2 = Isometry::from(array![|ii| rbs2[ii].position; SIMD_WIDTH]);
-
-        let delta1 = Isometry::from(
-            array![|ii| if flipped[ii] { manifolds[ii].delta2 } else { manifolds[ii].delta1 }; SIMD_WIDTH],
+        let coll_pos1 = Isometry::from(
+            array![|ii| if flipped[ii] { manifolds[ii].position2 } else { manifolds[ii].position1 }; SIMD_WIDTH],
         );
-        let delta2 = Isometry::from(
-            array![|ii| if flipped[ii] { manifolds[ii].delta1 } else { manifolds[ii].delta2 }; SIMD_WIDTH],
+        let coll_pos2 = Isometry::from(
+            array![|ii| if flipped[ii] { manifolds[ii].position1 } else { manifolds[ii].position2 }; SIMD_WIDTH],
         );
-
-        let coll_pos1 = pos1 * delta1;
-        let coll_pos2 = pos2 * delta2;
 
         let world_com1 = Point::from(array![|ii| rbs1[ii].world_com; SIMD_WIDTH]);
         let world_com2 = Point::from(array![|ii| rbs2[ii].world_com; SIMD_WIDTH]);

--- a/src/geometry/contact.rs
+++ b/src/geometry/contact.rs
@@ -236,8 +236,8 @@ impl ContactPair {
         // (This order can be modified by the contact determination algorithm).
         let manifold = &mut self.manifolds[0];
         if manifold.pair.collider1 == self.pair.collider1 {
-            manifold.position1 = *coll1.position();
-            manifold.position2 = *coll2.position();
+            manifold.position1 = coll1.position;
+            manifold.position2 = coll2.position;
             (
                 coll1,
                 coll2,
@@ -245,8 +245,8 @@ impl ContactPair {
                 self.generator_workspace.as_mut().map(|w| &mut *w.0),
             )
         } else {
-            manifold.position1 = *coll2.position();
-            manifold.position2 = *coll1.position();
+            manifold.position1 = coll2.position;
+            manifold.position2 = coll1.position;
             (
                 coll2,
                 coll1,

--- a/src/geometry/contact_generator/ball_ball_contact_generator.rs
+++ b/src/geometry/contact_generator/ball_ball_contact_generator.rs
@@ -28,7 +28,9 @@ fn generate_contacts_simd(ball1: &WBall, ball2: &WBall, pos21: &Isometry<SimdFlo
 
 #[cfg(feature = "simd-is-enabled")]
 pub fn generate_contacts_ball_ball_simd(ctxt: &mut PrimitiveContactGenerationContextSimd) {
-    let pos_ba = ctxt.positions2.inverse() * ctxt.positions1;
+    let positions1 = Isometry::from(array![|ii| ctxt.manifolds[ii].position1; SIMD_WIDTH]);
+    let positions2 = Isometry::from(array![|ii| ctxt.manifolds[ii].position2; SIMD_WIDTH]);
+    let pos_ba = positions2.inverse() * positions1;
     let radii_a =
         SimdFloat::from(array![|ii| ctxt.shapes1[ii].as_ball().unwrap().radius; SIMD_WIDTH]);
     let radii_b =
@@ -63,7 +65,7 @@ pub fn generate_contacts_ball_ball_simd(ctxt: &mut PrimitiveContactGenerationCon
 }
 
 pub fn generate_contacts_ball_ball(ctxt: &mut PrimitiveContactGenerationContext) {
-    let pos_ba = ctxt.position2.inverse() * ctxt.position1;
+    let pos_ba = ctxt.manifold.position2.inverse() * ctxt.manifold.position1;
     let radius_a = ctxt.shape1.as_ball().unwrap().radius;
     let radius_b = ctxt.shape2.as_ball().unwrap().radius;
 

--- a/src/geometry/contact_generator/ball_convex_contact_generator.rs
+++ b/src/geometry/contact_generator/ball_convex_contact_generator.rs
@@ -25,11 +25,11 @@ fn do_generate_contacts<P: ?Sized + PointQuery<f32>>(
     let position2;
 
     if swapped {
-        position1 = ctxt.position2;
-        position2 = ctxt.position1;
+        position1 = ctxt.manifold.position2;
+        position2 = ctxt.manifold.position1;
     } else {
-        position1 = ctxt.position1;
-        position2 = ctxt.position2;
+        position1 = ctxt.manifold.position1;
+        position2 = ctxt.manifold.position2;
     }
 
     let local_p2_1 = position1.inverse_transform_point(&position2.translation.vector.into());

--- a/src/geometry/contact_generator/capsule_capsule_contact_generator.rs
+++ b/src/geometry/contact_generator/capsule_capsule_contact_generator.rs
@@ -9,14 +9,7 @@ use ncollide::shape::SegmentPointLocation;
 
 pub fn generate_contacts_capsule_capsule(ctxt: &mut PrimitiveContactGenerationContext) {
     if let (Some(capsule1), Some(capsule2)) = (ctxt.shape1.as_capsule(), ctxt.shape2.as_capsule()) {
-        generate_contacts(
-            ctxt.prediction_distance,
-            capsule1,
-            ctxt.position1,
-            capsule2,
-            ctxt.position2,
-            ctxt.manifold,
-        );
+        generate_contacts(ctxt.prediction_distance, capsule1, capsule2, ctxt.manifold);
     }
 
     ctxt.manifold.update_warmstart_multiplier();
@@ -27,16 +20,14 @@ pub fn generate_contacts_capsule_capsule(ctxt: &mut PrimitiveContactGenerationCo
 pub fn generate_contacts<'a>(
     prediction_distance: f32,
     capsule1: &'a Capsule,
-    pos1: &'a Isometry<f32>,
     capsule2: &'a Capsule,
-    pos2: &'a Isometry<f32>,
     manifold: &mut ContactManifold,
 ) {
     // FIXME: the contact kinematics is not correctly set here.
     // We use the common "Point-Plane" kinematics with zero radius everytime.
     // Instead we should select point/point ore point-plane (with non-zero
     // radius for the point) depending on the features involved in the contact.
-    let pos12 = pos1.inverse() * pos2;
+    let pos12 = manifold.position1.inverse() * manifold.position2;
     let pos21 = pos12.inverse();
 
     let seg1 = capsule1.segment;
@@ -146,12 +137,10 @@ pub fn generate_contacts<'a>(
 pub fn generate_contacts<'a>(
     prediction_distance: f32,
     capsule1: &'a Capsule,
-    pos1: &'a Isometry<f32>,
     capsule2: &'a Capsule,
-    pos2: &'a Isometry<f32>,
     manifold: &mut ContactManifold,
 ) {
-    let pos12 = pos1.inverse() * pos2;
+    let pos12 = manifold.position1.inverse() * manifold.position2;
     let pos21 = pos12.inverse();
 
     let seg1 = capsule1.segment;

--- a/src/geometry/contact_generator/contact_generator.rs
+++ b/src/geometry/contact_generator/contact_generator.rs
@@ -36,8 +36,6 @@ impl ContactPhase {
                     collider2,
                     shape1: collider1.shape(),
                     shape2: collider2.shape(),
-                    position1: collider1.position(),
-                    position2: collider2.position(),
                     manifold,
                     workspace,
                 };
@@ -107,12 +105,6 @@ impl ContactPhase {
                     colliders2,
                     shapes1: array![|ii| colliders1[ii].shape(); SIMD_WIDTH],
                     shapes2: array![|ii| colliders2[ii].shape(); SIMD_WIDTH],
-                    positions1: &Isometry::from(
-                        array![|ii| *colliders1[ii].position(); SIMD_WIDTH],
-                    ),
-                    positions2: &Isometry::from(
-                        array![|ii| *colliders2[ii].position(); SIMD_WIDTH],
-                    ),
                     manifolds: manifold_arr.as_mut_slice(),
                     workspaces: workspace_arr.as_mut_slice(),
                 };
@@ -145,8 +137,6 @@ pub struct PrimitiveContactGenerationContext<'a> {
     pub collider2: &'a Collider,
     pub shape1: &'a dyn Shape,
     pub shape2: &'a dyn Shape,
-    pub position1: &'a Isometry<f32>,
-    pub position2: &'a Isometry<f32>,
     pub manifold: &'a mut ContactManifold,
     pub workspace: Option<&'a mut (dyn MaybeSerializableData)>,
 }
@@ -158,8 +148,6 @@ pub struct PrimitiveContactGenerationContextSimd<'a, 'b> {
     pub colliders2: [&'a Collider; SIMD_WIDTH],
     pub shapes1: [&'a dyn Shape; SIMD_WIDTH],
     pub shapes2: [&'a dyn Shape; SIMD_WIDTH],
-    pub positions1: &'a Isometry<SimdFloat>,
-    pub positions2: &'a Isometry<SimdFloat>,
     pub manifolds: &'a mut [&'b mut ContactManifold],
     pub workspaces: &'a mut [Option<&'b mut (dyn MaybeSerializableData)>],
 }

--- a/src/geometry/contact_generator/cuboid_cuboid_contact_generator.rs
+++ b/src/geometry/contact_generator/cuboid_cuboid_contact_generator.rs
@@ -7,14 +7,7 @@ use ncollide::shape::Cuboid;
 
 pub fn generate_contacts_cuboid_cuboid(ctxt: &mut PrimitiveContactGenerationContext) {
     if let (Some(cube1), Some(cube2)) = (ctxt.shape1.as_cuboid(), ctxt.shape2.as_cuboid()) {
-        generate_contacts(
-            ctxt.prediction_distance,
-            cube1,
-            ctxt.position1,
-            cube2,
-            ctxt.position2,
-            ctxt.manifold,
-        );
+        generate_contacts(ctxt.prediction_distance, cube1, cube2, ctxt.manifold);
     } else {
         unreachable!()
     }
@@ -26,12 +19,10 @@ pub fn generate_contacts_cuboid_cuboid(ctxt: &mut PrimitiveContactGenerationCont
 pub fn generate_contacts<'a>(
     prediction_distance: f32,
     mut cube1: &'a Cuboid<f32>,
-    mut pos1: &'a Isometry<f32>,
     mut cube2: &'a Cuboid<f32>,
-    mut pos2: &'a Isometry<f32>,
     manifold: &mut ContactManifold,
 ) {
-    let mut pos12 = pos1.inverse() * pos2;
+    let mut pos12 = manifold.position1.inverse() * manifold.position2;
     let mut pos21 = pos12.inverse();
 
     if manifold.try_update_contacts(&pos12) {
@@ -81,7 +72,6 @@ pub fn generate_contacts<'a>(
     if sep2.0 > sep1.0 && sep2.0 > sep3.0 {
         // The reference shape will be the second shape.
         std::mem::swap(&mut cube1, &mut cube2);
-        std::mem::swap(&mut pos1, &mut pos2);
         std::mem::swap(&mut pos12, &mut pos21);
         manifold.swap_identifiers();
         best_sep = sep2;

--- a/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
@@ -151,8 +151,6 @@ fn do_generate_contacts(
                 collider2: collider1,
                 shape1: collider2.shape(),
                 shape2: &sub_shape1,
-                position1: collider2.position(),
-                position2: position1,
                 manifold,
                 workspace: sub_detector.workspace.as_mut().map(|w| &mut *w.0),
             }
@@ -165,8 +163,6 @@ fn do_generate_contacts(
                 collider2,
                 shape1: &sub_shape1,
                 shape2: collider2.shape(),
-                position1,
-                position2: collider2.position(),
                 manifold,
                 workspace: sub_detector.workspace.as_mut().map(|w| &mut *w.0),
             }

--- a/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/heightfield_shape_contact_generator.rs
@@ -143,6 +143,8 @@ fn do_generate_contacts(
         let manifold = &mut manifolds[sub_detector.manifold_id];
 
         let mut ctxt2 = if coll_pair.collider1 != manifold.pair.collider1 {
+            manifold.position1 = collider2.position;
+            manifold.position2 = collider1.position;
             PrimitiveContactGenerationContext {
                 prediction_distance,
                 collider1: collider2,
@@ -155,6 +157,8 @@ fn do_generate_contacts(
                 workspace: sub_detector.workspace.as_mut().map(|w| &mut *w.0),
             }
         } else {
+            manifold.position1 = collider1.position;
+            manifold.position2 = collider2.position;
             PrimitiveContactGenerationContext {
                 prediction_distance,
                 collider1,

--- a/src/geometry/contact_generator/pfm_pfm_contact_generator.rs
+++ b/src/geometry/contact_generator/pfm_pfm_contact_generator.rs
@@ -52,7 +52,7 @@ fn do_generate_contacts(
     border_radius2: f32,
     ctxt: &mut PrimitiveContactGenerationContext,
 ) {
-    let pos12 = ctxt.position1.inverse() * ctxt.position2;
+    let pos12 = ctxt.manifold.position1.inverse() * ctxt.manifold.position2;
     let pos21 = pos12.inverse();
 
     // We use very small thresholds for the manifold update because something to high would

--- a/src/geometry/contact_generator/polygon_polygon_contact_generator.rs
+++ b/src/geometry/contact_generator/polygon_polygon_contact_generator.rs
@@ -11,9 +11,9 @@ pub fn generate_contacts_polygon_polygon(_ctxt: &mut PrimitiveContactGenerationC
     // if let (Shape::Polygon(polygon1), Shape::Polygon(polygon2)) = (ctxt.shape1, ctxt.shape2) {
     //     generate_contacts(
     //         polygon1,
-    //         &ctxt.position1,
+    //         &ctxt.manifold.position1,
     //         polygon2,
-    //         &ctxt.position2,
+    //         &ctxt.manifold.position2,
     //         ctxt.manifold,
     //     );
     //     ctxt.manifold.update_warmstart_multiplier();

--- a/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
@@ -185,8 +185,6 @@ fn do_generate_contacts(
                 collider2: collider1,
                 shape1: collider2.shape(),
                 shape2: &triangle1,
-                position1: collider2.position(),
-                position2: collider1.position(),
                 manifold,
                 workspace: workspace2.as_mut().map(|w| &mut *w.0),
             }
@@ -199,8 +197,6 @@ fn do_generate_contacts(
                 collider2,
                 shape1: &triangle1,
                 shape2: collider2.shape(),
-                position1: collider1.position(),
-                position2: collider2.position(),
                 manifold,
                 workspace: workspace2.as_mut().map(|w| &mut *w.0),
             }

--- a/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
+++ b/src/geometry/contact_generator/trimesh_shape_contact_generator.rs
@@ -177,6 +177,8 @@ fn do_generate_contacts(
             .dispatch_primitives(ShapeType::Triangle, shape_type2);
 
         let mut ctxt2 = if ctxt_pair_pair.collider1 != manifold.pair.collider1 {
+            manifold.position1 = *collider2.position();
+            manifold.position2 = *collider1.position();
             PrimitiveContactGenerationContext {
                 prediction_distance: ctxt.prediction_distance,
                 collider1: collider2,
@@ -189,6 +191,8 @@ fn do_generate_contacts(
                 workspace: workspace2.as_mut().map(|w| &mut *w.0),
             }
         } else {
+            manifold.position1 = *collider1.position();
+            manifold.position2 = *collider2.position();
             PrimitiveContactGenerationContext {
                 prediction_distance: ctxt.prediction_distance,
                 collider1,


### PR DESCRIPTION
Currently, contact manifold contains two fields `delta1` and `delta2` which are the colliders' positions relative to their rigid-body. This piece of data already exist on colliders and is mostly constant. But we have them duplicated into the `ContactManifold` structure for performance reasons (to avoid lookups of collider data inside of the constraints solver).

This PR replaced these fields by `position1` and `position2` which are the colliders' world-space positions at the time the contacts were detected. That way, these field will also be useful for the end-user that would like to know the world-space location of contacts points and normals at the time of the contact. Without these the user could not retrieve these world-space data because the position of the colliders after the execution of the timestep would have already changed.