### PR TITLE
CI: use trigger the bench message workfrow on a pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/rapier-ci-bench.yml
+++ b/.github/workflows/rapier-ci-bench.yml
@@ -3,7 +3,7 @@ name: Rapier CI bench
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
   workflow_dispatch:
 


### PR DESCRIPTION
Currently, the `send-bench-message` CI workflow will always fail on pull-requests originating from forks. This is caused by the fact that forks PRs don't have access to secrets. In this PR, we switch to `pull_request_target` as it should give (safely) access to secrets: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

I will make another PR after this one to check that this change actually works.