### PR TITLE
Don't serialize solver contacts + remove erased-serde dependency.

### DIFF
--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -26,7 +26,7 @@ simd-nightly = [ "simba/packed_simd", "simd-is-enabled" ]
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
-serde-serialize = [ "erased-serde", "nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde", "arrayvec/serde" ]
+serde-serialize = [ "nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d-f64/enhanced-determinism", "indexmap" ]
 
 [lib]
@@ -50,7 +50,6 @@ arrayvec = "0.5"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }
-erased-serde = { version = "0.3", optional = true }
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -26,7 +26,7 @@ simd-nightly = [ "simba/packed_simd", "simd-is-enabled" ]
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
-serde-serialize = [ "erased-serde", "nalgebra/serde-serialize", "parry2d/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde", "arrayvec/serde" ]
+serde-serialize = [ "nalgebra/serde-serialize", "parry2d/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d/enhanced-determinism", "indexmap" ]
 
 [lib]
@@ -50,7 +50,6 @@ arrayvec = "0.5"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }
-erased-serde = { version = "0.3", optional = true }
 indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -26,7 +26,7 @@ simd-nightly = [ "parry3d-f64/simd-nightly", "simba/packed_simd", "simd-is-enabl
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
-serde-serialize = [ "erased-serde", "nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde" ]
+serde-serialize = [ "nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d-f64/enhanced-determinism" ]
 
 [lib]
@@ -50,7 +50,6 @@ arrayvec = "0.5"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }
-erased-serde = { version = "0.3", optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -26,7 +26,7 @@ simd-nightly = [ "parry3d/simd-nightly", "simba/packed_simd", "simd-is-enabled" 
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = [ ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
-serde-serialize = [ "erased-serde", "nalgebra/serde-serialize", "parry3d/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde" ]
+serde-serialize = [ "nalgebra/serde-serialize", "parry3d/serde-serialize", "serde", "generational-arena/serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d/enhanced-determinism" ]
 
 [lib]
@@ -50,7 +50,6 @@ arrayvec = "0.5"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }
-erased-serde = { version = "0.3", optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,7 +1,6 @@
 //! Data structures modified with guaranteed deterministic behavior after deserialization.
 
 pub use self::coarena::Coarena;
-pub use parry::utils::MaybeSerializableData;
 
 pub mod arena;
 mod coarena;

--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -90,15 +90,19 @@ pub struct ContactManifoldData {
     pub body_pair: BodyPair,
     pub(crate) warmstart_multiplier: Real,
     // The two following are set by the constraints solver.
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub(crate) constraint_index: usize,
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub(crate) position_constraint_index: usize,
     // We put the following fields here to avoids reading the colliders inside of the
     // contact preparation method.
     /// Flags used to control some aspects of the constraints solver for this contact manifold.
     pub solver_flags: SolverFlags,
     /// The world-space contact normal shared by all the contact in this contact manifold.
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub normal: Vector<Real>,
     /// The contacts that will be seen by the constraints solver for computing forces.
+    #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub solver_contacts: Vec<SolverContact>,
 }
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1401,11 +1401,21 @@ CCD: {:.2}ms
         if self.state.flags.contains(TestbedStateFlags::DEBUG) {
             let t = instant::now();
             let physics = &self.harness.physics;
+            // let t = instant::now();
             let bf = bincode::serialize(&physics.broad_phase).unwrap();
+            // println!("bf: {}", instant::now() - t);
+            // let t = instant::now();
             let nf = bincode::serialize(&physics.narrow_phase).unwrap();
+            // println!("nf: {}", instant::now() - t);
+            // let t = instant::now();
             let bs = bincode::serialize(&physics.bodies).unwrap();
+            // println!("bs: {}", instant::now() - t);
+            // let t = instant::now();
             let cs = bincode::serialize(&physics.colliders).unwrap();
+            // println!("cs: {}", instant::now() - t);
+            // let t = instant::now();
             let js = bincode::serialize(&physics.joints).unwrap();
+            // println!("js: {}", instant::now() - t);
             let serialization_time = instant::now() - t;
             let hash_bf = md5::compute(&bf);
             let hash_nf = md5::compute(&nf);


### PR DESCRIPTION
Solver contacts don't need to be serialized in order to preserve determinism after deserialization, so they are now skipped by serde.