### PR TITLE
Extract Physics into module, make new public

### DIFF
--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -23,7 +23,7 @@ extern crate log;
 
 pub use crate::engine::GraphicsManager;
 pub use crate::plugin::TestbedPlugin;
-pub use crate::testbed::{PhysicsState, Testbed};
+pub use crate::testbed::Testbed;
 
 #[cfg(all(feature = "dim2", feature = "other-backends"))]
 mod box2d_backend;
@@ -31,6 +31,7 @@ mod engine;
 #[cfg(feature = "other-backends")]
 mod nphysics_backend;
 pub mod objects;
+mod physics;
 #[cfg(all(feature = "dim3", feature = "other-backends"))]
 mod physx_backend;
 mod plugin;

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -1,12 +1,8 @@
 use crossbeam::channel::Receiver;
+use rapier::dynamics::{IntegrationParameters, JointSet, RigidBodySet};
+use rapier::geometry::{BroadPhase, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent};
 use rapier::math::Vector;
 use rapier::pipeline::{PhysicsPipeline, QueryPipeline};
-use rapier::dynamics::{
-    IntegrationParameters, JointSet,RigidBodySet,
-};
-use rapier::geometry::{
-    BroadPhase, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent,
-};
 
 pub struct PhysicsSnapshot {
     timestep_id: usize,

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -1,0 +1,112 @@
+use crossbeam::channel::Receiver;
+use rapier::math::Vector;
+use rapier::pipeline::{PhysicsPipeline, QueryPipeline};
+use rapier::dynamics::{
+    IntegrationParameters, JointSet,RigidBodySet,
+};
+use rapier::geometry::{
+    BroadPhase, ColliderSet, ContactEvent, NarrowPhase, ProximityEvent,
+};
+
+pub struct PhysicsSnapshot {
+    timestep_id: usize,
+    broad_phase: Vec<u8>,
+    narrow_phase: Vec<u8>,
+    bodies: Vec<u8>,
+    colliders: Vec<u8>,
+    joints: Vec<u8>,
+}
+
+impl PhysicsSnapshot {
+    pub fn new(
+        timestep_id: usize,
+        broad_phase: &BroadPhase,
+        narrow_phase: &NarrowPhase,
+        bodies: &RigidBodySet,
+        colliders: &ColliderSet,
+        joints: &JointSet,
+    ) -> bincode::Result<Self> {
+        Ok(Self {
+            timestep_id,
+            broad_phase: bincode::serialize(broad_phase)?,
+            narrow_phase: bincode::serialize(narrow_phase)?,
+            bodies: bincode::serialize(bodies)?,
+            colliders: bincode::serialize(colliders)?,
+            joints: bincode::serialize(joints)?,
+        })
+    }
+
+    pub fn restore(
+        &self,
+    ) -> bincode::Result<(
+        usize,
+        BroadPhase,
+        NarrowPhase,
+        RigidBodySet,
+        ColliderSet,
+        JointSet,
+    )> {
+        Ok((
+            self.timestep_id,
+            bincode::deserialize(&self.broad_phase)?,
+            bincode::deserialize(&self.narrow_phase)?,
+            bincode::deserialize(&self.bodies)?,
+            bincode::deserialize(&self.colliders)?,
+            bincode::deserialize(&self.joints)?,
+        ))
+    }
+
+    pub fn print_snapshot_len(&self) {
+        let total = self.broad_phase.len()
+            + self.narrow_phase.len()
+            + self.bodies.len()
+            + self.colliders.len()
+            + self.joints.len();
+        println!("Snapshot length: {}B", total);
+        println!("|_ broad_phase: {}B", self.broad_phase.len());
+        println!("|_ narrow_phase: {}B", self.narrow_phase.len());
+        println!("|_ bodies: {}B", self.bodies.len());
+        println!("|_ colliders: {}B", self.colliders.len());
+        println!("|_ joints: {}B", self.joints.len());
+    }
+}
+
+pub struct PhysicsState {
+    pub broad_phase: BroadPhase,
+    pub narrow_phase: NarrowPhase,
+    pub bodies: RigidBodySet,
+    pub colliders: ColliderSet,
+    pub joints: JointSet,
+    pub pipeline: PhysicsPipeline,
+    pub query_pipeline: QueryPipeline,
+    pub integration_parameters: IntegrationParameters,
+    pub gravity: Vector<f32>,
+}
+
+impl PhysicsState {
+    pub fn new() -> Self {
+        Self {
+            broad_phase: BroadPhase::new(),
+            narrow_phase: NarrowPhase::new(),
+            bodies: RigidBodySet::new(),
+            colliders: ColliderSet::new(),
+            joints: JointSet::new(),
+            pipeline: PhysicsPipeline::new(),
+            query_pipeline: QueryPipeline::new(),
+            integration_parameters: IntegrationParameters::default(),
+            gravity: Vector::y() * -9.81,
+        }
+    }
+}
+
+pub struct PhysicsEvents {
+    pub contact_events: Receiver<ContactEvent>,
+    pub proximity_events: Receiver<ProximityEvent>,
+}
+
+impl PhysicsEvents {
+    pub fn poll_all(&self) {
+        while let Ok(_) = self.contact_events.try_recv() {}
+        while let Ok(_) = self.proximity_events.try_recv() {}
+    }
+}

--- a/src_testbed/plugin.rs
+++ b/src_testbed/plugin.rs
@@ -1,4 +1,4 @@
-use crate::testbed::PhysicsState;
+use crate::physics::PhysicsState;
 use kiss3d::window::Window;
 use na::Point3;
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -186,7 +186,7 @@ pub struct PhysicsState {
 }
 
 impl PhysicsState {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             broad_phase: BroadPhase::new(),
             narrow_phase: NarrowPhase::new(),

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -21,9 +21,7 @@ use na::{self, Point2, Point3, Vector3};
 use rapier::dynamics::{
     ActivationStatus, IntegrationParameters, JointSet, RigidBodyHandle, RigidBodySet,
 };
-use rapier::geometry::{
-    BroadPhase, ColliderHandle, ColliderSet, NarrowPhase,
-};
+use rapier::geometry::{BroadPhase, ColliderHandle, ColliderSet, NarrowPhase};
 #[cfg(feature = "dim3")]
 use rapier::geometry::{InteractionGroups, Ray};
 use rapier::math::Vector;


### PR DESCRIPTION
Mainly adds public constructors to PhysicsState & PhysicsSnapshot.

Also moves PhysicsState & PhysicsSnapshot  & PhysicsEvents to their own module.

I mainly need this for the run harness work (only the public new's). If you'd prefer to keep it within testbed, I can change this back.