### PR TITLE
Add ColliderHandle:s to PairFilterContext

### DIFF
--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -424,6 +424,8 @@ impl NarrowPhase {
                 let context = PairFilterContext {
                     rigid_body1: rb1,
                     rigid_body2: rb2,
+                    collider_handle1: handle1,
+                    collider_handle2: handle2,
                     collider1: co1,
                     collider2: co2,
                 };
@@ -492,6 +494,8 @@ impl NarrowPhase {
                 let context = PairFilterContext {
                     rigid_body1: rb1,
                     rigid_body2: rb2,
+                    collider_handle1: pair.pair.collider1,
+                    collider_handle2: pair.pair.collider2,
                     collider1: co1,
                     collider2: co2,
                 };

--- a/src/geometry/pair_filter.rs
+++ b/src/geometry/pair_filter.rs
@@ -1,5 +1,5 @@
 use crate::dynamics::RigidBody;
-use crate::geometry::{Collider, SolverFlags};
+use crate::geometry::{Collider, ColliderHandle, SolverFlags};
 
 /// Context given to custom collision filters to filter-out collisions.
 pub struct PairFilterContext<'a> {
@@ -7,6 +7,10 @@ pub struct PairFilterContext<'a> {
     pub rigid_body1: &'a RigidBody,
     /// The first collider involved in the potential collision.
     pub rigid_body2: &'a RigidBody,
+    /// The first collider involved in the potential collision.
+    pub collider_handle1: ColliderHandle,
+    /// The first collider involved in the potential collision.
+    pub collider_handle2: ColliderHandle,
     /// The first collider involved in the potential collision.
     pub collider1: &'a Collider,
     /// The first collider involved in the potential collision.


### PR DESCRIPTION
This makes it easy to write custom filters based on the handles.

For instance, a user can add pairs of `ColliderHandle`s into a `HashSet` (or `Coarena`) and do a lookup in a `ContactPairFilter` to easily (if maybe not efficiently) disable collisions between pairs of colliders.

The same could be accomplished by using the `user_data: u128` field of the `Collider`, but it would be less ergonomic, and also with this PR that `user_data` space can be saved for more important things.