### PR TITLE
Split bouncy and resting contacts

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -125,12 +125,27 @@ impl RigidBody {
         self.active_set_timestamp = 0;
     }
 
-    pub(crate) fn integrate_accelerations(&mut self, dt: f32, gravity: Vector<f32>) {
-        if self.mass_properties.inv_mass != 0.0 {
-            self.linvel += (gravity + self.linacc) * dt;
-            self.angvel += self.angacc * dt;
+    // pub(crate) fn integrate_accelerations(&mut self, dt: f32, gravity: Vector<f32>) {
+    //     if self.mass_properties.inv_mass != 0.0 {
+    //         self.linvel += (gravity + self.linacc) * dt;
+    //         self.angvel += self.angacc * dt;
 
-            // Reset the accelerations.
+    //         // Reset the accelerations.
+    //         self.linacc = na::zero();
+    //         self.angacc = na::zero();
+    //     }
+    // }
+
+    pub(crate) fn add_gravity(&mut self, gravity: Vector<f32>) {
+        if self.mass_properties.inv_mass != 0.0 {
+            self.linacc += gravity;
+        }
+    }
+
+    pub(crate) fn integrate_accelerations(&mut self, dt: f32) {
+        if self.mass_properties.inv_mass != 0.0 {
+            self.linvel += self.linacc * dt;
+            self.angvel += self.angacc * dt;
             self.linacc = na::zero();
             self.angacc = na::zero();
         }

--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -165,10 +165,28 @@ impl BallVelocityGroundConstraint {
             )
         };
 
+        let (anchor_world1, anchor_world2) = if flipped {
+            (
+                rb1.position * cparams.local_anchor2,
+                rb2.position * cparams.local_anchor1,
+            )
+        } else {
+            (
+                rb1.position * cparams.local_anchor1,
+                rb2.position * cparams.local_anchor2,
+            )
+        };
+
+        eprintln!("anchor_world1: {:?}", anchor_world1);
+        eprintln!("anchor_world2: {:?}", anchor_world2);
+
         let im2 = rb2.mass_properties.inv_mass;
         let vel1 = rb1.linvel + rb1.angvel.gcross(anchor1);
         let vel2 = rb2.linvel + rb2.angvel.gcross(anchor2);
         let rhs = vel2 - vel1;
+
+        // rhs *= 0.05;
+        rhs += 0.2 * params.inv_dt() * (anchor_world2 - anchor_world1);
 
         let cmat2 = anchor2.gcross_matrix();
         let gcross2 = rb2.world_inv_inertia_sqrt.transform_lin_vector(anchor2);

--- a/src/dynamics/solver/parallel_island_solver.rs
+++ b/src/dynamics/solver/parallel_island_solver.rs
@@ -183,6 +183,28 @@ impl ParallelIslandSolver {
         self.positions
             .resize(bodies.active_island(island_id).len(), Isometry::identity());
 
+        {
+            // Initialize `mj_lambdas` (per-body velocity deltas) with external forces (gravity etc):
+
+            let island_range = bodies.active_island_range(island_id);
+            let active_bodies = &bodies.active_dynamic_set[island_range];
+            let bodies = &mut bodies.bodies;
+
+            let thread = &self.thread;
+
+            concurrent_loop! {
+                let batch_size = thread.batch_size;
+                for handle in active_bodies[thread.body_integration_index, thread.num_integrated_bodies] {
+                    let rb = &mut bodies[*handle];
+                    let dvel = &mut mj_lambdas[rb.active_set_offset];
+                    dvel.linear += rb.linacc * params.dt;
+                    dvel.angular += rb.angacc * params.dt;
+                    rb.linacc = na::zero();
+                    rb.angacc = na::zero();
+                }
+            }
+        }
+
         for _ in 0..num_task_per_island {
             // We use AtomicPtr because it is Send+Sync while *mut is not.
             // See https://internals.rust-lang.org/t/shouldnt-pointers-be-send-sync-or/8818

--- a/src/dynamics/solver/position_constraint.rs
+++ b/src/dynamics/solver/position_constraint.rs
@@ -88,6 +88,10 @@ impl PositionConstraint {
         out_constraints: &mut Vec<AnyPositionConstraint>,
         push: bool,
     ) {
+        if manifold.is_bouncing() {
+            return; // let the bounce take care of it
+        }
+
         let rb1 = &bodies[manifold.body_pair.body1];
         let rb2 = &bodies[manifold.body_pair.body2];
         let shift1 = manifold.local_n1 * -manifold.kinematics.radius1;

--- a/src/dynamics/solver/position_ground_constraint.rs
+++ b/src/dynamics/solver/position_ground_constraint.rs
@@ -28,6 +28,10 @@ impl PositionGroundConstraint {
         out_constraints: &mut Vec<AnyPositionConstraint>,
         push: bool,
     ) {
+        if manifold.is_bouncing() {
+            return; // let the bounce take care of the overlap
+        }
+
         let mut rb1 = &bodies[manifold.body_pair.body1];
         let mut rb2 = &bodies[manifold.body_pair.body2];
         let flip = !rb2.is_dynamic();

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -384,6 +384,7 @@ impl VelocityConstraint {
 
     pub fn writeback_impulses(&self, manifolds_all: &mut [&mut ContactManifold]) {
         let manifold = &mut manifolds_all[self.manifold_id];
+        manifold.old = true;
         let k_base = self.manifold_contact_id;
 
         for k in 0..self.num_contacts as usize {

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -216,8 +216,7 @@ impl VelocityConstraint {
                 constraint.num_contacts = manifold_points.len() as u8;
             }
 
-            for k in 0..manifold_points.len() {
-                let manifold_point = &manifold_points[k];
+            for (k, manifold_point) in manifold_points.iter().enumerate() {
                 let dp1 = (pos_coll1 * manifold_point.local_p1) - rb1.world_com;
                 let dp2 = (pos_coll2 * manifold_point.local_p2) - rb2.world_com;
 
@@ -247,7 +246,7 @@ impl VelocityConstraint {
 
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
 
-                    let impulse = manifold_points[k].impulse * warmstart_coeff;
+                    let impulse = manifold_point.impulse * warmstart_coeff;
 
                     constraint.elements[k].normal_part = VelocityConstraintElementPart {
                         gcross1,
@@ -276,9 +275,9 @@ impl VelocityConstraint {
                                 + gcross2.gdot(gcross2));
                         let rhs = (vel1 - vel2).dot(&tangents1[j]);
                         #[cfg(feature = "dim2")]
-                        let impulse = manifold_points[k].tangent_impulse * warmstart_coeff;
+                        let impulse = manifold_point.tangent_impulse * warmstart_coeff;
                         #[cfg(feature = "dim3")]
-                        let impulse = manifold_points[k].tangent_impulse[j] * warmstart_coeff;
+                        let impulse = manifold_point.tangent_impulse[j] * warmstart_coeff;
 
                         constraint.elements[k].tangent_part[j] = VelocityConstraintElementPart {
                             gcross1,

--- a/src/dynamics/solver/velocity_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_constraint_wide.rs
@@ -340,6 +340,7 @@ impl WVelocityConstraint {
 
             for ii in 0..SIMD_WIDTH {
                 let manifold = &mut manifolds_all[self.manifold_id[ii]];
+                manifold.old = true;
                 let k_base = self.manifold_contact_id;
                 let active_contacts = manifold.active_contacts_mut();
                 active_contacts[k_base + k].impulse = impulses[ii];

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -286,6 +286,7 @@ impl VelocityGroundConstraint {
     // FIXME: duplicated code. This is exactly the same as in the non-ground velocity constraint.
     pub fn writeback_impulses(&self, manifolds_all: &mut [&mut ContactManifold]) {
         let manifold = &mut manifolds_all[self.manifold_id];
+        manifold.old = true;
         let k_base = self.manifold_contact_id;
 
         for k in 0..self.num_contacts as usize {

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -143,8 +143,7 @@ impl VelocityGroundConstraint {
                 constraint.num_contacts = manifold_points.len() as u8;
             }
 
-            for k in 0..manifold_points.len() {
-                let manifold_point = &manifold_points[k];
+            for (k, manifold_point) in manifold_points.iter().enumerate() {
                 let (p1, p2) = if flipped {
                     // NOTE: we already swapped rb1 and rb2
                     // so we multiply by coll_pos1/coll_pos2.
@@ -179,7 +178,7 @@ impl VelocityGroundConstraint {
 
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
 
-                    let impulse = manifold_points[k].impulse * warmstart_coeff;
+                    let impulse = manifold_point.impulse * warmstart_coeff;
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintElementPart {
                         gcross2,
@@ -200,9 +199,9 @@ impl VelocityGroundConstraint {
                         let r = 1.0 / (rb2.mass_properties.inv_mass + gcross2.gdot(gcross2));
                         let rhs = -vel2.dot(&tangents1[j]) + vel1.dot(&tangents1[j]);
                         #[cfg(feature = "dim2")]
-                        let impulse = manifold_points[k].tangent_impulse * warmstart_coeff;
+                        let impulse = manifold_point.tangent_impulse * warmstart_coeff;
                         #[cfg(feature = "dim3")]
-                        let impulse = manifold_points[k].tangent_impulse[j] * warmstart_coeff;
+                        let impulse = manifold_point.tangent_impulse[j] * warmstart_coeff;
 
                         constraint.elements[k].tangent_part[j] =
                             VelocityGroundConstraintElementPart {

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -300,6 +300,7 @@ impl WVelocityGroundConstraint {
 
             for ii in 0..SIMD_WIDTH {
                 let manifold = &mut manifolds_all[self.manifold_id[ii]];
+                manifold.old = true;
                 let k_base = self.manifold_contact_id;
                 let active_contacts = manifold.active_contacts_mut();
                 active_contacts[k_base + k].impulse = impulses[ii];

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -110,9 +110,9 @@ impl WVelocityGroundConstraint {
         let mj_lambda2 = array![|ii| rbs2[ii].active_set_offset; SIMD_WIDTH];
 
         let friction = SimdFloat::from(array![|ii| manifolds[ii].friction; SIMD_WIDTH]);
-        let restitution = SimdFloat::from(array![|ii| manifolds[ii].restitution; SIMD_WIDTH]);
-        let restitution_velocity_threshold =
-            SimdFloat::splat(params.restitution_velocity_threshold);
+        let restitution_plus_1 =
+            SimdFloat::from(array![|ii| manifolds[ii].restitution + 1.0; SIMD_WIDTH]);
+        let is_bouncing = SimdBool::from(array![|ii| manifolds[ii].is_bouncing(); SIMD_WIDTH]);
 
         let warmstart_multiplier =
             SimdFloat::from(array![|ii| manifolds[ii].warmstart_multiplier; SIMD_WIDTH]);
@@ -158,11 +158,11 @@ impl WVelocityGroundConstraint {
                     let gcross2 = ii2.transform_vector(dp2.gcross(-force_dir1));
 
                     let r = SimdFloat::splat(1.0) / (im2 + gcross2.gdot(gcross2));
-                    let mut rhs = (vel1 - vel2).dot(&force_dir1);
-                    let use_restitution = rhs.simd_le(-restitution_velocity_threshold);
-                    let rhs_with_restitution = rhs + rhs * restitution;
-                    rhs = rhs_with_restitution.select(use_restitution, rhs);
-                    rhs += dist.simd_max(SimdFloat::zero()) * inv_dt;
+                    let projected_velocity = (vel1 - vel2).dot(&force_dir1);
+                    let rhs_resting =
+                        projected_velocity + dist.simd_max(SimdFloat::zero()) * inv_dt;
+                    let rhs_bouncing = projected_velocity * restitution_plus_1;
+                    let rhs = rhs_bouncing.select(is_bouncing, rhs_resting);
 
                     constraint.elements[k].normal_part = WVelocityGroundConstraintElementPart {
                         gcross2,

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -61,6 +61,17 @@ impl VelocitySolver {
         self.mj_lambdas
             .resize(bodies.active_island(island_id).len(), DeltaVel::zero());
 
+        // Initialize delta-velocities (`mj_lambdas`) with external forces (gravity etc):
+        bodies.foreach_active_island_body_mut_internal(island_id, |_, rb| {
+            // eprintln!("initial rb.linvel: {}", rb.linvel);
+            let dvel = &mut self.mj_lambdas[rb.active_set_offset];
+            dvel.linear += rb.linacc * params.dt;
+            dvel.angular += rb.angacc * params.dt;
+            // eprintln!("initial dvel.linear: {}", dvel.linear);
+            rb.linacc = na::zero();
+            rb.angacc = na::zero();
+        });
+
         /*
          * Warmstart constraints.
          */

--- a/src/geometry/contact.rs
+++ b/src/geometry/contact.rs
@@ -532,4 +532,24 @@ impl ContactManifold {
             }
         }
     }
+
+    /// Should this be treated as a bouncing contact, i.e. applying restitution?
+    #[inline]
+    pub(crate) fn is_bouncing(&self) -> bool {
+        if self.is_new() {
+            // Treat new collisions as bouncing at first, unless we have zero restitution.
+            self.restitution > 0.0
+        } else {
+            // If the manifold is still here one step later, it is now a resting contact.
+            // The exception is very high restitutions, which can never rest
+            self.restitution >= 1.0
+        }
+    }
+
+    /// Is this a new contact manifold?
+    /// Returns `false` iff this contact manifold was present the previous time step.
+    #[inline]
+    pub(crate) fn is_new(&self) -> bool {
+        !self.old
+    }
 }

--- a/src/geometry/contact.rs
+++ b/src/geometry/contact.rs
@@ -301,6 +301,8 @@ pub struct ContactManifold {
     pub delta2: Isometry<f32>,
     /// Flags used to control some aspects of the constraints solver for this contact manifold.
     pub solver_flags: SolverFlags,
+    /// Set to `true` after a contact has been through one velocity solve.
+    pub old: bool,
 }
 
 impl ContactManifold {
@@ -334,6 +336,7 @@ impl ContactManifold {
             constraint_index: 0,
             position_constraint_index: 0,
             solver_flags,
+            old: false,
         }
     }
 
@@ -358,6 +361,7 @@ impl ContactManifold {
             constraint_index: self.constraint_index,
             position_constraint_index: self.position_constraint_index,
             solver_flags: self.solver_flags,
+            old: self.old,
         }
     }
 

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -160,7 +160,7 @@ impl PhysicsPipeline {
         self.counters.stages.update_time.start();
         bodies.foreach_active_dynamic_body_mut_internal(|_, b| {
             b.update_world_mass_properties();
-            b.integrate_accelerations(integration_parameters.dt, *gravity)
+            b.add_gravity(*gravity);
         });
         self.counters.stages.update_time.pause();
 


### PR DESCRIPTION
Various experiments. Needs rebasing on `master` now that rapier 0.5 has been released. Or more likely I'll reimplement the ideas in a more clean manner.

The goal of this work was to get energy conservation for bouncing spheres when restitution=1, not because that is something important in itself, but because failing to conserve energy is symptomatic of larger problems.

The longer goal is that by splitting resting and bouncing contacts we can start applying corrective impulses in the velocity solver, which will mean we won't need the positional/projection solver. Position iterations is always a bad idea, so getting rapier to a point where it is optional would be very good.