### PR TITLE
Switch from Explicit Euler integration to Symplectic Euler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Switch from explicit euler integration to symplectic euler to get better energy conservation.
+
 ## v0.5.0
 In this release we are dropping `ncollide` and use our new crate [`parry`](https://parry.rs)
 instead! This comes with a lot of new features, as well as two new crates: `rapier2d-f64` and
@@ -39,7 +42,7 @@ Various RigidBody-related getter and setters have been added:
   the rigid-body.
 - `RigidBodyBuilder::restrict_rotations` to prevent rotations along specific coordinate axes. This replaces the three
   boolean arguments previously passed to `.set_principal_angular_inertia`.
-  
+
 ### Breaking changes
 Breaking changes related to contacts:
 - The way contacts are represented changed. Refer to the documentation of `parry::query::ContactManifold`, `parry::query::TrackedContact`


### PR DESCRIPTION
Explicit Euler tends to add energy to the system,
which in the worst case can lead to divergence and explosion.

Symplectic Euler is energy conserving.

A simple test is ball bouncing on a fixed plane, both with restitution=1 (https://github.com/dimforge/rapier/issues/97).
With the old euler integration, the ball would quickly bounce higher and higher.
With the new symplectic euler, the ball slowly loses energy instead, which is much better.

(This energy loss is because gravity is applied before the velocity iterations.
In a later PR I will instead make accelerations from gravity and other external forces
be part of the velocity solver. This should eliminate this energy leakage.)