### PR TITLE
Optional violation correction in velocity solver

### DIFF
--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -181,6 +181,12 @@ impl IntegrationParameters {
             self.dt = 1.0 / inv_dt
         }
     }
+
+    /// Convenience: `velocity_based_erp / dt`
+    #[inline]
+    pub(crate) fn velocity_based_erp_inv_dt(&self) -> Real {
+        self.velocity_based_erp * self.inv_dt()
+    }
 }
 
 impl Default for IntegrationParameters {

--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -27,6 +27,19 @@ pub struct IntegrationParameters {
     /// Each cached impulse are multiplied by this coefficient in `[0, 1]`
     /// when they are re-used to initialize the solver (default `1.0`).
     pub warmstart_coeff: Real,
+
+    /// 0-1: how much of the velocity to dampen out in the constraint solver?
+    /// (default `1.0`).
+    pub velocity_solve_fraction: Real,
+
+    /// 0-1: multiplier for how much of the constraint violation (e.g. contact penetration)
+    /// will be compensated for during the velocity solve.
+    /// If zero, you need to enable the positional solver.
+    /// If non-zero, you do not need the positional solver.
+    /// A good non-zero value is around `0.2`.
+    /// (default `0.0`).
+    pub velocity_based_erp: Real,
+
     /// Amount of penetration the engine wont attempt to correct (default: `0.005m`).
     pub allowed_linear_error: Real,
     /// The maximal distance separating two objects that will generate predictive contacts (default: `0.002`).
@@ -121,17 +134,12 @@ impl IntegrationParameters {
             max_stabilization_multiplier,
             max_velocity_iterations,
             max_position_iterations,
-            // FIXME: what is the optimal value for min_island_size?
-            // It should not be too big so that we don't end up with
-            // huge islands that don't fit in cache.
-            // However we don't want it to be too small and end up with
-            // tons of islands, reducing SIMD parallelism opportunities.
-            min_island_size: 128,
             max_ccd_position_iterations,
             max_ccd_substeps,
             return_after_ccd_substep,
             multiple_ccd_substep_sensor_events_enabled,
             ccd_on_penetration_enabled,
+            ..Default::default()
         }
     }
 
@@ -183,6 +191,8 @@ impl Default for IntegrationParameters {
             return_after_ccd_substep: false,
             erp: 0.2,
             joint_erp: 0.2,
+            velocity_solve_fraction: 1.0,
+            velocity_based_erp: 0.0,
             warmstart_coeff: 1.0,
             allowed_linear_error: 0.005,
             prediction_distance: 0.002,

--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -40,17 +40,21 @@ impl BallVelocityConstraint {
         rb2: &RigidBody,
         joint: &BallJoint,
     ) -> Self {
-        let anchor1 = rb1.position * joint.local_anchor1 - rb1.world_com;
-        let anchor2 = rb2.position * joint.local_anchor2 - rb2.world_com;
+        let anchor_world1 = rb1.position * joint.local_anchor1;
+        let anchor_world2 = rb2.position * joint.local_anchor2;
+        let anchor1 = anchor_world1 - rb1.world_com;
+        let anchor2 = anchor_world2 - rb2.world_com;
 
         let vel1 = rb1.linvel + rb1.angvel.gcross(anchor1);
         let vel2 = rb2.linvel + rb2.angvel.gcross(anchor2);
         let im1 = rb1.effective_inv_mass;
         let im2 = rb2.effective_inv_mass;
 
-        let rhs = -(vel1 - vel2);
-        let lhs;
+        let mut rhs = params.velocity_solve_fraction * (vel2 - vel1);
 
+        rhs += params.velocity_based_erp * params.inv_dt() * (anchor_world2 - anchor_world1);
+
+        let lhs;
         let cmat1 = anchor1.gcross_matrix();
         let cmat2 = anchor2.gcross_matrix();
 
@@ -271,22 +275,27 @@ impl BallVelocityGroundConstraint {
         joint: &BallJoint,
         flipped: bool,
     ) -> Self {
-        let (anchor1, anchor2) = if flipped {
+        let (anchor_world1, anchor_world2) = if flipped {
             (
-                rb1.position * joint.local_anchor2 - rb1.world_com,
-                rb2.position * joint.local_anchor1 - rb2.world_com,
+                rb1.position * joint.local_anchor2,
+                rb2.position * joint.local_anchor1,
             )
         } else {
             (
-                rb1.position * joint.local_anchor1 - rb1.world_com,
-                rb2.position * joint.local_anchor2 - rb2.world_com,
+                rb1.position * joint.local_anchor1,
+                rb2.position * joint.local_anchor2,
             )
         };
+
+        let anchor1 = anchor_world1 - rb1.world_com;
+        let anchor2 = anchor_world2 - rb2.world_com;
 
         let im2 = rb2.effective_inv_mass;
         let vel1 = rb1.linvel + rb1.angvel.gcross(anchor1);
         let vel2 = rb2.linvel + rb2.angvel.gcross(anchor2);
-        let rhs = vel2 - vel1;
+        let mut rhs = params.velocity_solve_fraction * (vel2 - vel1);
+
+        rhs += params.velocity_based_erp * params.inv_dt() * (anchor_world2 - anchor_world1);
 
         let cmat2 = anchor2.gcross_matrix();
 

--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -50,9 +50,8 @@ impl BallVelocityConstraint {
         let im1 = rb1.effective_inv_mass;
         let im2 = rb2.effective_inv_mass;
 
-        let mut rhs = params.velocity_solve_fraction * (vel2 - vel1);
-
-        rhs += params.velocity_based_erp * params.inv_dt() * (anchor_world2 - anchor_world1);
+        let rhs = (vel2 - vel1) * params.velocity_solve_fraction
+            + (anchor_world2 - anchor_world1) * params.velocity_based_erp_inv_dt();
 
         let lhs;
         let cmat1 = anchor1.gcross_matrix();
@@ -293,9 +292,9 @@ impl BallVelocityGroundConstraint {
         let im2 = rb2.effective_inv_mass;
         let vel1 = rb1.linvel + rb1.angvel.gcross(anchor1);
         let vel2 = rb2.linvel + rb2.angvel.gcross(anchor2);
-        let mut rhs = params.velocity_solve_fraction * (vel2 - vel1);
 
-        rhs += params.velocity_based_erp * params.inv_dt() * (anchor_world2 - anchor_world1);
+        let rhs = (vel2 - vel1) * params.velocity_solve_fraction
+            + (anchor_world2 - anchor_world1) * params.velocity_based_erp_inv_dt();
 
         let cmat2 = anchor2.gcross_matrix();
 

--- a/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
@@ -113,18 +113,18 @@ impl FixedVelocityConstraint {
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {
-            let error = anchor2 * anchor1.inverse();
-            let lin_err = error.translation.vector;
+            let lin_err = anchor2.translation.vector - anchor1.translation.vector;
+            let ang_err = anchor2.rotation * anchor1.rotation.inverse();
 
             #[cfg(feature = "dim2")]
             {
-                let ang_err = error.rotation.angle();
+                let ang_err = ang_err.angle();
                 rhs += Vector3::new(lin_err.x, lin_err.y, ang_err) * velocity_based_erp_inv_dt;
             }
 
             #[cfg(feature = "dim3")]
             {
-                let ang_err = error.rotation.scaled_axis();
+                let ang_err = ang_err.scaled_axis();
                 rhs += Vector6::new(
                     lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
                 ) * velocity_based_erp_inv_dt;

--- a/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
@@ -323,15 +323,6 @@ impl FixedVelocityGroundConstraint {
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {
-            // let error = anchor2 * anchor1.inverse();
-            // let lin_err = error.translation.vector;
-            // let ang_err = error.rotation;
-
-            // Doesn't quite do what it should
-            // let target_pos = anchor1.lerp_slerp(&anchor2, velocity_based_erp_inv_dt);
-            // let error = target_pos * anchor1.inverse();
-            // let lin_err = error.translation.vector;
-
             let lin_err = anchor2.translation.vector - anchor1.translation.vector;
             let ang_err = anchor2.rotation * anchor1.rotation.inverse();
 

--- a/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
@@ -112,26 +112,23 @@ impl FixedVelocityConstraint {
                 lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
             );
 
-        if params.velocity_based_erp != 0.0 {
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
             let error = anchor2 * anchor1.inverse();
             let lin_err = error.translation.vector;
 
             #[cfg(feature = "dim2")]
             {
                 let ang_err = error.rotation.angle();
-                rhs += params.velocity_based_erp
-                    * params.inv_dt()
-                    * Vector3::new(lin_err.x, lin_err.y, ang_err);
+                rhs += Vector3::new(lin_err.x, lin_err.y, ang_err) * velocity_based_erp_inv_dt;
             }
 
             #[cfg(feature = "dim3")]
             {
                 let ang_err = error.rotation.scaled_axis();
-                rhs += params.velocity_based_erp
-                    * params.inv_dt()
-                    * Vector6::new(
-                        lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
-                    );
+                rhs += Vector6::new(
+                    lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
+                ) * velocity_based_erp_inv_dt;
             }
         }
 
@@ -326,16 +323,14 @@ impl FixedVelocityGroundConstraint {
                 lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
             );
 
-        if params.velocity_based_erp != 0.0 {
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
             // let error = anchor2 * anchor1.inverse();
             // let lin_err = error.translation.vector;
             // let ang_err = error.rotation;
 
             // Doesn't quite do what it should
-            // let target_pos = anchor1.lerp_slerp(
-            //     &anchor2,
-            //     params.velocity_based_erp * params.inv_dt(),
-            // );
+            // let target_pos = anchor1.lerp_slerp(&anchor2, velocity_based_erp_inv_dt);
             // let error = target_pos * anchor1.inverse();
             // let lin_err = error.translation.vector;
 
@@ -345,19 +340,15 @@ impl FixedVelocityGroundConstraint {
             #[cfg(feature = "dim2")]
             {
                 let ang_err = ang_err.angle();
-                rhs += params.velocity_based_erp
-                    * params.inv_dt()
-                    * Vector3::new(lin_err.x, lin_err.y, ang_err);
+                rhs += Vector3::new(lin_err.x, lin_err.y, ang_err) * velocity_based_erp_inv_dt;
             }
 
             #[cfg(feature = "dim3")]
             {
                 let ang_err = ang_err.scaled_axis();
-                rhs += params.velocity_based_erp
-                    * params.inv_dt()
-                    * Vector6::new(
-                        lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
-                    );
+                rhs += Vector6::new(
+                    lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
+                ) * velocity_based_erp_inv_dt;
             }
         }
 

--- a/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/fixed_velocity_constraint.rs
@@ -104,13 +104,12 @@ impl FixedVelocityConstraint {
 
         #[cfg(feature = "dim2")]
         let mut rhs =
-            params.velocity_solve_fraction * Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+            Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel) * params.velocity_solve_fraction;
 
         #[cfg(feature = "dim3")]
-        let mut rhs = params.velocity_solve_fraction
-            * Vector6::new(
-                lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
-            );
+        let mut rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        ) * params.velocity_solve_fraction;
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {
@@ -316,12 +315,11 @@ impl FixedVelocityGroundConstraint {
 
         #[cfg(feature = "dim2")]
         let mut rhs =
-            params.velocity_solve_fraction * Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+            Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel) * params.velocity_solve_fraction;
         #[cfg(feature = "dim3")]
-        let mut rhs = params.velocity_solve_fraction
-            * Vector6::new(
-                lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
-            );
+        let mut rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        ) * params.velocity_solve_fraction;
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
@@ -159,11 +159,9 @@ impl PrismaticVelocityConstraint {
             let frame2 = rb2.position * joint.local_frame2();
             let ang_err = frame2.rotation * frame1.rotation.inverse();
 
-            if limit_err < joint.limits[0] {
-                linear_err += *axis1 * (limit_err - joint.limits[0]);
-            } else if limit_err > joint.limits[1] {
-                linear_err += *axis1 * (limit_err - joint.limits[1]);
-            }
+            let (min_limit, max_limit) = (joint.limits[0], joint.limits[1]);
+            linear_err +=
+                *axis1 * ((limit_err - max_limit).max(0.0) - (min_limit - limit_err).max(0.0));
 
             #[cfg(feature = "dim2")]
             {
@@ -585,11 +583,9 @@ impl PrismaticVelocityGroundConstraint {
 
             let ang_err = frame2.rotation * frame1.rotation.inverse();
 
-            if limit_err < joint.limits[0] {
-                linear_err += *axis1 * (limit_err - joint.limits[0]);
-            } else if limit_err > joint.limits[1] {
-                linear_err += *axis1 * (limit_err - joint.limits[1]);
-            }
+            let (min_limit, max_limit) = (joint.limits[0], joint.limits[1]);
+            linear_err +=
+                *axis1 * ((limit_err - max_limit).max(0.0) - (min_limit - limit_err).max(0.0));
 
             #[cfg(feature = "dim2")]
             {

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
@@ -156,8 +156,7 @@ impl PrismaticVelocityConstraint {
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {
-            let dpos = anchor2 - anchor1;
-            let linear_err = basis1.tr_mul(&dpos);
+            let linear_err = basis1.tr_mul(&(anchor2 - anchor1));
 
             let frame1 = rb1.position * joint.local_frame1();
             let frame2 = rb2.position * joint.local_frame2();
@@ -226,12 +225,8 @@ impl PrismaticVelocityConstraint {
             let min_enabled = dist < min_limit;
             let max_enabled = max_limit < dist;
 
-            if min_enabled {
-                limits_impulse_limits.1 = Real::INFINITY;
-            }
-            if max_enabled {
-                limits_impulse_limits.0 = -Real::INFINITY;
-            }
+            limits_impulse_limits.0 = if max_enabled { -Real::INFINITY } else { 0.0 };
+            limits_impulse_limits.1 = if min_enabled { Real::INFINITY } else { 0.0 };
 
             limits_active = min_enabled || max_enabled;
             if limits_active {
@@ -311,10 +306,8 @@ impl PrismaticVelocityConstraint {
 
         // Warmstart limits.
         if self.limits_active {
-            let limits_forcedir1 = -self.limits_forcedir2;
-            let limits_forcedir2 = self.limits_forcedir2;
-            let limit_impulse1 = limits_forcedir1 * self.limits_impulse;
-            let limit_impulse2 = limits_forcedir2 * self.limits_impulse;
+            let limit_impulse1 = -self.limits_forcedir2 * self.limits_impulse;
+            let limit_impulse2 = self.limits_forcedir2 * self.limits_impulse;
             mj_lambda1.linear += self.im1 * limit_impulse1;
             mj_lambda1.angular += self
                 .ii1_sqrt
@@ -592,8 +585,7 @@ impl PrismaticVelocityGroundConstraint {
 
         let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
         if velocity_based_erp_inv_dt != 0.0 {
-            let dpos = anchor2 - anchor1;
-            let linear_err = basis1.tr_mul(&dpos);
+            let linear_err = basis1.tr_mul(&(anchor2 - anchor1));
 
             let (frame1, frame2);
             if flipped {
@@ -669,12 +661,8 @@ impl PrismaticVelocityGroundConstraint {
             let min_enabled = dist < min_limit;
             let max_enabled = max_limit < dist;
 
-            if min_enabled {
-                limits_impulse_limits.1 = Real::INFINITY;
-            }
-            if max_enabled {
-                limits_impulse_limits.0 = -Real::INFINITY;
-            }
+            limits_impulse_limits.0 = if max_enabled { -Real::INFINITY } else { 0.0 };
+            limits_impulse_limits.1 = if min_enabled { Real::INFINITY } else { 0.0 };
 
             limits_active = min_enabled || max_enabled;
             if limits_active {

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
@@ -155,14 +155,14 @@ impl PrismaticVelocityConstraint {
             let limit_err = dpos.dot(&axis1);
             let mut linear_err = dpos - *axis1 * limit_err;
 
-            let frame1 = rb1.position * cparams.local_frame1();
-            let frame2 = rb2.position * cparams.local_frame2();
+            let frame1 = rb1.position * joint.local_frame1();
+            let frame2 = rb2.position * joint.local_frame2();
             let ang_err = frame2.rotation * frame1.rotation.inverse();
 
-            if limit_err < cparams.limits[0] {
-                linear_err += *axis1 * (limit_err - cparams.limits[0]);
-            } else if limit_err > cparams.limits[1] {
-                linear_err += *axis1 * (limit_err - cparams.limits[1]);
+            if limit_err < joint.limits[0] {
+                linear_err += *axis1 * (limit_err - joint.limits[0]);
+            } else if limit_err > joint.limits[1] {
+                linear_err += *axis1 * (limit_err - joint.limits[1]);
             }
 
             #[cfg(feature = "dim2")]
@@ -572,11 +572,11 @@ impl PrismaticVelocityGroundConstraint {
         if velocity_based_erp_inv_dt != 0.0 {
             let (frame1, frame2);
             if flipped {
-                frame1 = rb1.position * cparams.local_frame2();
-                frame2 = rb2.position * cparams.local_frame1();
+                frame1 = rb1.position * joint.local_frame2();
+                frame2 = rb2.position * joint.local_frame1();
             } else {
-                frame1 = rb1.position * cparams.local_frame1();
-                frame2 = rb2.position * cparams.local_frame2();
+                frame1 = rb1.position * joint.local_frame1();
+                frame2 = rb2.position * joint.local_frame2();
             }
 
             let dpos = anchor2 - anchor1;
@@ -585,10 +585,10 @@ impl PrismaticVelocityGroundConstraint {
 
             let ang_err = frame2.rotation * frame1.rotation.inverse();
 
-            if limit_err < cparams.limits[0] {
-                linear_err += *axis1 * (limit_err - cparams.limits[0]);
-            } else if limit_err > cparams.limits[1] {
-                linear_err += *axis1 * (limit_err - cparams.limits[1]);
+            if limit_err < joint.limits[0] {
+                linear_err += *axis1 * (limit_err - joint.limits[0]);
+            } else if limit_err > joint.limits[1] {
+                linear_err += *axis1 * (limit_err - joint.limits[1]);
             }
 
             #[cfg(feature = "dim2")]

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
@@ -205,8 +205,7 @@ impl WPrismaticVelocityConstraint {
         if velocity_based_erp_inv_dt != 0.0 {
             let velocity_based_erp_inv_dt = SimdReal::splat(velocity_based_erp_inv_dt);
 
-            let dpos = anchor2 - anchor1;
-            let linear_err = basis1.tr_mul(&dpos);
+            let linear_err = basis1.tr_mul(&(anchor2 - anchor1));
 
             let local_frame1 = Isometry::from(array![|ii| cparams[ii].local_frame1(); SIMD_WIDTH]);
             let local_frame2 = Isometry::from(array![|ii| cparams[ii].local_frame2(); SIMD_WIDTH]);
@@ -251,8 +250,8 @@ impl WPrismaticVelocityConstraint {
             let min_enabled = dist.simd_lt(min_limit);
             let max_enabled = dist.simd_gt(max_limit);
 
-            limits_impulse_limits.1 = SimdReal::splat(Real::INFINITY).select(min_enabled, zero);
             limits_impulse_limits.0 = SimdReal::splat(-Real::INFINITY).select(max_enabled, zero);
+            limits_impulse_limits.1 = SimdReal::splat(Real::INFINITY).select(min_enabled, zero);
 
             limits_active = (min_enabled | max_enabled).any();
             if limits_active {
@@ -632,8 +631,7 @@ impl WPrismaticVelocityGroundConstraint {
         if velocity_based_erp_inv_dt != 0.0 {
             let velocity_based_erp_inv_dt = SimdReal::splat(velocity_based_erp_inv_dt);
 
-            let dpos = anchor2 - anchor1;
-            let linear_err = basis1.tr_mul(&dpos);
+            let linear_err = basis1.tr_mul(&(anchor2 - anchor1));
 
             let frame1 = position1
                 * Isometry::from(
@@ -680,8 +678,8 @@ impl WPrismaticVelocityGroundConstraint {
             let min_enabled = dist.simd_lt(min_limit);
             let max_enabled = dist.simd_gt(max_limit);
 
-            limits_impulse_limits.1 = SimdReal::splat(Real::INFINITY).select(min_enabled, zero);
             limits_impulse_limits.0 = SimdReal::splat(-Real::INFINITY).select(max_enabled, zero);
+            limits_impulse_limits.1 = SimdReal::splat(Real::INFINITY).select(min_enabled, zero);
 
             limits_active = (min_enabled | max_enabled).any();
             if limits_active {

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
@@ -248,7 +248,6 @@ impl WPrismaticVelocityConstraint {
         let mut limits_rhs = na::zero();
         let mut limits_impulse = na::zero();
         let mut limits_inv_lhs = na::zero();
-        let limits_enabled = SimdBool::from(array![|ii| cparams[ii].limits_enabled; SIMD_WIDTH]);
 
         if limits_enabled {
             let danchor = anchor2 - anchor1;

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -107,6 +107,7 @@ impl RevoluteVelocityConstraint {
 
             let axis1 = rb1.position * joint.local_axis1;
             let axis2 = rb2.position * joint.local_axis2;
+
             let ang_err =
                 Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
             let ang_err = ang_err.scaled_axis();

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -109,7 +109,7 @@ impl RevoluteVelocityConstraint {
             let axis2 = rb2.position * joint.local_axis2;
 
             let axis_error = axis1.cross(&axis2);
-            let ang_err = basis2.tr_mul(&axis_error) - basis1.tr_mul(&axis_error);
+            let ang_err = (basis2.tr_mul(&axis_error) + basis1.tr_mul(&axis_error)) * 0.5;
 
             rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
                 * velocity_based_erp_inv_dt;

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -108,9 +108,8 @@ impl RevoluteVelocityConstraint {
             let axis1 = rb1.position * joint.local_axis1;
             let axis2 = rb2.position * joint.local_axis2;
 
-            let ang_err =
-                Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
-            let ang_err = ang_err.scaled_axis();
+            let axis_error = axis1.cross(&axis2);
+            let ang_err = basis2.tr_mul(&axis_error) - basis1.tr_mul(&axis_error);
 
             rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
                 * velocity_based_erp_inv_dt;
@@ -416,9 +415,8 @@ impl RevoluteVelocityGroundConstraint {
                 axis1 = rb1.position * joint.local_axis1;
                 axis2 = rb2.position * joint.local_axis2;
             }
-            let ang_err =
-                Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
-            let ang_err = ang_err.scaled_axis();
+            let axis_error = axis1.cross(&axis2);
+            let ang_err = basis2.tr_mul(&axis_error);
 
             rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
                 * velocity_based_erp_inv_dt;
@@ -521,6 +519,7 @@ impl RevoluteVelocityGroundConstraint {
             .ii2_sqrt
             .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
     }
+
     fn solve_motors(&mut self, mj_lambda2: &mut DeltaVel<Real>) {
         if self.motor_inv_lhs != 0.0 {
             let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -3,9 +3,8 @@ use crate::dynamics::{
     IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RevoluteJoint, RigidBody,
 };
 use crate::math::{AngularInertia, Real, Rotation, Vector};
-use crate::na::UnitQuaternion;
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
-use na::{Cholesky, Matrix3x2, Matrix5, Vector5, U2, U3};
+use na::{Cholesky, Matrix3x2, Matrix5, UnitQuaternion, Vector5, U2, U3};
 
 #[derive(Debug)]
 pub(crate) struct RevoluteVelocityConstraint {
@@ -90,9 +89,31 @@ impl RevoluteVelocityConstraint {
 
         let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
 
-        let lin_rhs = (rb2.linvel + rb2.angvel.gcross(r2)) - (rb1.linvel + rb1.angvel.gcross(r1));
-        let ang_rhs = basis2.tr_mul(&rb2.angvel) - basis1.tr_mul(&rb1.angvel);
-        let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
+        let linvel_err =
+            (rb2.linvel + rb2.angvel.gcross(r2)) - (rb1.linvel + rb1.angvel.gcross(r1));
+        let angvel_err = basis2.tr_mul(&rb2.angvel) - basis1.tr_mul(&rb1.angvel);
+
+        let mut rhs = Vector5::new(
+            linvel_err.x,
+            linvel_err.y,
+            linvel_err.z,
+            angvel_err.x,
+            angvel_err.y,
+        ) * params.velocity_solve_fraction;
+
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
+            let lin_err = anchor2 - anchor1;
+
+            let axis1 = rb1.position * joint.local_axis1;
+            let axis2 = rb2.position * joint.local_axis2;
+            let ang_err =
+                Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
+            let ang_err = ang_err.scaled_axis();
+
+            rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
+                * velocity_based_erp_inv_dt;
+        }
 
         /*
          * Motor.
@@ -371,9 +392,36 @@ impl RevoluteVelocityGroundConstraint {
 
         let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
 
-        let lin_rhs = (rb2.linvel + rb2.angvel.gcross(r2)) - (rb1.linvel + rb1.angvel.gcross(r1));
-        let ang_rhs = basis2.tr_mul(&rb2.angvel) - basis1.tr_mul(&rb1.angvel);
-        let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
+        let linvel_err =
+            (rb2.linvel + rb2.angvel.gcross(r2)) - (rb1.linvel + rb1.angvel.gcross(r1));
+        let angvel_err = basis2.tr_mul(&rb2.angvel) - basis1.tr_mul(&rb1.angvel);
+        let mut rhs = Vector5::new(
+            linvel_err.x,
+            linvel_err.y,
+            linvel_err.z,
+            angvel_err.x,
+            angvel_err.y,
+        ) * params.velocity_solve_fraction;
+
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
+            let lin_err = anchor2 - anchor1;
+
+            let (axis1, axis2);
+            if flipped {
+                axis1 = rb1.position * joint.local_axis2;
+                axis2 = rb2.position * joint.local_axis1;
+            } else {
+                axis1 = rb1.position * joint.local_axis1;
+                axis2 = rb2.position * joint.local_axis2;
+            }
+            let ang_err =
+                Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
+            let ang_err = ang_err.scaled_axis();
+
+            rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
+                * velocity_based_erp_inv_dt;
+        }
 
         /*
          * Motor part.

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
@@ -8,7 +8,7 @@ use crate::math::{
     AngVector, AngularInertia, Isometry, Point, Real, Rotation, SimdReal, Vector, SIMD_WIDTH,
 };
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
-use na::{Cholesky, Matrix3x2, Matrix5, Vector5, U2, U3};
+use na::{Cholesky, Matrix3x2, Matrix5, Vector3, Vector5, U2, U3};
 
 #[derive(Debug)]
 pub(crate) struct WRevoluteVelocityConstraint {
@@ -107,9 +107,32 @@ impl WRevoluteVelocityConstraint {
 
         let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
 
-        let lin_rhs = linvel2 + angvel2.gcross(r2) - linvel1 - angvel1.gcross(r1);
-        let ang_rhs = basis2.tr_mul(&angvel2) - basis1.tr_mul(&angvel1);
-        let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
+        let linvel_err = linvel2 + angvel2.gcross(r2) - linvel1 - angvel1.gcross(r1);
+        let angvel_err = basis2.tr_mul(&angvel2) - basis1.tr_mul(&angvel1);
+
+        let mut rhs = Vector5::new(
+            linvel_err.x,
+            linvel_err.y,
+            linvel_err.z,
+            angvel_err.x,
+            angvel_err.y,
+        ) * SimdReal::splat(params.velocity_solve_fraction);
+
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
+            let velocity_based_erp_inv_dt = SimdReal::splat(velocity_based_erp_inv_dt);
+
+            let lin_err = anchor2 - anchor1;
+
+            let ang_err = Vector3::<SimdReal>::from(array![|ii| {
+                    let axis1 = rbs1[ii].position * joints[ii].local_axis1;
+                    let axis2 = rbs2[ii].position * joints[ii].local_axis2;
+                    Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity).scaled_axis()
+                }; SIMD_WIDTH]);
+
+            rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
+                * velocity_based_erp_inv_dt;
+        }
 
         /*
          * Adjust the warmstart impulse.
@@ -357,9 +380,32 @@ impl WRevoluteVelocityGroundConstraint {
 
         let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
 
-        let lin_rhs = (linvel2 + angvel2.gcross(r2)) - (linvel1 + angvel1.gcross(r1));
-        let ang_rhs = basis2.tr_mul(&angvel2) - basis1.tr_mul(&angvel1);
-        let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
+        let linvel_err = (linvel2 + angvel2.gcross(r2)) - (linvel1 + angvel1.gcross(r1));
+        let angvel_err = basis2.tr_mul(&angvel2) - basis1.tr_mul(&angvel1);
+
+        let mut rhs = Vector5::new(
+            linvel_err.x,
+            linvel_err.y,
+            linvel_err.z,
+            angvel_err.x,
+            angvel_err.y,
+        ) * SimdReal::splat(params.velocity_solve_fraction);
+
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+        if velocity_based_erp_inv_dt != 0.0 {
+            let velocity_based_erp_inv_dt = SimdReal::splat(velocity_based_erp_inv_dt);
+
+            let lin_err = anchor2 - anchor1;
+
+            let ang_err = Vector3::<SimdReal>::from(array![|ii| {
+                    let axis1 = rbs1[ii].position * if flipped[ii] { joints[ii].local_axis2 } else { joints[ii].local_axis1 };
+                    let axis2 = rbs2[ii].position * if flipped[ii] { joints[ii].local_axis1 } else { joints[ii].local_axis2 };
+                    Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity).scaled_axis()
+                }; SIMD_WIDTH]);
+
+            rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
+                * velocity_based_erp_inv_dt;
+        }
 
         WRevoluteVelocityGroundConstraint {
             joint_id,

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
@@ -133,7 +133,8 @@ impl WRevoluteVelocityConstraint {
             let axis2 = position2 * local_axis2;
 
             let axis_error = axis1.cross(&axis2);
-            let ang_err = basis2.tr_mul(&axis_error) - basis1.tr_mul(&axis_error);
+            let ang_err =
+                (basis2.tr_mul(&axis_error) + basis1.tr_mul(&axis_error)) * SimdReal::splat(0.5);
 
             rhs += Vector5::new(lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y)
                 * velocity_based_erp_inv_dt;

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -244,17 +244,22 @@ impl VelocityConstraint {
                             + gcross2.gdot(gcross2));
 
                     let is_bouncy = manifold_point.is_bouncy() as u32 as Real;
-                    let rhs = (1.0 + is_bouncy * manifold_point.restitution)
-                        * (vel1 - vel2).dot(&force_dir1)
-                        + manifold_point.dist.max(0.0) * inv_dt;
+                    let is_resting = 1.0 - is_bouncy;
 
-                    let impulse = manifold_point.data.impulse * warmstart_coeff;
+                    let mut rhs = (1.0 + is_bouncy * manifold_point.restitution)
+                        * (vel1 - vel2).dot(&force_dir1);
+                    rhs += manifold_point.dist.max(0.0) * inv_dt;
+                    rhs *= params.velocity_solve_fraction;
+                    rhs += is_resting
+                        * params.velocity_based_erp
+                        * inv_dt
+                        * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityConstraintElementPart {
                         gcross1,
                         gcross2,
                         rhs,
-                        impulse,
+                        impulse: manifold_point.data.impulse * warmstart_coeff,
                         r,
                     };
                 }

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -251,7 +251,7 @@ impl VelocityConstraint {
                     let mut rhs = (1.0 + is_bouncy * manifold_point.restitution)
                         * (vel1 - vel2).dot(&force_dir1);
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
-                    rhs *= params.velocity_solve_fraction;
+                    rhs *= is_bouncy + is_resting * params.velocity_solve_fraction;
                     rhs += is_resting * velocity_based_erp_inv_dt * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityConstraintElementPart {

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -147,6 +147,8 @@ impl VelocityConstraint {
         assert_eq!(manifold.data.relative_dominance, 0);
 
         let inv_dt = params.inv_dt();
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+
         let rb1 = &bodies[manifold.data.body_pair.body1];
         let rb2 = &bodies[manifold.data.body_pair.body2];
         let mj_lambda1 = rb1.active_set_offset;
@@ -250,10 +252,7 @@ impl VelocityConstraint {
                         * (vel1 - vel2).dot(&force_dir1);
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
                     rhs *= params.velocity_solve_fraction;
-                    rhs += is_resting
-                        * params.velocity_based_erp
-                        * inv_dt
-                        * manifold_point.dist.min(0.0);
+                    rhs += is_resting * velocity_based_erp_inv_dt * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityConstraintElementPart {
                         gcross1,

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -163,7 +163,7 @@ impl VelocityGroundConstraint {
                     let mut rhs = (1.0 + is_bouncy * manifold_point.restitution)
                         * (vel1 - vel2).dot(&force_dir1);
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
-                    rhs *= params.velocity_solve_fraction;
+                    rhs *= is_bouncy + is_resting * params.velocity_solve_fraction;
                     rhs += is_resting * velocity_based_erp_inv_dt * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintElementPart {

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -64,6 +64,8 @@ impl VelocityGroundConstraint {
         push: bool,
     ) {
         let inv_dt = params.inv_dt();
+        let velocity_based_erp_inv_dt = params.velocity_based_erp_inv_dt();
+
         let mut rb1 = &bodies[manifold.data.body_pair.body1];
         let mut rb2 = &bodies[manifold.data.body_pair.body2];
         let flipped = manifold.data.relative_dominance < 0;
@@ -162,10 +164,7 @@ impl VelocityGroundConstraint {
                         * (vel1 - vel2).dot(&force_dir1);
                     rhs += manifold_point.dist.max(0.0) * inv_dt;
                     rhs *= params.velocity_solve_fraction;
-                    rhs += is_resting
-                        * params.velocity_based_erp
-                        * inv_dt
-                        * manifold_point.dist.min(0.0);
+                    rhs += is_resting * velocity_based_erp_inv_dt * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintElementPart {
                         gcross2,

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -156,16 +156,21 @@ impl VelocityGroundConstraint {
                     let r = 1.0 / (rb2.effective_inv_mass + gcross2.gdot(gcross2));
 
                     let is_bouncy = manifold_point.is_bouncy() as u32 as Real;
-                    let rhs = (1.0 + is_bouncy * manifold_point.restitution)
-                        * (vel1 - vel2).dot(&force_dir1)
-                        + manifold_point.dist.max(0.0) * inv_dt;
+                    let is_resting = 1.0 - is_bouncy;
 
-                    let impulse = manifold_point.data.impulse * warmstart_coeff;
+                    let mut rhs = (1.0 + is_bouncy * manifold_point.restitution)
+                        * (vel1 - vel2).dot(&force_dir1);
+                    rhs += manifold_point.dist.max(0.0) * inv_dt;
+                    rhs *= params.velocity_solve_fraction;
+                    rhs += is_resting
+                        * params.velocity_based_erp
+                        * inv_dt
+                        * manifold_point.dist.min(0.0);
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintElementPart {
                         gcross2,
                         rhs,
-                        impulse,
+                        impulse: manifold_point.data.impulse * warmstart_coeff,
                         r,
                     };
                 }

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -64,6 +64,9 @@ impl WVelocityGroundConstraint {
         push: bool,
     ) {
         let inv_dt = SimdReal::splat(params.inv_dt());
+        let velocity_solve_fraction = SimdReal::splat(params.velocity_solve_fraction);
+        let velocity_based_erp_inv_dt = SimdReal::splat(params.velocity_based_erp_inv_dt());
+
         let mut rbs1 = array![|ii| &bodies[manifolds[ii].data.body_pair.body1]; SIMD_WIDTH];
         let mut rbs2 = array![|ii| &bodies[manifolds[ii].data.body_pair.body2]; SIMD_WIDTH];
         let mut flipped = [1.0; SIMD_WIDTH];
@@ -124,6 +127,7 @@ impl WVelocityGroundConstraint {
                 let is_bouncy = SimdReal::from(
                     array![|ii| manifold_points[ii][k].is_bouncy() as u32 as Real; SIMD_WIDTH],
                 );
+                let is_resting = SimdReal::splat(1.0) - is_bouncy;
                 let point = Point::from(array![|ii| manifold_points[ii][k].point; SIMD_WIDTH]);
                 let dist = SimdReal::from(array![|ii| manifold_points[ii][k].dist; SIMD_WIDTH]);
                 let tangent_velocity =
@@ -147,8 +151,12 @@ impl WVelocityGroundConstraint {
 
                     let r = SimdReal::splat(1.0) / (im2 + gcross2.gdot(gcross2));
                     let projected_velocity = (vel1 - vel2).dot(&force_dir1);
-                    let rhs = (SimdReal::splat(1.0) + is_bouncy * restitution) * projected_velocity
-                        + dist.simd_max(SimdReal::zero()) * inv_dt;
+                    let mut rhs =
+                        (SimdReal::splat(1.0) + is_bouncy * restitution) * projected_velocity;
+                    rhs += dist.simd_max(SimdReal::zero()) * inv_dt;
+                    rhs *= is_bouncy + is_resting * velocity_solve_fraction;
+                    rhs +=
+                        dist.simd_min(SimdReal::zero()) * (velocity_based_erp_inv_dt * is_resting);
 
                     constraint.elements[k].normal_part = WVelocityGroundConstraintElementPart {
                         gcross2,


### PR DESCRIPTION
This PR introduces a restorative impulse in the velocity solver that aims to resolve the constraint violation. The default strength of this is zero, i.e. it is disabled.

This PR also introduces a multiplier for the velocity correction of the velocity solver. The default is `1` (keeping the old behavior).

## Other changes / improvements

I fixed a bug in the prismatic limit joint that used to cause violations of the conservation of momentum.

I also added support for having the prismatic joints range be zero or negative (i.e. activating both sides of the prismatic limits).

## Benefits

Some of the benefits of having the violation resolution in the velocity solver include:

* No need for the positional solver
  * Saves some CPU time
  * Saves us from potential energy violations
* Faster violation resolution
  * Since we generally run the velocity solver for more iterations we have more iterations to converge on a solution
* Better coupling between velocity and position violations

## Downsides

Initial overlaps between colliders introduces a separating velocity, which makes the objects shoot away from each other rather than slowly separate.

# Progress

There are five constraints in Rapier (contact, ball, fixed, prismatic and revolute). Each has a scalar and simd (wide) version. Each has a dynamic-dynamic and dynamic-static ("ground") version. Each has a 2d and 3d version. So there are 5x2x2x2 = 40 things to update in this PR.

* [x] contact
* [x] ball
* [x] fixed
* [x] prismatic
* [x] revolute
* [x] Rebase on https://github.com/dimforge/rapier/pull/114
* [x] Rebase on https://github.com/dimforge/rapier/pull/119
* [x] Self review
* [x] Manual testing of the narrow versions (though not of `flipped` vs `!flipped`)
* [ ] Systematic testing

# Open questions

**For contacts**: How should we handle `allowed_linear_error`? It is currently pretty large (5 mm), and we also have `prediction_distance` (at 2mm).

## Testing

I've found these parameters work well:

```
max_position_iterations: 0,
warmstart_coeff: 0.5,
velocity_solve_fraction: 0.95,
velocity_based_erp: 0.20,
```

(and the rest left at default)

It would be nice to be able to test this in some automated fashion. That is, run the test barrage with these params and see that the tests works *approximately* the same as they do with the default parameters.

...though, is there even a test barrage? There is `src_testbed`, but I haven't found any docs or explanation for it. Seems to be only for manual testing?

# Results

In the subsequent test I compare the default parameters with the one described above.

## Contacts

When stirring around in a bowl the position solver will often damp out the movement, and the objects will tunnel though each other:

https://user-images.githubusercontent.com/1148717/108525718-b3308e80-72d0-11eb-870a-3c5076428c78.mp4

With the new velocity-based solver objects are properly displaced and move to make way for the object being dragged:

https://user-images.githubusercontent.com/1148717/108525782-c2afd780-72d0-11eb-8c8f-c79c991e1a4e.mp4

## Fixjoint resolution

In this test I have created a chain of bodies attached by fixjoints, with huge initial violations.

### Before

The position solver is slow to converge towards equilibrium, and the bodies falls asleep before reaching it (I need to poke the root body to wake up the chain):

![rapier-fixed-before](https://user-images.githubusercontent.com/1148717/108499399-81a6cb80-72ae-11eb-9efc-aa5f15f3b1ff.gif)

### After

![rapier-fixed-after](https://user-images.githubusercontent.com/1148717/108499539-bb77d200-72ae-11eb-9712-d578f2efc487.gif)

We see a much faster convergence. An analogy to machine learning comes to mind: while the position solver does gradient decent (with lr=0.2), the new solver does gradient decent with momentum.

## Revolute resolution

In this test a series of boxes are connected with revolute joints (the root is connected to the world).

### Before
The position solver does not seem to at all converge on a solution. I'm not sure if this is a bug or not:

![revolute-rapier](https://user-images.githubusercontent.com/1148717/109132602-4dbb2280-7754-11eb-83a8-c887f1d2ac32.gif)

### After
The new velocity solver converges after some swaying:

![revolute-velocity-2](https://user-images.githubusercontent.com/1148717/109132771-7e9b5780-7754-11eb-846d-8f23953c95c8.gif)

increasing the number of velocity iteration makes it converge faster (as expected).