### PR TITLE
Add joint motors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ members = [ "build/rapier2d", "build/rapier2d-f64", "build/rapier_testbed2d", "e
 #nalgebra = { path = "../nalgebra" }
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
-#parry2d = { git = "https://github.com/sebcrozet/parry" }
-#parry3d = { git = "https://github.com/sebcrozet/parry" }
-#parry2d-f64 = { git = "https://github.com/sebcrozet/parry" }
-#parry3d-f64 = { git = "https://github.com/sebcrozet/parry" }
+nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
+parry2d = { git = "https://github.com/dimforge/parry" }
+parry3d = { git = "https://github.com/dimforge/parry" }
+parry2d-f64 = { git = "https://github.com/dimforge/parry" }
+parry3d-f64 = { git = "https://github.com/dimforge/parry" }
 #ncollide2d = { git = "https://github.com/dimforge/ncollide" }
 #ncollide3d = { git = "https://github.com/dimforge/ncollide" }
 #nphysics2d = { git = "https://github.com/dimforge/nphysics" }

--- a/examples3d/joints3.rs
+++ b/examples3d/joints3.rs
@@ -1,7 +1,7 @@
-use na::{Isometry3, Point3, Unit, Vector3};
+use na::{Isometry3, Point3, Unit, UnitQuaternion, Vector3};
 use rapier3d::dynamics::{
     BallJoint, BodyStatus, FixedJoint, JointSet, PrismaticJoint, RevoluteJoint, RigidBodyBuilder,
-    RigidBodySet,
+    RigidBodyHandle, RigidBodySet,
 };
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed3d::Testbed;
@@ -14,7 +14,7 @@ fn create_prismatic_joints(
     num: usize,
 ) {
     let rad = 0.4;
-    let shift = 1.0;
+    let shift = 2.0;
 
     let ground = RigidBodyBuilder::new_static()
         .translation(origin.x, origin.y, origin.z)
@@ -40,7 +40,7 @@ fn create_prismatic_joints(
 
         let z = Vector3::z();
         let mut prism = PrismaticJoint::new(
-            Point3::origin(),
+            Point3::new(0.0, 0.0, 0.0),
             axis,
             z,
             Point3::new(0.0, 0.0, -shift),
@@ -50,6 +50,7 @@ fn create_prismatic_joints(
         prism.limits_enabled = true;
         prism.limits[0] = -2.0;
         prism.limits[1] = 2.0;
+
         joints.insert(bodies, curr_parent, curr_child, prism);
 
         curr_parent = curr_child;
@@ -222,6 +223,130 @@ fn create_ball_joints(
     }
 }
 
+fn create_actuated_revolute_joints(
+    bodies: &mut RigidBodySet,
+    colliders: &mut ColliderSet,
+    joints: &mut JointSet,
+    origin: Point3<f32>,
+    num: usize,
+) {
+    let rad = 0.4;
+    let shift = 2.0;
+
+    // We will reuse this base configuration for all the joints here.
+    let joint_template = RevoluteJoint::new(
+        Point3::origin(),
+        Vector3::z_axis(),
+        Point3::new(0.0, 0.0, -shift),
+        Vector3::z_axis(),
+    );
+
+    let mut parent_handle = RigidBodyHandle::invalid();
+
+    for i in 0..num {
+        let fi = i as f32;
+
+        // NOTE: the num - 2 test is to avoid two consecutive
+        // fixed bodies. Because physx will crash if we add
+        // a joint between these.
+        let status = if i == 0 {
+            BodyStatus::Static
+        } else {
+            BodyStatus::Dynamic
+        };
+
+        let shifty = (i >= 1) as u32 as f32 * -2.0;
+
+        let rigid_body = RigidBodyBuilder::new(status)
+            .translation(origin.x, origin.y + shifty, origin.z + fi * shift)
+            // .rotation(Vector3::new(0.0, fi * 1.1, 0.0))
+            .build();
+
+        let child_handle = bodies.insert(rigid_body);
+        let collider = ColliderBuilder::cuboid(rad * 2.0, rad * 6.0 / (fi + 1.0), rad).build();
+        colliders.insert(collider, child_handle, bodies);
+
+        if i > 0 {
+            let mut joint = joint_template.clone();
+
+            if i % 3 == 1 {
+                joint.configure_motor_velocity(-20.0, 0.1);
+            } else if i == num - 1 {
+                let stiffness = 0.2;
+                let damping = 1.0;
+                joint.configure_motor_position(3.14 / 2.0, stiffness, damping);
+            }
+
+            if i == 1 {
+                joint.local_anchor2.y = 2.0;
+                joint.configure_motor_velocity(-2.0, 0.1);
+            }
+
+            joints.insert(bodies, parent_handle, child_handle, joint);
+        }
+
+        parent_handle = child_handle;
+    }
+}
+
+fn create_actuated_ball_joints(
+    bodies: &mut RigidBodySet,
+    colliders: &mut ColliderSet,
+    joints: &mut JointSet,
+    origin: Point3<f32>,
+    num: usize,
+) {
+    let rad = 0.4;
+    let shift = 2.0;
+
+    // We will reuse this base configuration for all the joints here.
+    let joint_template = BallJoint::new(Point3::new(0.0, 0.0, shift), Point3::origin());
+
+    let mut parent_handle = RigidBodyHandle::invalid();
+
+    for i in 0..num {
+        let fi = i as f32;
+
+        // NOTE: the num - 2 test is to avoid two consecutive
+        // fixed bodies. Because physx will crash if we add
+        // a joint between these.
+        let status = if i == 0 {
+            BodyStatus::Static
+        } else {
+            BodyStatus::Dynamic
+        };
+
+        let rigid_body = RigidBodyBuilder::new(status)
+            .translation(origin.x, origin.y, origin.z + fi * shift)
+            // .rotation(Vector3::new(0.0, fi * 1.1, 0.0))
+            .build();
+
+        let child_handle = bodies.insert(rigid_body);
+        let collider = ColliderBuilder::capsule_y(rad * 2.0 / (fi + 1.0), rad).build();
+        colliders.insert(collider, child_handle, bodies);
+
+        if i > 0 {
+            let mut joint = joint_template.clone();
+
+            if i == 1 {
+                joint.configure_motor_velocity(Vector3::new(0.0, 0.5, -2.0), 0.1);
+            } else if i == num - 1 {
+                let stiffness = 0.2;
+                let damping = 1.0;
+                joint.configure_motor_position(
+                    UnitQuaternion::new(Vector3::new(0.0, 1.0, 3.14 / 2.0)),
+                    stiffness,
+                    damping,
+                );
+            }
+
+            joints.insert(bodies, parent_handle, child_handle, joint);
+        }
+
+        parent_handle = child_handle;
+    }
+}
+
 pub fn init_world(testbed: &mut Testbed) {
     /*
      * World
@@ -234,8 +359,8 @@ pub fn init_world(testbed: &mut Testbed) {
         &mut bodies,
         &mut colliders,
         &mut joints,
-        Point3::new(20.0, 10.0, 0.0),
-        5,
+        Point3::new(20.0, 5.0, 0.0),
+        4,
     );
     create_revolute_joints(
         &mut bodies,
@@ -249,7 +374,21 @@ pub fn init_world(testbed: &mut Testbed) {
         &mut colliders,
         &mut joints,
         Point3::new(0.0, 10.0, 0.0),
-        5,
+        10,
+    );
+    create_actuated_revolute_joints(
+        &mut bodies,
+        &mut colliders,
+        &mut joints,
+        Point3::new(20.0, 10.0, 0.0),
+        6,
+    );
+    create_actuated_ball_joints(
+        &mut bodies,
+        &mut colliders,
+        &mut joints,
+        Point3::new(13.0, 10.0, 0.0),
+        3,
     );
     create_ball_joints(&mut bodies, &mut colliders, &mut joints, 15);
 

--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -1,7 +1,7 @@
 use crate::math::Real;
 
 /// Parameters for a time-step of the physics engine.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct IntegrationParameters {
     /// The timestep length (default: `1.0 / 60.0`)

--- a/src/dynamics/joint/ball_joint.rs
+++ b/src/dynamics/joint/ball_joint.rs
@@ -1,4 +1,5 @@
-use crate::math::{Point, Real, Vector};
+use crate::dynamics::SpringModel;
+use crate::math::{Point, Real, Rotation, Vector};
 
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -12,6 +13,33 @@ pub struct BallJoint {
     ///
     /// The impulse applied to the second body is given by `-impulse`.
     pub impulse: Vector<Real>,
+
+    /// The target relative angular velocity the motor will attempt to reach.
+    #[cfg(feature = "dim2")]
+    pub motor_target_vel: Real,
+    /// The target relative angular velocity the motor will attempt to reach.
+    #[cfg(feature = "dim3")]
+    pub motor_target_vel: Vector<Real>,
+    /// The target angular position of this joint, expressed as an axis-angle.
+    pub motor_target_pos: Rotation<Real>,
+    /// The motor's stiffness.
+    /// See the documentation of `SpringModel` for more information on this parameter.
+    pub motor_stiffness: Real,
+    /// The motor's damping.
+    /// See the documentation of `SpringModel` for more information on this parameter.
+    pub motor_damping: Real,
+    /// The maximal impulse the motor is able to deliver.
+    pub motor_max_impulse: Real,
+    /// The angular impulse applied by the motor.
+    #[cfg(feature = "dim2")]
+    pub motor_impulse: Real,
+    /// The angular impulse applied by the motor.
+    #[cfg(feature = "dim3")]
+    pub motor_impulse: Vector<Real>,
+    /// The spring-like model used by the motor to reach the target velocity and .
+    pub motor_model: SpringModel,
+    // Used to handle cases where the position target ends up being more than pi radians away.
+    pub(crate) motor_last_angle: Real,
 }
 
 impl BallJoint {
@@ -29,11 +57,71 @@ impl BallJoint {
             local_anchor1,
             local_anchor2,
             impulse,
+            motor_target_vel: na::zero(),
+            motor_target_pos: Rotation::identity(),
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_impulse: na::zero(),
+            motor_max_impulse: Real::MAX,
+            motor_model: SpringModel::default(),
+            motor_last_angle: 0.0,
         }
     }
 
     /// Can a SIMD constraint be used for resolving this joint?
     pub fn supports_simd_constraints(&self) -> bool {
-        true
+        // SIMD ball constraints don't support motors right now.
+        self.motor_max_impulse == 0.0 || (self.motor_stiffness == 0.0 && self.motor_damping == 0.0)
+    }
+
+    pub fn configure_motor_model(&mut self, model: SpringModel) {
+        self.motor_model = model;
+    }
+
+    #[cfg(feature = "dim2")]
+    pub fn configure_motor_velocity(&mut self, target_vel: Real, factor: Real) {
+        self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn configure_motor_velocity(&mut self, target_vel: Vector<Real>, factor: Real) {
+        self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
+    }
+
+    pub fn configure_motor_position(
+        &mut self,
+        target_pos: Rotation<Real>,
+        stiffness: Real,
+        damping: Real,
+    ) {
+        self.configure_motor(target_pos, na::zero(), stiffness, damping)
+    }
+
+    #[cfg(feature = "dim2")]
+    pub fn configure_motor(
+        &mut self,
+        target_pos: Rotation<Real>,
+        target_vel: Real,
+        stiffness: Real,
+        damping: Real,
+    ) {
+        self.motor_target_vel = target_vel;
+        self.motor_target_pos = target_pos;
+        self.motor_stiffness = stiffness;
+        self.motor_damping = damping;
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn configure_motor(
+        &mut self,
+        target_pos: Rotation<Real>,
+        target_vel: Vector<Real>,
+        stiffness: Real,
+        damping: Real,
+    ) {
+        self.motor_target_vel = target_vel;
+        self.motor_target_pos = target_pos;
+        self.motor_stiffness = stiffness;
+        self.motor_damping = damping;
     }
 }

--- a/src/dynamics/joint/ball_joint.rs
+++ b/src/dynamics/joint/ball_joint.rs
@@ -31,4 +31,9 @@ impl BallJoint {
             impulse,
         }
     }
+
+    /// Can a SIMD constraint be used for resolving this joint?
+    pub fn supports_simd_constraints(&self) -> bool {
+        true
+    }
 }

--- a/src/dynamics/joint/ball_joint.rs
+++ b/src/dynamics/joint/ball_joint.rs
@@ -38,8 +38,6 @@ pub struct BallJoint {
     pub motor_impulse: Vector<Real>,
     /// The spring-like model used by the motor to reach the target velocity and .
     pub motor_model: SpringModel,
-    // Used to handle cases where the position target ends up being more than pi radians away.
-    pub(crate) motor_last_angle: Real,
 }
 
 impl BallJoint {
@@ -64,7 +62,6 @@ impl BallJoint {
             motor_impulse: na::zero(),
             motor_max_impulse: Real::MAX,
             motor_model: SpringModel::default(),
-            motor_last_angle: 0.0,
         }
     }
 

--- a/src/dynamics/joint/ball_joint.rs
+++ b/src/dynamics/joint/ball_joint.rs
@@ -74,20 +74,24 @@ impl BallJoint {
         self.motor_max_impulse == 0.0 || (self.motor_stiffness == 0.0 && self.motor_damping == 0.0)
     }
 
+    /// Set the spring-like model used by the motor to reach the desired target velocity and position.
     pub fn configure_motor_model(&mut self, model: SpringModel) {
         self.motor_model = model;
     }
 
+    /// Sets the target velocity and velocity correction factor this motor.
     #[cfg(feature = "dim2")]
     pub fn configure_motor_velocity(&mut self, target_vel: Real, factor: Real) {
         self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
     }
 
+    /// Sets the target velocity and velocity correction factor this motor.
     #[cfg(feature = "dim3")]
     pub fn configure_motor_velocity(&mut self, target_vel: Vector<Real>, factor: Real) {
         self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
     }
 
+    /// Sets the target orientation this motor needs to reach.
     pub fn configure_motor_position(
         &mut self,
         target_pos: Rotation<Real>,
@@ -97,6 +101,7 @@ impl BallJoint {
         self.configure_motor(target_pos, na::zero(), stiffness, damping)
     }
 
+    /// Sets the target orientation this motor needs to reach.
     #[cfg(feature = "dim2")]
     pub fn configure_motor(
         &mut self,
@@ -111,6 +116,7 @@ impl BallJoint {
         self.motor_damping = damping;
     }
 
+    /// Configure both the target orientation and target velocity of the motor.
     #[cfg(feature = "dim3")]
     pub fn configure_motor(
         &mut self,

--- a/src/dynamics/joint/fixed_joint.rs
+++ b/src/dynamics/joint/fixed_joint.rs
@@ -30,4 +30,9 @@ impl FixedJoint {
             impulse: SpacialVector::zeros(),
         }
     }
+
+    /// Can a SIMD constraint be used for resolving this joint?
+    pub fn supports_simd_constraints(&self) -> bool {
+        true
+    }
 }

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -1,4 +1,4 @@
-use crate::dynamics::RevoluteJoint;
+use crate::dynamics::{BallJoint, FixedJoint, PrismaticJoint, RevoluteJoint};
 use crate::math::{Isometry, Real, SpacialVector, SPATIAL_DIM};
 use crate::na::{Rotation3, UnitQuaternion};
 
@@ -24,11 +24,16 @@ pub struct GenericJoint {
 
     pub min_position: SpacialVector<Real>,
     pub max_position: SpacialVector<Real>,
-    pub target_velocity: SpacialVector<Real>,
-    /// The maximum negative impulse the joint can apply on each DoF. Must be <= 0.0
-    pub max_negative_impulse: SpacialVector<Real>,
+    pub min_velocity: SpacialVector<Real>,
+    pub max_velocity: SpacialVector<Real>,
+    /// The minimum negative impulse the joint can apply on each DoF. Must be <= 0.0
+    pub min_impulse: SpacialVector<Real>,
     /// The maximum positive impulse the joint can apply on each DoF. Must be >= 0.0
-    pub max_positive_impulse: SpacialVector<Real>,
+    pub max_impulse: SpacialVector<Real>,
+    /// The minimum negative position impulse the joint can apply on each DoF. Must be <= 0.0
+    pub min_pos_impulse: SpacialVector<Real>,
+    /// The maximum positive position impulse the joint can apply on each DoF. Must be >= 0.0
+    pub max_pos_impulse: SpacialVector<Real>,
 }
 
 impl GenericJoint {
@@ -40,25 +45,78 @@ impl GenericJoint {
             impulse: SpacialVector::zeros(),
             min_position: SpacialVector::zeros(),
             max_position: SpacialVector::zeros(),
-            target_velocity: SpacialVector::zeros(),
-            max_negative_impulse: SpacialVector::repeat(-Real::MAX),
-            max_positive_impulse: SpacialVector::repeat(Real::MAX),
+            min_velocity: SpacialVector::zeros(),
+            max_velocity: SpacialVector::zeros(),
+            min_impulse: SpacialVector::repeat(-Real::MAX),
+            max_impulse: SpacialVector::repeat(Real::MAX),
+            min_pos_impulse: SpacialVector::repeat(-Real::MAX),
+            max_pos_impulse: SpacialVector::repeat(Real::MAX),
         }
+    }
+
+    pub fn free_dof(&mut self, dof: u8) {
+        self.min_position[dof as usize] = -Real::MAX;
+        self.max_position[dof as usize] = Real::MAX;
+        self.min_velocity[dof as usize] = -Real::MAX;
+        self.max_velocity[dof as usize] = Real::MAX;
+        self.min_impulse[dof as usize] = 0.0;
+        self.max_impulse[dof as usize] = 0.0;
+        self.min_pos_impulse[dof as usize] = 0.0;
+        self.max_pos_impulse[dof as usize] = 0.0;
+    }
+
+    pub fn set_dof_limits(&mut self, dof: u8, min: Real, max: Real) {
+        self.min_position[dof as usize] = min;
+        self.max_position[dof as usize] = max;
     }
 }
 
 impl From<RevoluteJoint> for GenericJoint {
     fn from(joint: RevoluteJoint) -> Self {
-        let basis1 = [joint.local_axis1, joint.basis1[0], joint.basis1[1]];
-        let basis2 = [joint.local_axis2, joint.basis2[0], joint.basis2[1]];
-        let quat1 = UnitQuaternion::from_basis_unchecked(&basis1[..]);
-        let quat2 = UnitQuaternion::from_basis_unchecked(&basis2[..]);
+        let basis1 = [*joint.local_axis1, joint.basis1[0], joint.basis1[1]];
+        let basis2 = [*joint.local_axis2, joint.basis2[0], joint.basis2[1]];
+        let quat1 = UnitQuaternion::from_basis_unchecked(&basis1);
+        let quat2 = UnitQuaternion::from_basis_unchecked(&basis2);
         let local_anchor1 = Isometry::from_parts(joint.local_anchor1.coords.into(), quat1);
         let local_anchor2 = Isometry::from_parts(joint.local_anchor2.coords.into(), quat2);
 
         let mut result = Self::new(local_anchor1, local_anchor2);
-        result.min_position[3] = -Real::MAX;
-        result.max_position[3] = Real::MAX;
+        result.free_dof(3);
         result
+    }
+}
+
+impl From<BallJoint> for GenericJoint {
+    fn from(joint: BallJoint) -> Self {
+        let local_anchor1 = Isometry::new(joint.local_anchor1.coords, na::zero());
+        let local_anchor2 = Isometry::new(joint.local_anchor2.coords, na::zero());
+
+        let mut result = Self::new(local_anchor1, local_anchor2);
+        result.free_dof(3);
+        result.free_dof(4);
+        result.free_dof(5);
+        result
+    }
+}
+
+impl From<PrismaticJoint> for GenericJoint {
+    fn from(joint: PrismaticJoint) -> Self {
+        let basis1 = [*joint.local_axis1, joint.basis1[0], joint.basis1[1]];
+        let basis2 = [*joint.local_axis2, joint.basis2[0], joint.basis2[1]];
+        let quat1 = UnitQuaternion::from_basis_unchecked(&basis1);
+        let quat2 = UnitQuaternion::from_basis_unchecked(&basis2);
+        let local_anchor1 = Isometry::from_parts(joint.local_anchor1.coords.into(), quat1);
+        let local_anchor2 = Isometry::from_parts(joint.local_anchor2.coords.into(), quat2);
+
+        let mut result = Self::new(local_anchor1, local_anchor2);
+        result.free_dof(0);
+        result.set_dof_limits(0, joint.limits[0], joint.limits[1]);
+        result
+    }
+}
+
+impl From<FixedJoint> for GenericJoint {
+    fn from(joint: FixedJoint) -> Self {
+        Self::new(joint.local_anchor1, joint.local_anchor2)
     }
 }

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -54,6 +54,13 @@ impl GenericJoint {
         }
     }
 
+    pub fn set_dof_vel(&mut self, dof: u8, target_vel: Real, max_force: Real) {
+        self.min_velocity[dof as usize] = target_vel;
+        self.max_velocity[dof as usize] = target_vel;
+        self.min_impulse[dof as usize] = -max_force;
+        self.max_impulse[dof as usize] = max_force;
+    }
+
     pub fn free_dof(&mut self, dof: u8) {
         self.min_position[dof as usize] = -Real::MAX;
         self.max_position[dof as usize] = Real::MAX;
@@ -82,6 +89,18 @@ impl From<RevoluteJoint> for GenericJoint {
 
         let mut result = Self::new(local_anchor1, local_anchor2);
         result.free_dof(3);
+
+        if joint.motor_damping != 0.0 {
+            result.set_dof_vel(3, joint.motor_target_vel, joint.motor_max_impulse);
+        }
+
+        result.impulse[0] = joint.impulse[0];
+        result.impulse[1] = joint.impulse[1];
+        result.impulse[2] = joint.impulse[2];
+        result.impulse[3] = joint.motor_impulse;
+        result.impulse[4] = joint.impulse[3];
+        result.impulse[5] = joint.impulse[4];
+
         result
     }
 }
@@ -92,6 +111,9 @@ impl From<BallJoint> for GenericJoint {
         let local_anchor2 = Isometry::new(joint.local_anchor2.coords, na::zero());
 
         let mut result = Self::new(local_anchor1, local_anchor2);
+        result.impulse[0] = joint.impulse[0];
+        result.impulse[1] = joint.impulse[1];
+        result.impulse[2] = joint.impulse[2];
         result.free_dof(3);
         result.free_dof(4);
         result.free_dof(5);

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -1,0 +1,46 @@
+use crate::math::{Isometry, Real, SpacialVector, SPATIAL_DIM};
+
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+/// A joint that prevents all relative movement between two bodies.
+///
+/// Given two frames of references, this joint aims to ensure these frame always coincide in world-space.
+pub struct GenericJoint {
+    /// The frame of reference for the first body affected by this joint, expressed in the local frame
+    /// of the first body.
+    pub local_anchor1: Isometry<Real>,
+    /// The frame of reference for the second body affected by this joint, expressed in the local frame
+    /// of the first body.
+    pub local_anchor2: Isometry<Real>,
+    /// The impulse applied to the first body affected by this joint.
+    ///
+    /// The impulse applied to the second body affected by this joint is given by `-impulse`.
+    /// This combines both linear and angular impulses:
+    /// - In 2D, `impulse.xy()` gives the linear impulse, and `impulse.z` the angular impulse.
+    /// - In 3D, `impulse.xyz()` gives the linear impulse, and `(impulse[3], impulse[4], impulse[5])` the angular impulse.
+    pub impulse: SpacialVector<Real>,
+
+    pub min_position: SpacialVector<Real>,
+    pub max_position: SpacialVector<Real>,
+    pub target_velocity: SpacialVector<Real>,
+    /// The maximum negative impulse the joint can apply on each DoF. Must be <= 0.0
+    pub max_negative_impulse: SpacialVector<Real>,
+    /// The maximum positive impulse the joint can apply on each DoF. Must be >= 0.0
+    pub max_positive_impulse: SpacialVector<Real>,
+}
+
+impl GenericJoint {
+    /// Creates a new fixed joint from the frames of reference of both bodies.
+    pub fn new(local_anchor1: Isometry<Real>, local_anchor2: Isometry<Real>) -> Self {
+        Self {
+            local_anchor1,
+            local_anchor2,
+            impulse: SpacialVector::zeros(),
+            min_position: SpacialVector::zeros(),
+            max_position: SpacialVector::zeros(),
+            target_velocity: SpacialVector::zeros(),
+            max_negative_impulse: SpacialVector::repeat(-Real::MAX),
+            max_positive_impulse: SpacialVector::repeat(Real::MAX),
+        }
+    }
+}

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -1,5 +1,5 @@
 use crate::dynamics::{BallJoint, FixedJoint, PrismaticJoint, RevoluteJoint};
-use crate::math::{Isometry, Real, SpacialVector, SPATIAL_DIM};
+use crate::math::{Isometry, Real, SpacialVector};
 use crate::na::{Rotation3, UnitQuaternion};
 
 #[derive(Copy, Clone, Debug)]

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -132,10 +132,11 @@ pub struct Joint {
 impl Joint {
     pub fn supports_simd_constraints(&self) -> bool {
         match &self.params {
-            JointParams::RevoluteJoint(joint) => joint.supports_simd_constraints(),
             JointParams::PrismaticJoint(joint) => joint.supports_simd_constraints(),
             JointParams::FixedJoint(joint) => joint.supports_simd_constraints(),
             JointParams::BallJoint(joint) => joint.supports_simd_constraints(),
+            #[cfg(feature = "dim3")]
+            JointParams::RevoluteJoint(joint) => joint.supports_simd_constraints(),
         }
     }
 }

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -130,6 +130,7 @@ pub struct Joint {
 }
 
 impl Joint {
+    /// Can this joint use SIMD-accelerated constraint formulations?
     pub fn supports_simd_constraints(&self) -> bool {
         match &self.params {
             JointParams::PrismaticJoint(joint) => joint.supports_simd_constraints(),

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -128,3 +128,14 @@ pub struct Joint {
     /// The joint geometric parameters and impulse.
     pub params: JointParams,
 }
+
+impl Joint {
+    pub fn supports_simd_constraints(&self) -> bool {
+        match &self.params {
+            JointParams::RevoluteJoint(joint) => joint.supports_simd_constraints(),
+            JointParams::PrismaticJoint(joint) => joint.supports_simd_constraints(),
+            JointParams::FixedJoint(joint) => joint.supports_simd_constraints(),
+            JointParams::BallJoint(joint) => joint.supports_simd_constraints(),
+        }
+    }
+}

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "dim3")]
 use crate::dynamics::RevoluteJoint;
-use crate::dynamics::{
-    BallJoint, FixedJoint, GenericJoint, JointHandle, PrismaticJoint, RigidBodyHandle,
-};
+use crate::dynamics::{BallJoint, FixedJoint, JointHandle, PrismaticJoint, RigidBodyHandle};
 
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -19,7 +17,7 @@ pub enum JointParams {
     /// A revolute joint that removes all degrees of degrees of freedom between the affected
     /// bodies except for the translation along one axis.
     RevoluteJoint(RevoluteJoint),
-    GenericJoint(GenericJoint),
+    // GenericJoint(GenericJoint),
 }
 
 impl JointParams {
@@ -29,7 +27,7 @@ impl JointParams {
             JointParams::BallJoint(_) => 0,
             JointParams::FixedJoint(_) => 1,
             JointParams::PrismaticJoint(_) => 2,
-            JointParams::GenericJoint(_) => 3,
+            // JointParams::GenericJoint(_) => 3,
             #[cfg(feature = "dim3")]
             JointParams::RevoluteJoint(_) => 4,
         }
@@ -53,14 +51,14 @@ impl JointParams {
         }
     }
 
-    /// Gets a reference to the underlying generic joint, if `self` is one.
-    pub fn as_generic_joint(&self) -> Option<&GenericJoint> {
-        if let JointParams::GenericJoint(j) = self {
-            Some(j)
-        } else {
-            None
-        }
-    }
+    // /// Gets a reference to the underlying generic joint, if `self` is one.
+    // pub fn as_generic_joint(&self) -> Option<&GenericJoint> {
+    //     if let JointParams::GenericJoint(j) = self {
+    //         Some(j)
+    //     } else {
+    //         None
+    //     }
+    // }
 
     /// Gets a reference to the underlying prismatic joint, if `self` is one.
     pub fn as_prismatic_joint(&self) -> Option<&PrismaticJoint> {
@@ -94,11 +92,11 @@ impl From<FixedJoint> for JointParams {
     }
 }
 
-impl From<GenericJoint> for JointParams {
-    fn from(j: GenericJoint) -> Self {
-        JointParams::GenericJoint(j)
-    }
-}
+// impl From<GenericJoint> for JointParams {
+//     fn from(j: GenericJoint) -> Self {
+//         JointParams::GenericJoint(j)
+//     }
+// }
 
 #[cfg(feature = "dim3")]
 impl From<RevoluteJoint> for JointParams {

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "dim3")]
 use crate::dynamics::RevoluteJoint;
-use crate::dynamics::{BallJoint, FixedJoint, JointHandle, PrismaticJoint, RigidBodyHandle};
+use crate::dynamics::{
+    BallJoint, FixedJoint, GenericJoint, JointHandle, PrismaticJoint, RigidBodyHandle,
+};
 
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -17,6 +19,7 @@ pub enum JointParams {
     /// A revolute joint that removes all degrees of degrees of freedom between the affected
     /// bodies except for the translation along one axis.
     RevoluteJoint(RevoluteJoint),
+    GenericJoint(GenericJoint),
 }
 
 impl JointParams {
@@ -26,8 +29,9 @@ impl JointParams {
             JointParams::BallJoint(_) => 0,
             JointParams::FixedJoint(_) => 1,
             JointParams::PrismaticJoint(_) => 2,
+            JointParams::GenericJoint(_) => 3,
             #[cfg(feature = "dim3")]
-            JointParams::RevoluteJoint(_) => 3,
+            JointParams::RevoluteJoint(_) => 4,
         }
     }
 
@@ -43,6 +47,15 @@ impl JointParams {
     /// Gets a reference to the underlying fixed joint, if `self` is one.
     pub fn as_fixed_joint(&self) -> Option<&FixedJoint> {
         if let JointParams::FixedJoint(j) = self {
+            Some(j)
+        } else {
+            None
+        }
+    }
+
+    /// Gets a reference to the underlying generic joint, if `self` is one.
+    pub fn as_generic_joint(&self) -> Option<&GenericJoint> {
+        if let JointParams::GenericJoint(j) = self {
             Some(j)
         } else {
             None
@@ -78,6 +91,12 @@ impl From<BallJoint> for JointParams {
 impl From<FixedJoint> for JointParams {
     fn from(j: FixedJoint) -> Self {
         JointParams::FixedJoint(j)
+    }
+}
+
+impl From<GenericJoint> for JointParams {
+    fn from(j: GenericJoint) -> Self {
+        JointParams::GenericJoint(j)
     }
 }
 

--- a/src/dynamics/joint/mod.rs
+++ b/src/dynamics/joint/mod.rs
@@ -1,18 +1,20 @@
 pub use self::ball_joint::BallJoint;
 pub use self::fixed_joint::FixedJoint;
-pub use self::generic_joint::GenericJoint;
+// pub use self::generic_joint::GenericJoint;
 pub use self::joint::{Joint, JointParams};
 pub(crate) use self::joint_set::{JointGraphEdge, JointIndex};
 pub use self::joint_set::{JointHandle, JointSet};
 pub use self::prismatic_joint::PrismaticJoint;
 #[cfg(feature = "dim3")]
 pub use self::revolute_joint::RevoluteJoint;
+pub use self::spring_model::SpringModel;
 
 mod ball_joint;
 mod fixed_joint;
-mod generic_joint;
+// mod generic_joint;
 mod joint;
 mod joint_set;
 mod prismatic_joint;
 #[cfg(feature = "dim3")]
 mod revolute_joint;
+mod spring_model;

--- a/src/dynamics/joint/mod.rs
+++ b/src/dynamics/joint/mod.rs
@@ -1,5 +1,6 @@
 pub use self::ball_joint::BallJoint;
 pub use self::fixed_joint::FixedJoint;
+pub use self::generic_joint::GenericJoint;
 pub use self::joint::{Joint, JointParams};
 pub(crate) use self::joint_set::{JointGraphEdge, JointIndex};
 pub use self::joint_set::{JointHandle, JointSet};
@@ -9,6 +10,7 @@ pub use self::revolute_joint::RevoluteJoint;
 
 mod ball_joint;
 mod fixed_joint;
+mod generic_joint;
 mod joint;
 mod joint_set;
 mod prismatic_joint;

--- a/src/dynamics/joint/prismatic_joint.rs
+++ b/src/dynamics/joint/prismatic_joint.rs
@@ -135,6 +135,11 @@ impl PrismaticJoint {
         self.local_axis2
     }
 
+    /// Can a SIMD constraint be used for resolving this joint?
+    pub fn supports_simd_constraints(&self) -> bool {
+        true
+    }
+
     // FIXME: precompute this?
     #[cfg(feature = "dim2")]
     pub(crate) fn local_frame1(&self) -> Isometry<Real> {

--- a/src/dynamics/joint/prismatic_joint.rs
+++ b/src/dynamics/joint/prismatic_joint.rs
@@ -89,8 +89,8 @@ impl PrismaticJoint {
             Unit::try_new(local_axis1.cross(&local_tangent1), 1.0e-3)
         {
             [
-                local_bitangent1.into_inner(),
                 local_bitangent1.cross(&local_axis1),
+                local_bitangent1.into_inner(),
             ]
         } else {
             local_axis1.orthonormal_basis()
@@ -100,8 +100,8 @@ impl PrismaticJoint {
             Unit::try_new(local_axis2.cross(&local_tangent2), 2.0e-3)
         {
             [
-                local_bitangent2.into_inner(),
                 local_bitangent2.cross(&local_axis2),
+                local_bitangent2.into_inner(),
             ]
         } else {
             local_axis2.orthonormal_basis()

--- a/src/dynamics/joint/prismatic_joint.rs
+++ b/src/dynamics/joint/prismatic_joint.rs
@@ -217,18 +217,22 @@ impl PrismaticJoint {
         Isometry::from_parts(translation, rotation)
     }
 
+    /// Set the spring-like model used by the motor to reach the desired target velocity and position.
     pub fn configure_motor_model(&mut self, model: SpringModel) {
         self.motor_model = model;
     }
 
+    /// Sets the target velocity this motor needs to reach.
     pub fn configure_motor_velocity(&mut self, target_vel: Real, factor: Real) {
         self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
     }
 
+    /// Sets the target position this motor needs to reach.
     pub fn configure_motor_position(&mut self, target_pos: Real, stiffness: Real, damping: Real) {
         self.configure_motor(target_pos, 0.0, stiffness, damping)
     }
 
+    /// Configure both the target position and target velocity of the motor.
     pub fn configure_motor(
         &mut self,
         target_pos: Real,

--- a/src/dynamics/joint/prismatic_joint.rs
+++ b/src/dynamics/joint/prismatic_joint.rs
@@ -1,3 +1,4 @@
+use crate::dynamics::SpringModel;
 use crate::math::{Isometry, Point, Real, Vector, DIM};
 use crate::utils::WBasis;
 use na::Unit;
@@ -36,10 +37,23 @@ pub struct PrismaticJoint {
     ///
     /// The impulse applied to the second body is given by `-impulse`.
     pub limits_impulse: Real,
-    // pub motor_enabled: bool,
-    // pub target_motor_vel: Real,
-    // pub max_motor_impulse: Real,
-    // pub motor_impulse: Real,
+
+    /// The target relative angular velocity the motor will attempt to reach.
+    pub motor_target_vel: Real,
+    /// The target relative angle along the joint axis the motor will attempt to reach.
+    pub motor_target_pos: Real,
+    /// The motor's stiffness.
+    /// See the documentation of `SpringModel` for more information on this parameter.
+    pub motor_stiffness: Real,
+    /// The motor's damping.
+    /// See the documentation of `SpringModel` for more information on this parameter.
+    pub motor_damping: Real,
+    /// The maximal impulse the motor is able to deliver.
+    pub motor_max_impulse: Real,
+    /// The angular impulse applied by the motor.
+    pub motor_impulse: Real,
+    /// The spring-like model used by the motor to reach the target velocity and .
+    pub motor_model: SpringModel,
 }
 
 impl PrismaticJoint {
@@ -63,10 +77,13 @@ impl PrismaticJoint {
             limits_enabled: false,
             limits: [-Real::MAX, Real::MAX],
             limits_impulse: 0.0,
-            // motor_enabled: false,
-            // target_motor_vel: 0.0,
-            // max_motor_impulse: Real::MAX,
-            // motor_impulse: 0.0,
+            motor_target_vel: 0.0,
+            motor_target_pos: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_max_impulse: Real::MAX,
+            motor_impulse: 0.0,
+            motor_model: SpringModel::VelocityBased,
         }
     }
 
@@ -118,10 +135,13 @@ impl PrismaticJoint {
             limits_enabled: false,
             limits: [-Real::MAX, Real::MAX],
             limits_impulse: 0.0,
-            // motor_enabled: false,
-            // target_motor_vel: 0.0,
-            // max_motor_impulse: Real::MAX,
-            // motor_impulse: 0.0,
+            motor_target_vel: 0.0,
+            motor_target_pos: 0.0,
+            motor_stiffness: 0.0,
+            motor_damping: 0.0,
+            motor_max_impulse: Real::MAX,
+            motor_impulse: 0.0,
+            motor_model: SpringModel::VelocityBased,
         }
     }
 
@@ -137,7 +157,8 @@ impl PrismaticJoint {
 
     /// Can a SIMD constraint be used for resolving this joint?
     pub fn supports_simd_constraints(&self) -> bool {
-        true
+        // SIMD revolute constraints don't support motors right now.
+        self.motor_max_impulse == 0.0 || (self.motor_stiffness == 0.0 && self.motor_damping == 0.0)
     }
 
     // FIXME: precompute this?
@@ -194,5 +215,30 @@ impl PrismaticJoint {
         let rotation = UnitQuaternion::from_rotation_matrix(&rotmat);
         let translation = self.local_anchor2.coords.into();
         Isometry::from_parts(translation, rotation)
+    }
+
+    pub fn configure_motor_model(&mut self, model: SpringModel) {
+        self.motor_model = model;
+    }
+
+    pub fn configure_motor_velocity(&mut self, target_vel: Real, factor: Real) {
+        self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
+    }
+
+    pub fn configure_motor_position(&mut self, target_pos: Real, stiffness: Real, damping: Real) {
+        self.configure_motor(target_pos, 0.0, stiffness, damping)
+    }
+
+    pub fn configure_motor(
+        &mut self,
+        target_pos: Real,
+        target_vel: Real,
+        stiffness: Real,
+        damping: Real,
+    ) {
+        self.motor_target_vel = target_vel;
+        self.motor_target_pos = target_pos;
+        self.motor_stiffness = stiffness;
+        self.motor_damping = damping;
     }
 }

--- a/src/dynamics/joint/revolute_joint.rs
+++ b/src/dynamics/joint/revolute_joint.rs
@@ -77,6 +77,12 @@ impl RevoluteJoint {
         }
     }
 
+    /// Can a SIMD constraint be used for resolving this joint?
+    pub fn supports_simd_constraints(&self) -> bool {
+        // SIMD revolute constraints don't support motors right now.
+        self.motor_max_impulse == 0.0 || (self.motor_stiffness == 0.0 && self.motor_damping == 0.0)
+    }
+
     pub fn configure_motor_model(&mut self, model: SpringModel) {
         self.motor_model = model;
     }

--- a/src/dynamics/joint/revolute_joint.rs
+++ b/src/dynamics/joint/revolute_joint.rs
@@ -72,7 +72,7 @@ impl RevoluteJoint {
             motor_max_impulse: Real::MAX,
             motor_impulse: 0.0,
             prev_axis1: *local_axis1,
-            motor_model: SpringModel::VelocityBased,
+            motor_model: SpringModel::default(),
             motor_last_angle: 0.0,
         }
     }

--- a/src/dynamics/joint/revolute_joint.rs
+++ b/src/dynamics/joint/revolute_joint.rs
@@ -85,18 +85,22 @@ impl RevoluteJoint {
         self.motor_max_impulse == 0.0 || (self.motor_stiffness == 0.0 && self.motor_damping == 0.0)
     }
 
+    /// Set the spring-like model used by the motor to reach the desired target velocity and position.
     pub fn configure_motor_model(&mut self, model: SpringModel) {
         self.motor_model = model;
     }
 
+    /// Sets the target velocity this motor needs to reach.
     pub fn configure_motor_velocity(&mut self, target_vel: Real, factor: Real) {
         self.configure_motor(self.motor_target_pos, target_vel, 0.0, factor)
     }
 
+    /// Sets the target angle this motor needs to reach.
     pub fn configure_motor_position(&mut self, target_pos: Real, stiffness: Real, damping: Real) {
         self.configure_motor(target_pos, 0.0, stiffness, damping)
     }
 
+    /// Configure both the target angle and target velocity of the motor.
     pub fn configure_motor(
         &mut self,
         target_pos: Real,

--- a/src/dynamics/joint/revolute_joint.rs
+++ b/src/dynamics/joint/revolute_joint.rs
@@ -23,6 +23,7 @@ pub struct RevoluteJoint {
     ///
     /// The impulse applied to the second body is given by `-impulse`.
     pub impulse: Vector5<Real>,
+
     /// The target relative angular velocity the motor will attempt to reach.
     pub motor_target_vel: Real,
     /// The target relative angle along the joint axis the motor will attempt to reach.
@@ -39,6 +40,7 @@ pub struct RevoluteJoint {
     pub motor_impulse: Real,
     /// The spring-like model used by the motor to reach the target velocity and .
     pub motor_model: SpringModel,
+
     // Used to handle cases where the position target ends up being more than pi radians away.
     pub(crate) motor_last_angle: Real,
     // The angular impulse expressed in world-space.

--- a/src/dynamics/joint/spring_model.rs
+++ b/src/dynamics/joint/spring_model.rs
@@ -1,0 +1,59 @@
+use crate::math::Real;
+
+/// The spring-like model used for constraints resolution.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+pub enum SpringModel {
+    /// No equation is solved.
+    Disabled,
+    /// The solved spring-like equation is:
+    /// `delta_velocity(t + dt) = stiffness / dt * (target_pos - pos(t)) + damping * (target_vel - vel(t))`
+    ///
+    /// Here the `stiffness` is the ratio of position error to be solved at each timestep (like
+    /// a velocity-based ERP), and the `damping` is the ratio of velocity error to be solved at
+    /// each timestep.
+    VelocityBased,
+    /// The solved spring-like equation is:
+    /// `acceleration(t + dt) = stiffness * (target_pos - pos(t)) + damping * (target_vel - vel(t))`
+    AccelerationBased,
+    /// The solved spring-like equation is:
+    /// `force(t + dt) = stiffness * (target_pos - pos(t + dt)) + damping * (target_vel - vel(t + dt))`
+    ForceBased,
+}
+
+impl SpringModel {
+    /// Combines the coefficients used for solving the spring equation.
+    ///
+    /// Returns the new coefficients (stiffness, damping, inv_lhs_scale, keep_inv_lhs)
+    /// coefficients for the equivalent impulse-based equation. These new
+    /// coefficients must be used in the following way:
+    /// - `rhs = (stiffness * pos_err + damping * vel_err) / gamma`.
+    /// - `new_inv_lhs = gamma * if keep_inv_lhs { inv_lhs } else { 1.0 }`.
+    /// Note that the returned `gamma` will be zero if both `stiffness` and `damping` are zero.
+    pub fn combine_coefficients(
+        self,
+        dt: Real,
+        stiffness: Real,
+        damping: Real,
+    ) -> (Real, Real, Real, bool) {
+        match self {
+            SpringModel::VelocityBased => (stiffness * crate::utils::inv(dt), damping, 1.0, true),
+            SpringModel::AccelerationBased => {
+                let effective_stiffness = stiffness * dt;
+                let effective_damping = damping * dt;
+                // TODO: Using gamma behaves very badly for some reasons.
+                // Maybe I got the formulation wrong, so let's keep it to 1.0 for now,
+                // and get back to this later.
+                // let gamma = effective_stiffness * dt + effective_damping;
+                (effective_stiffness, effective_damping, 1.0, true)
+            }
+            SpringModel::ForceBased => {
+                let effective_stiffness = stiffness * dt;
+                let effective_damping = damping * dt;
+                let gamma = effective_stiffness * dt + effective_damping;
+                (effective_stiffness, effective_damping, gamma, false)
+            }
+            SpringModel::Disabled => return (0.0, 0.0, 0.0, false),
+        }
+    }
+}

--- a/src/dynamics/joint/spring_model.rs
+++ b/src/dynamics/joint/spring_model.rs
@@ -21,6 +21,12 @@ pub enum SpringModel {
     ForceBased,
 }
 
+impl Default for SpringModel {
+    fn default() -> Self {
+        SpringModel::VelocityBased
+    }
+}
+
 impl SpringModel {
     /// Combines the coefficients used for solving the spring equation.
     ///

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use self::joint::JointIndex;
 #[cfg(feature = "dim3")]
 pub use self::joint::RevoluteJoint;
 pub use self::joint::{
-    BallJoint, FixedJoint, Joint, JointHandle, JointParams, JointSet, PrismaticJoint,
+    BallJoint, FixedJoint, GenericJoint, Joint, JointHandle, JointParams, JointSet, PrismaticJoint,
 };
 pub use self::rigid_body::{ActivationStatus, BodyStatus, RigidBody, RigidBodyBuilder};
 pub use self::rigid_body_set::{BodyPair, RigidBodyHandle, RigidBodySet};

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -5,7 +5,14 @@ pub(crate) use self::joint::JointIndex;
 #[cfg(feature = "dim3")]
 pub use self::joint::RevoluteJoint;
 pub use self::joint::{
-    BallJoint, FixedJoint, GenericJoint, Joint, JointHandle, JointParams, JointSet, PrismaticJoint,
+    BallJoint,
+    FixedJoint,
+    Joint,
+    JointHandle,
+    JointParams,
+    JointSet,
+    PrismaticJoint,
+    SpringModel, // GenericJoint
 };
 pub use self::rigid_body::{ActivationStatus, BodyStatus, RigidBody, RigidBodyBuilder};
 pub use self::rigid_body_set::{BodyPair, RigidBodyHandle, RigidBodySet};

--- a/src/dynamics/solver/interaction_groups.rs
+++ b/src/dynamics/solver/interaction_groups.rs
@@ -214,6 +214,12 @@ impl InteractionGroups {
                 continue;
             }
 
+            if !interaction.supports_simd_constraints() {
+                // This joint does not support simd constraints yet.
+                self.nongrouped_interactions.push(*interaction_i);
+                continue;
+            }
+
             let ijoint = interaction.params.type_id();
             let i1 = body1.active_set_offset;
             let i2 = body2.active_set_offset;

--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -2,7 +2,7 @@ use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{
     BallJoint, IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RigidBody,
 };
-use crate::math::{AngularInertia, Real, SdpMatrix, Vector};
+use crate::math::{AngVector, AngularInertia, Real, SdpMatrix, Vector};
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
 
 #[derive(Debug)]
@@ -13,12 +13,16 @@ pub(crate) struct BallVelocityConstraint {
     joint_id: JointIndex,
 
     rhs: Vector<Real>,
-    pub(crate) impulse: Vector<Real>,
+    impulse: Vector<Real>,
 
     r1: Vector<Real>,
     r2: Vector<Real>,
 
     inv_lhs: SdpMatrix<Real>,
+
+    motor_rhs: AngVector<Real>,
+    motor_impulse: AngVector<Real>,
+    motor_inv_lhs: Option<AngularInertia<Real>>,
 
     im1: Real,
     im2: Real,
@@ -33,10 +37,10 @@ impl BallVelocityConstraint {
         joint_id: JointIndex,
         rb1: &RigidBody,
         rb2: &RigidBody,
-        cparams: &BallJoint,
+        joint: &BallJoint,
     ) -> Self {
-        let anchor1 = rb1.position * cparams.local_anchor1 - rb1.world_com;
-        let anchor2 = rb2.position * cparams.local_anchor2 - rb2.world_com;
+        let anchor1 = rb1.position * joint.local_anchor1 - rb1.world_com;
+        let anchor2 = rb2.position * joint.local_anchor2 - rb2.world_com;
 
         let vel1 = rb1.linvel + rb1.angvel.gcross(anchor1);
         let vel2 = rb2.linvel + rb2.angvel.gcross(anchor2);
@@ -77,17 +81,86 @@ impl BallVelocityConstraint {
 
         let inv_lhs = lhs.inverse_unchecked();
 
+        /*
+         * Motor part.
+         */
+        let mut motor_rhs = na::zero();
+        let mut motor_inv_lhs = None;
+        let motor_max_impulse = joint.motor_max_impulse;
+
+        let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
+            params.dt,
+            joint.motor_stiffness,
+            joint.motor_damping,
+        );
+
+        if stiffness != 0.0 {
+            let dpos =
+                rb2.position.rotation * (rb1.position.rotation * joint.motor_target_pos).inverse();
+            #[cfg(feature = "dim2")]
+            {
+                motor_rhs += dpos.angle() * stiffness;
+            }
+            #[cfg(feature = "dim3")]
+            {
+                motor_rhs += dpos.scaled_axis() * stiffness;
+            }
+        }
+
+        if damping != 0.0 {
+            let curr_vel = rb2.angvel - rb1.angvel;
+            motor_rhs += (curr_vel - joint.motor_target_vel) * damping;
+        }
+
+        #[cfg(feature = "dim2")]
+        if stiffness != 0.0 || damping != 0.0 {
+            motor_inv_lhs = if keep_lhs {
+                let ii1 = rb1.effective_world_inv_inertia_sqrt.squared();
+                let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+                Some(gamma / (ii1 + ii2))
+            } else {
+                Some(gamma)
+            };
+            motor_rhs /= gamma;
+        }
+
+        #[cfg(feature = "dim3")]
+        if stiffness != 0.0 || damping != 0.0 {
+            motor_inv_lhs = if keep_lhs {
+                let ii1 = rb1.effective_world_inv_inertia_sqrt.squared();
+                let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+                Some((ii1 + ii2).inverse_unchecked() * gamma)
+            } else {
+                Some(SdpMatrix::diagonal(gamma))
+            };
+            motor_rhs /= gamma;
+        }
+
+        #[cfg(feature = "dim2")]
+        let motor_impulse = na::clamp(joint.motor_impulse, -motor_max_impulse, motor_max_impulse)
+            * params.warmstart_coeff;
+
+        #[cfg(feature = "dim3")]
+        let motor_impulse = joint
+            .motor_impulse
+            .try_clamp_magnitude(-motor_max_impulse, motor_max_impulse, 1.0e-6)
+            .unwrap_or_else(na::zero)
+            * params.warmstart_coeff;
+
         BallVelocityConstraint {
             joint_id,
             mj_lambda1: rb1.active_set_offset,
             mj_lambda2: rb2.active_set_offset,
             im1,
             im2,
-            impulse: cparams.impulse * params.warmstart_coeff,
+            impulse: joint.impulse * params.warmstart_coeff,
             r1: anchor1,
             r2: anchor2,
             rhs,
             inv_lhs,
+            motor_rhs,
+            motor_impulse,
+            motor_inv_lhs,
             ii1_sqrt: rb1.effective_world_inv_inertia_sqrt,
             ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
         }
@@ -98,9 +171,13 @@ impl BallVelocityConstraint {
         let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
 
         mj_lambda1.linear += self.im1 * self.impulse;
-        mj_lambda1.angular += self.ii1_sqrt.transform_vector(self.r1.gcross(self.impulse));
+        mj_lambda1.angular += self
+            .ii1_sqrt
+            .transform_vector(self.r1.gcross(self.impulse) + self.motor_impulse);
         mj_lambda2.linear -= self.im2 * self.impulse;
-        mj_lambda2.angular -= self.ii2_sqrt.transform_vector(self.r2.gcross(self.impulse));
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(self.r2.gcross(self.impulse) + self.motor_impulse);
 
         mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
         mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
@@ -125,6 +202,21 @@ impl BallVelocityConstraint {
         mj_lambda2.linear -= self.im2 * impulse;
         mj_lambda2.angular -= self.ii2_sqrt.transform_vector(self.r2.gcross(impulse));
 
+        /*
+         * Motor part.
+         */
+        if let Some(motor_inv_lhs) = &self.motor_inv_lhs {
+            let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
+            let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+            let dangvel = (ang_vel2 - ang_vel1) + self.motor_rhs;
+            let impulse = motor_inv_lhs.transform_vector(dangvel);
+            self.motor_impulse += impulse;
+
+            mj_lambda1.angular += self.ii1_sqrt.transform_vector(impulse);
+            mj_lambda2.angular -= self.ii2_sqrt.transform_vector(impulse);
+        }
+
         mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
         mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
     }
@@ -141,10 +233,16 @@ impl BallVelocityConstraint {
 pub(crate) struct BallVelocityGroundConstraint {
     mj_lambda2: usize,
     joint_id: JointIndex,
+    r2: Vector<Real>,
+
     rhs: Vector<Real>,
     impulse: Vector<Real>,
-    r2: Vector<Real>,
     inv_lhs: SdpMatrix<Real>,
+
+    motor_rhs: AngVector<Real>,
+    motor_impulse: AngVector<Real>,
+    motor_inv_lhs: Option<AngularInertia<Real>>,
+
     im2: Real,
     ii2_sqrt: AngularInertia<Real>,
 }
@@ -155,18 +253,18 @@ impl BallVelocityGroundConstraint {
         joint_id: JointIndex,
         rb1: &RigidBody,
         rb2: &RigidBody,
-        cparams: &BallJoint,
+        joint: &BallJoint,
         flipped: bool,
     ) -> Self {
         let (anchor1, anchor2) = if flipped {
             (
-                rb1.position * cparams.local_anchor2 - rb1.world_com,
-                rb2.position * cparams.local_anchor1 - rb2.world_com,
+                rb1.position * joint.local_anchor2 - rb1.world_com,
+                rb2.position * joint.local_anchor1 - rb2.world_com,
             )
         } else {
             (
-                rb1.position * cparams.local_anchor1 - rb1.world_com,
-                rb2.position * cparams.local_anchor2 - rb2.world_com,
+                rb1.position * joint.local_anchor1 - rb1.world_com,
+                rb2.position * joint.local_anchor2 - rb2.world_com,
             )
         };
 
@@ -199,14 +297,81 @@ impl BallVelocityGroundConstraint {
 
         let inv_lhs = lhs.inverse_unchecked();
 
+        /*
+         * Motor part.
+         */
+        let mut motor_rhs = na::zero();
+        let mut motor_inv_lhs = None;
+        let motor_max_impulse = joint.motor_max_impulse;
+
+        let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
+            params.dt,
+            joint.motor_stiffness,
+            joint.motor_damping,
+        );
+
+        if stiffness != 0.0 {
+            let dpos =
+                rb2.position.rotation * (rb1.position.rotation * joint.motor_target_pos).inverse();
+            #[cfg(feature = "dim2")]
+            {
+                motor_rhs += dpos.angle() * stiffness;
+            }
+            #[cfg(feature = "dim3")]
+            {
+                motor_rhs += dpos.scaled_axis() * stiffness;
+            }
+        }
+
+        if damping != 0.0 {
+            let curr_vel = rb2.angvel - rb1.angvel;
+            motor_rhs += (curr_vel - joint.motor_target_vel) * damping;
+        }
+
+        #[cfg(feature = "dim2")]
+        if stiffness != 0.0 || damping != 0.0 {
+            motor_inv_lhs = if keep_lhs {
+                let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+                Some(gamma / ii2)
+            } else {
+                Some(gamma)
+            };
+            motor_rhs /= gamma;
+        }
+
+        #[cfg(feature = "dim3")]
+        if stiffness != 0.0 || damping != 0.0 {
+            motor_inv_lhs = if keep_lhs {
+                let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+                Some(ii2.inverse_unchecked() * gamma)
+            } else {
+                Some(SdpMatrix::diagonal(gamma))
+            };
+            motor_rhs /= gamma;
+        }
+
+        #[cfg(feature = "dim2")]
+        let motor_impulse = na::clamp(joint.motor_impulse, -motor_max_impulse, motor_max_impulse)
+            * params.warmstart_coeff;
+
+        #[cfg(feature = "dim3")]
+        let motor_impulse = joint
+            .motor_impulse
+            .try_clamp_magnitude(-motor_max_impulse, motor_max_impulse, 1.0e-6)
+            .unwrap_or_else(na::zero)
+            * params.warmstart_coeff;
+
         BallVelocityGroundConstraint {
             joint_id,
             mj_lambda2: rb2.active_set_offset,
             im2,
-            impulse: cparams.impulse * params.warmstart_coeff,
+            impulse: joint.impulse * params.warmstart_coeff,
             r2: anchor2,
             rhs,
             inv_lhs,
+            motor_rhs,
+            motor_impulse,
+            motor_inv_lhs,
             ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
         }
     }
@@ -214,7 +379,9 @@ impl BallVelocityGroundConstraint {
     pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
         let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
         mj_lambda2.linear -= self.im2 * self.impulse;
-        mj_lambda2.angular -= self.ii2_sqrt.transform_vector(self.r2.gcross(self.impulse));
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(self.r2.gcross(self.impulse) + self.motor_impulse);
         mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
     }
 
@@ -230,6 +397,19 @@ impl BallVelocityGroundConstraint {
 
         mj_lambda2.linear -= self.im2 * impulse;
         mj_lambda2.angular -= self.ii2_sqrt.transform_vector(self.r2.gcross(impulse));
+
+        /*
+         * Motor part.
+         */
+        if let Some(motor_inv_lhs) = &self.motor_inv_lhs {
+            let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+            let dangvel = ang_vel2 + self.motor_rhs;
+            let impulse = motor_inv_lhs.transform_vector(dangvel);
+            self.motor_impulse += impulse;
+
+            mj_lambda2.angular -= self.ii2_sqrt.transform_vector(impulse);
+        }
 
         mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
     }

--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -210,7 +210,8 @@ impl BallVelocityConstraint {
             let new_impulse = self.motor_impulse + motor_inv_lhs.transform_vector(dangvel);
 
             #[cfg(feature = "dim2")]
-            let clamped_impulse = na::clamp(new_impulse, -motor_max_impulse, motor_max_impulse);
+            let clamped_impulse =
+                na::clamp(new_impulse, -self.motor_max_impulse, self.motor_max_impulse);
             #[cfg(feature = "dim3")]
             let clamped_impulse = new_impulse.cap_magnitude(self.motor_max_impulse);
 
@@ -418,7 +419,8 @@ impl BallVelocityGroundConstraint {
             let new_impulse = self.motor_impulse + motor_inv_lhs.transform_vector(dangvel);
 
             #[cfg(feature = "dim2")]
-            let clamped_impulse = na::clamp(new_impulse, -motor_max_impulse, motor_max_impulse);
+            let clamped_impulse =
+                na::clamp(new_impulse, -self.motor_max_impulse, self.motor_max_impulse);
             #[cfg(feature = "dim3")]
             let clamped_impulse = new_impulse.cap_magnitude(self.motor_max_impulse);
 

--- a/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
@@ -152,7 +152,6 @@ impl GenericPositionConstraint {
                 }
             }
 
-            // Will be actually inverted right after.
             // TODO: we should keep the SdpMatrix3 type.
             let rotmat = basis.to_rotation_matrix().into_inner();
             let delassus = (self.ii1.quadform(&rotmat) + self.ii2.quadform(&rotmat)).into_matrix();
@@ -259,7 +258,6 @@ impl GenericPositionGroundConstraint {
             let rotmat = basis.to_rotation_matrix().into_inner();
             let rmat2 = r2.gcross_matrix() * rotmat;
 
-            // Will be actually inverted right after.
             // TODO: we should keep the SdpMatrix3 type.
             let delassus = self
                 .ii2

--- a/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
@@ -48,57 +48,7 @@ impl GenericPositionConstraint {
     }
 
     pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
-        let mut position1 = positions[self.position1 as usize];
-        let mut position2 = positions[self.position2 as usize];
-
-        let anchor1 = position1 * self.local_anchor1;
-        let anchor2 = position2 * self.local_anchor2;
-        let r1 = Point::from(anchor1.translation.vector) - position1 * self.local_com1;
-        let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
-
-        let delta_pos = Isometry::from_parts(
-            anchor2.translation * anchor1.translation.inverse(),
-            anchor2.rotation * anchor1.rotation.inverse(),
-        );
-
-        let mass_matrix = GenericVelocityConstraint::compute_mass_matrix(
-            &self.joint,
-            self.im1,
-            self.im2,
-            self.ii1,
-            self.ii2,
-            r1,
-            r2,
-            false,
-        );
-
-        let lin_dpos = delta_pos.translation.vector;
-        let ang_dpos = delta_pos.rotation.scaled_axis();
-        let dpos = Vector6::new(
-            lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
-        );
-        let err = dpos
-            - dpos
-                .sup(&self.joint.min_position)
-                .inf(&self.joint.max_position);
-        let impulse = mass_matrix * err;
-        let lin_impulse = impulse.xyz();
-        let ang_impulse = Vector3::new(impulse[3], impulse[4], impulse[5]);
-
-        position1.rotation = Rotation::new(
-            self.ii1
-                .transform_vector(ang_impulse + r1.gcross(lin_impulse)),
-        ) * position1.rotation;
-        position2.rotation = Rotation::new(
-            self.ii2
-                .transform_vector(-ang_impulse - r2.gcross(lin_impulse)),
-        ) * position2.rotation;
-
-        position1.translation.vector += self.im1 * lin_impulse;
-        position2.translation.vector -= self.im2 * lin_impulse;
-
-        positions[self.position1 as usize] = position1;
-        positions[self.position2 as usize] = position2;
+        return;
     }
 
     pub fn solve2(
@@ -152,43 +102,7 @@ impl GenericPositionGroundConstraint {
     }
 
     pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
-        let mut position2 = positions[self.position2 as usize];
-
-        let anchor2 = position2 * self.local_anchor2;
-        let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
-
-        let delta_pos = Isometry::from_parts(
-            anchor2.translation * self.anchor1.translation.inverse(),
-            anchor2.rotation * self.anchor1.rotation.inverse(),
-        );
-        let mass_matrix = GenericVelocityGroundConstraint::compute_mass_matrix(
-            &self.joint,
-            self.im2,
-            self.ii2,
-            r2,
-            false,
-        );
-
-        let lin_dpos = delta_pos.translation.vector;
-        let ang_dpos = delta_pos.rotation.scaled_axis();
-        let dpos = Vector6::new(
-            lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
-        );
-        let err = dpos
-            - dpos
-                .sup(&self.joint.min_position)
-                .inf(&self.joint.max_position);
-        let impulse = mass_matrix * err;
-        let lin_impulse = impulse.xyz();
-        let ang_impulse = Vector3::new(impulse[3], impulse[4], impulse[5]);
-
-        position2.rotation = Rotation::new(
-            self.ii2
-                .transform_vector(-ang_impulse - r2.gcross(lin_impulse)),
-        ) * position2.rotation;
-        position2.translation.vector -= self.im2 * lin_impulse;
-
-        positions[self.position2 as usize] = position2;
+        return;
     }
 
     pub fn solve2(

--- a/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
@@ -5,7 +5,7 @@ use crate::math::{
     AngDim, AngVector, AngularInertia, Dim, Isometry, Point, Real, Rotation, SpatialVector, Vector,
     DIM,
 };
-use crate::utils::{WAngularInertia, WCross};
+use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
 use na::{Vector3, Vector6};
 
 // FIXME: review this code for the case where the center of masses are not the origin.
@@ -48,16 +48,136 @@ impl GenericPositionConstraint {
     }
 
     pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
-        return;
-    }
+        let mut position1 = positions[self.position1];
+        let mut position2 = positions[self.position2];
+        let mut params = *params;
+        params.joint_erp = 0.8;
 
-    pub fn solve2(
-        &self,
-        params: &IntegrationParameters,
-        positions: &mut [Isometry<Real>],
-        dpos: &mut [DeltaVel<Real>],
-    ) {
-        return;
+        /*
+         *
+         * Translation part.
+         *
+         */
+        {
+            let anchor1 = position1 * self.joint.local_anchor1;
+            let anchor2 = position2 * self.joint.local_anchor2;
+            let basis = anchor1.rotation;
+            let r1 = Point::from(anchor1.translation.vector) - position1 * self.local_com1;
+            let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
+            let mut min_pos_impulse = self.joint.min_pos_impulse.xyz();
+            let mut max_pos_impulse = self.joint.max_pos_impulse.xyz();
+
+            let pos_rhs = GenericVelocityConstraint::compute_lin_position_error(
+                &anchor1,
+                &anchor2,
+                &basis,
+                &self.joint.min_position.xyz(),
+                &self.joint.max_position.xyz(),
+            ) * params.joint_erp;
+
+            for i in 0..3 {
+                if pos_rhs[i] < 0.0 {
+                    min_pos_impulse[i] = -Real::MAX;
+                }
+                if pos_rhs[i] > 0.0 {
+                    max_pos_impulse[i] = Real::MAX;
+                }
+            }
+
+            let rotmat = basis.to_rotation_matrix().into_inner();
+            let rmat1 = r1.gcross_matrix() * rotmat;
+            let rmat2 = r2.gcross_matrix() * rotmat;
+
+            // Will be actually inverted right after.
+            // TODO: we should keep the SdpMatrix3 type.
+            let delassus = (self.ii1.quadform(&rmat1).add_diagonal(self.im1)
+                + self.ii2.quadform(&rmat2).add_diagonal(self.im2))
+            .into_matrix();
+
+            let inv_delassus = GenericVelocityConstraint::invert_partial_delassus_matrix(
+                &min_pos_impulse,
+                &max_pos_impulse,
+                &mut Vector3::zeros(),
+                delassus,
+            );
+
+            let local_impulse = (inv_delassus * pos_rhs)
+                .inf(&max_pos_impulse)
+                .sup(&min_pos_impulse);
+            let impulse = basis * local_impulse;
+
+            let rot1 = self.ii1.transform_vector(r1.gcross(impulse));
+            let rot2 = self.ii2.transform_vector(r2.gcross(impulse));
+
+            position1.translation.vector += self.im1 * impulse;
+            position1.rotation = position1.rotation.append_axisangle_linearized(&rot1);
+            position2.translation.vector -= self.im2 * impulse;
+            position2.rotation = position2.rotation.append_axisangle_linearized(&-rot2);
+        }
+
+        /*
+         *
+         * Rotation part
+         *
+         */
+        {
+            let anchor1 = position1 * self.joint.local_anchor1;
+            let anchor2 = position2 * self.joint.local_anchor2;
+            let basis = anchor1.rotation;
+            let mut min_pos_impulse = self
+                .joint
+                .min_pos_impulse
+                .fixed_rows::<Dim>(DIM)
+                .into_owned();
+            let mut max_pos_impulse = self
+                .joint
+                .max_pos_impulse
+                .fixed_rows::<Dim>(DIM)
+                .into_owned();
+
+            let pos_rhs = GenericVelocityConstraint::compute_ang_position_error(
+                &anchor1,
+                &anchor2,
+                &basis,
+                &self.joint.min_position.fixed_rows::<Dim>(DIM).into_owned(),
+                &self.joint.max_position.fixed_rows::<Dim>(DIM).into_owned(),
+            ) * params.joint_erp;
+
+            for i in 0..3 {
+                if pos_rhs[i] < 0.0 {
+                    min_pos_impulse[i] = -Real::MAX;
+                }
+                if pos_rhs[i] > 0.0 {
+                    max_pos_impulse[i] = Real::MAX;
+                }
+            }
+
+            // Will be actually inverted right after.
+            // TODO: we should keep the SdpMatrix3 type.
+            let rotmat = basis.to_rotation_matrix().into_inner();
+            let delassus = (self.ii1.quadform(&rotmat) + self.ii2.quadform(&rotmat)).into_matrix();
+
+            let inv_delassus = GenericVelocityConstraint::invert_partial_delassus_matrix(
+                &min_pos_impulse,
+                &max_pos_impulse,
+                &mut Vector3::zeros(),
+                delassus,
+            );
+
+            let local_impulse = (inv_delassus * pos_rhs)
+                .inf(&max_pos_impulse)
+                .sup(&min_pos_impulse);
+            let impulse = basis * local_impulse;
+
+            let rot1 = self.ii1.transform_vector(impulse);
+            let rot2 = self.ii2.transform_vector(impulse);
+
+            position1.rotation = position1.rotation.append_axisangle_linearized(&rot1);
+            position2.rotation = position2.rotation.append_axisangle_linearized(&-rot2);
+        }
+
+        positions[self.position1] = position1;
+        positions[self.position2] = position2;
     }
 }
 
@@ -102,15 +222,127 @@ impl GenericPositionGroundConstraint {
     }
 
     pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
-        return;
-    }
+        let mut position2 = positions[self.position2];
+        let mut params = *params;
+        params.joint_erp = 0.8;
 
-    pub fn solve2(
-        &self,
-        params: &IntegrationParameters,
-        positions: &mut [Isometry<Real>],
-        dpos: &mut [DeltaVel<Real>],
-    ) {
-        return;
+        /*
+         *
+         * Translation part.
+         *
+         */
+        {
+            let anchor1 = self.anchor1;
+            let anchor2 = position2 * self.local_anchor2;
+            let basis = anchor1.rotation;
+            let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
+            let mut min_pos_impulse = self.joint.min_pos_impulse.xyz();
+            let mut max_pos_impulse = self.joint.max_pos_impulse.xyz();
+
+            let pos_rhs = GenericVelocityConstraint::compute_lin_position_error(
+                &anchor1,
+                &anchor2,
+                &basis,
+                &self.joint.min_position.xyz(),
+                &self.joint.max_position.xyz(),
+            ) * params.joint_erp;
+
+            for i in 0..3 {
+                if pos_rhs[i] < 0.0 {
+                    min_pos_impulse[i] = -Real::MAX;
+                }
+                if pos_rhs[i] > 0.0 {
+                    max_pos_impulse[i] = Real::MAX;
+                }
+            }
+
+            let rotmat = basis.to_rotation_matrix().into_inner();
+            let rmat2 = r2.gcross_matrix() * rotmat;
+
+            // Will be actually inverted right after.
+            // TODO: we should keep the SdpMatrix3 type.
+            let delassus = self
+                .ii2
+                .quadform(&rmat2)
+                .add_diagonal(self.im2)
+                .into_matrix();
+
+            let inv_delassus = GenericVelocityConstraint::invert_partial_delassus_matrix(
+                &min_pos_impulse,
+                &max_pos_impulse,
+                &mut Vector3::zeros(),
+                delassus,
+            );
+
+            let local_impulse = (inv_delassus * pos_rhs)
+                .inf(&max_pos_impulse)
+                .sup(&min_pos_impulse);
+            let impulse = basis * local_impulse;
+
+            let rot2 = self.ii2.transform_vector(r2.gcross(impulse));
+
+            position2.translation.vector -= self.im2 * impulse;
+            position2.rotation = position2.rotation.append_axisangle_linearized(&-rot2);
+        }
+
+        /*
+         *
+         * Rotation part
+         *
+         */
+        {
+            let anchor1 = self.anchor1;
+            let anchor2 = position2 * self.local_anchor2;
+            let basis = anchor1.rotation;
+            let mut min_pos_impulse = self
+                .joint
+                .min_pos_impulse
+                .fixed_rows::<Dim>(DIM)
+                .into_owned();
+            let mut max_pos_impulse = self
+                .joint
+                .max_pos_impulse
+                .fixed_rows::<Dim>(DIM)
+                .into_owned();
+
+            let pos_rhs = GenericVelocityConstraint::compute_ang_position_error(
+                &anchor1,
+                &anchor2,
+                &basis,
+                &self.joint.min_position.fixed_rows::<Dim>(DIM).into_owned(),
+                &self.joint.max_position.fixed_rows::<Dim>(DIM).into_owned(),
+            ) * params.joint_erp;
+
+            for i in 0..3 {
+                if pos_rhs[i] < 0.0 {
+                    min_pos_impulse[i] = -Real::MAX;
+                }
+                if pos_rhs[i] > 0.0 {
+                    max_pos_impulse[i] = Real::MAX;
+                }
+            }
+
+            // Will be actually inverted right after.
+            // TODO: we should keep the SdpMatrix3 type.
+            let rotmat = basis.to_rotation_matrix().into_inner();
+            let delassus = self.ii2.quadform(&rotmat).into_matrix();
+
+            let inv_delassus = GenericVelocityConstraint::invert_partial_delassus_matrix(
+                &min_pos_impulse,
+                &max_pos_impulse,
+                &mut Vector3::zeros(),
+                delassus,
+            );
+
+            let local_impulse = (inv_delassus * pos_rhs)
+                .inf(&max_pos_impulse)
+                .sup(&min_pos_impulse);
+            let impulse = basis * local_impulse;
+            let rot2 = self.ii2.transform_vector(impulse);
+
+            position2.rotation = position2.rotation.append_axisangle_linearized(&-rot2);
+        }
+
+        positions[self.position2] = position2;
     }
 }

--- a/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_position_constraint.rs
@@ -1,0 +1,171 @@
+use super::{GenericVelocityConstraint, GenericVelocityGroundConstraint};
+use crate::dynamics::{GenericJoint, IntegrationParameters, RigidBody};
+use crate::math::{
+    AngDim, AngVector, AngularInertia, Dim, Isometry, Point, Real, Rotation, SpatialVector, Vector,
+    DIM,
+};
+use crate::utils::{WAngularInertia, WCross};
+use na::{Vector3, Vector6};
+
+// FIXME: review this code for the case where the center of masses are not the origin.
+#[derive(Debug)]
+pub(crate) struct GenericPositionConstraint {
+    position1: usize,
+    position2: usize,
+    local_anchor1: Isometry<Real>,
+    local_anchor2: Isometry<Real>,
+    local_com1: Point<Real>,
+    local_com2: Point<Real>,
+    im1: Real,
+    im2: Real,
+    ii1: AngularInertia<Real>,
+    ii2: AngularInertia<Real>,
+
+    joint: GenericJoint,
+
+    lin_impulse: Cell<Vector3<Real>>,
+    ang_impulse: Cell<Vector3<Real>>,
+}
+
+impl GenericPositionConstraint {
+    pub fn from_params(rb1: &RigidBody, rb2: &RigidBody, joint: &GenericJoint) -> Self {
+        let ii1 = rb1.effective_world_inv_inertia_sqrt.squared();
+        let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+        let im1 = rb1.effective_inv_mass;
+        let im2 = rb2.effective_inv_mass;
+
+        Self {
+            local_anchor1: joint.local_anchor1,
+            local_anchor2: joint.local_anchor2,
+            position1: rb1.active_set_offset,
+            position2: rb2.active_set_offset,
+            im1,
+            im2,
+            ii1,
+            ii2,
+            local_com1: rb1.mass_properties.local_com,
+            local_com2: rb2.mass_properties.local_com,
+            joint: *joint,
+        }
+    }
+
+    pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
+        let mut position1 = positions[self.position1 as usize];
+        let mut position2 = positions[self.position2 as usize];
+
+        let anchor1 = position1 * self.local_anchor1;
+        let anchor2 = position2 * self.local_anchor2;
+        let r1 = Point::from(anchor1.translation.vector) - position1 * self.local_com1;
+        let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
+
+        let delta_pos = anchor1.inverse() * anchor2;
+        let mass_matrix = GenericVelocityConstraint::compute_mass_matrix(
+            &self.joint,
+            self.im1,
+            self.im2,
+            self.ii1,
+            self.ii2,
+            r1,
+            r2,
+            false,
+        );
+
+        let lin_err = delta_pos.translation.vector * params.joint_erp;
+        let ang_err = delta_pos.rotation.scaled_axis() * params.joint_erp;
+        let err = Vector6::new(
+            lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
+        );
+        let impulse = mass_matrix * err;
+        let lin_impulse = impulse.xyz();
+        let ang_impulse = Vector3::new(impulse[3], impulse[4], impulse[5]);
+
+        position1.rotation = Rotation::new(
+            self.ii1
+                .transform_vector(ang_impulse + r1.gcross(lin_impulse)),
+        ) * position1.rotation;
+        position2.rotation = Rotation::new(
+            self.ii2
+                .transform_vector(-ang_impulse - r2.gcross(lin_impulse)),
+        ) * position2.rotation;
+
+        position1.translation.vector += self.im1 * lin_impulse;
+        position2.translation.vector -= self.im2 * lin_impulse;
+
+        positions[self.position1 as usize] = position1;
+        positions[self.position2 as usize] = position2;
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GenericPositionGroundConstraint {
+    position2: usize,
+    anchor1: Isometry<Real>,
+    local_anchor2: Isometry<Real>,
+    local_com2: Point<Real>,
+    im2: Real,
+    ii2: AngularInertia<Real>,
+    joint: GenericJoint,
+}
+
+impl GenericPositionGroundConstraint {
+    pub fn from_params(
+        rb1: &RigidBody,
+        rb2: &RigidBody,
+        joint: &GenericJoint,
+        flipped: bool,
+    ) -> Self {
+        let anchor1;
+        let local_anchor2;
+
+        if flipped {
+            anchor1 = rb1.predicted_position * joint.local_anchor2;
+            local_anchor2 = joint.local_anchor1;
+        } else {
+            anchor1 = rb1.predicted_position * joint.local_anchor1;
+            local_anchor2 = joint.local_anchor2;
+        };
+
+        Self {
+            anchor1,
+            local_anchor2,
+            position2: rb2.active_set_offset,
+            im2: rb2.effective_inv_mass,
+            ii2: rb2.effective_world_inv_inertia_sqrt.squared(),
+            local_com2: rb2.mass_properties.local_com,
+            joint: *joint,
+        }
+    }
+
+    pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
+        let mut position2 = positions[self.position2 as usize];
+
+        let anchor2 = position2 * self.local_anchor2;
+        let r2 = Point::from(anchor2.translation.vector) - position2 * self.local_com2;
+
+        let delta_pos = self.anchor1.inverse() * anchor2;
+        let mass_matrix = GenericVelocityGroundConstraint::compute_mass_matrix(
+            &self.joint,
+            self.im2,
+            self.ii2,
+            r2,
+            false,
+        );
+
+        let lin_err = delta_pos.translation.vector * params.joint_erp;
+        let ang_err = Vector3::zeros(); // delta_pos.rotation.scaled_axis() * params.joint_erp;
+        let err = Vector6::new(
+            lin_err.x, lin_err.y, lin_err.z, ang_err.x, ang_err.y, ang_err.z,
+        );
+        let impulse = mass_matrix * err;
+        let lin_impulse = impulse.xyz();
+        let ang_impulse = Vector3::new(impulse[3], impulse[4], impulse[5]);
+
+        position2.rotation = Rotation::new(
+            self.ii2
+                .transform_vector(-ang_impulse - r2.gcross(lin_impulse)),
+        ) * position2.rotation;
+        position2.translation.vector -= self.im2 * lin_impulse;
+
+        positions[self.position2 as usize] = position2;
+    }
+}

--- a/src/dynamics/solver/joint_constraint/generic_position_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/generic_position_constraint_wide.rs
@@ -1,0 +1,51 @@
+use super::{GenericPositionConstraint, GenericPositionGroundConstraint};
+use crate::dynamics::{GenericJoint, IntegrationParameters, RigidBody};
+use crate::math::{Isometry, Real, SIMD_WIDTH};
+
+// TODO: this does not uses SIMD optimizations yet.
+#[derive(Debug)]
+pub(crate) struct WGenericPositionConstraint {
+    constraints: [GenericPositionConstraint; SIMD_WIDTH],
+}
+
+impl WGenericPositionConstraint {
+    pub fn from_params(
+        rbs1: [&RigidBody; SIMD_WIDTH],
+        rbs2: [&RigidBody; SIMD_WIDTH],
+        cparams: [&GenericJoint; SIMD_WIDTH],
+    ) -> Self {
+        Self {
+            constraints: array![|ii| GenericPositionConstraint::from_params(rbs1[ii], rbs2[ii], cparams[ii]); SIMD_WIDTH],
+        }
+    }
+
+    pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
+        for constraint in &self.constraints {
+            constraint.solve(params, positions);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WGenericPositionGroundConstraint {
+    constraints: [GenericPositionGroundConstraint; SIMD_WIDTH],
+}
+
+impl WGenericPositionGroundConstraint {
+    pub fn from_params(
+        rbs1: [&RigidBody; SIMD_WIDTH],
+        rbs2: [&RigidBody; SIMD_WIDTH],
+        cparams: [&GenericJoint; SIMD_WIDTH],
+        flipped: [bool; SIMD_WIDTH],
+    ) -> Self {
+        Self {
+            constraints: array![|ii| GenericPositionGroundConstraint::from_params(rbs1[ii], rbs2[ii], cparams[ii], flipped[ii]); SIMD_WIDTH],
+        }
+    }
+
+    pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
+        for constraint in &self.constraints {
+            constraint.solve(params, positions);
+        }
+    }
+}

--- a/src/dynamics/solver/joint_constraint/generic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_velocity_constraint.rs
@@ -1,0 +1,460 @@
+use crate::dynamics::solver::DeltaVel;
+use crate::dynamics::{
+    GenericJoint, IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RigidBody,
+};
+use crate::math::{AngularInertia, Dim, Real, SpacialVector, Vector};
+use crate::parry::math::SpatialVector;
+use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
+#[cfg(feature = "dim2")]
+use na::{Matrix3, Vector3};
+#[cfg(feature = "dim3")]
+use na::{Matrix6, Vector6, U3};
+
+#[derive(Debug)]
+pub(crate) struct GenericVelocityConstraint {
+    mj_lambda1: usize,
+    mj_lambda2: usize,
+
+    joint_id: JointIndex,
+
+    impulse: SpacialVector<Real>,
+    max_positive_impulse: SpatialVector<Real>,
+    max_negative_impulse: SpatialVector<Real>,
+
+    #[cfg(feature = "dim3")]
+    inv_lhs: Matrix6<Real>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim3")]
+    rhs: Vector6<Real>,
+
+    #[cfg(feature = "dim2")]
+    inv_lhs: Matrix3<Real>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim2")]
+    rhs: Vector3<Real>,
+
+    im1: Real,
+    im2: Real,
+
+    ii1: AngularInertia<Real>,
+    ii2: AngularInertia<Real>,
+
+    ii1_sqrt: AngularInertia<Real>,
+    ii2_sqrt: AngularInertia<Real>,
+
+    r1: Vector<Real>,
+    r2: Vector<Real>,
+}
+
+impl GenericVelocityConstraint {
+    #[inline(always)]
+    pub fn compute_mass_matrix(
+        joint: &GenericJoint,
+        im1: Real,
+        im2: Real,
+        ii1: AngularInertia<Real>,
+        ii2: AngularInertia<Real>,
+        r1: Vector<Real>,
+        r2: Vector<Real>,
+        velocity_solver: bool,
+    ) -> Matrix6<Real> {
+        let rmat1 = r1.gcross_matrix();
+        let rmat2 = r2.gcross_matrix();
+
+        #[allow(unused_mut)] // For 2D
+        let mut lhs;
+
+        #[cfg(feature = "dim3")]
+        {
+            let lhs00 =
+                ii1.quadform(&rmat1).add_diagonal(im1) + ii2.quadform(&rmat2).add_diagonal(im2);
+            let lhs10 = ii1.transform_matrix(&rmat1) + ii2.transform_matrix(&rmat2);
+            let lhs11 = (ii1 + ii2).into_matrix();
+
+            // Note that Cholesky only reads the lower-triangular part of the matrix
+            // so we don't need to fill lhs01.
+            lhs = Matrix6::zeros();
+            lhs.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&lhs00.into_matrix());
+            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
+            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
+
+            // Adjust the mass matrix to take force limits into account.
+            // If a DoF has a force limit, then we need to make its
+            // constraint independent from the others because otherwise
+            // the force clamping will cause errors to propagate in the
+            // other constraints.
+            if velocity_solver {
+                for i in 0..6 {
+                    if joint.max_negative_impulse[i] > -Real::MAX
+                        || joint.max_positive_impulse[i] < Real::MAX
+                    {
+                        let diag = lhs[(i, i)];
+                        lhs.row_mut(i).fill(0.0);
+                        lhs[(i, i)] = diag;
+                    }
+                }
+            } else {
+                for i in 0..6 {
+                    let diag = lhs[(i, i)];
+                    lhs.row_mut(i).fill(0.0);
+                    lhs[(i, i)] = diag;
+                }
+            }
+        }
+
+        // In 2D we just unroll the computation because
+        // it's just easier that way.
+        #[cfg(feature = "dim2")]
+        {
+            let m11 = im1 + im2 + rmat1.x * rmat1.x * ii1 + rmat2.x * rmat2.x * ii2;
+            let m12 = rmat1.x * rmat1.y * ii1 + rmat2.x * rmat2.y * ii2;
+            let m22 = im1 + im2 + rmat1.y * rmat1.y * ii1 + rmat2.y * rmat2.y * ii2;
+            let m13 = rmat1.x * ii1 + rmat2.x * ii2;
+            let m23 = rmat1.y * ii1 + rmat2.y * ii2;
+            let m33 = ii1 + ii2;
+            lhs = Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
+        }
+
+        // NOTE: we don't use Cholesky in 2D because we only have a 3x3 matrix
+        // for which a textbook inverse is still efficient.
+        #[cfg(feature = "dim2")]
+        return lhs.try_inverse().expect("Singular system.");
+        #[cfg(feature = "dim3")]
+        return lhs.cholesky().expect("Singular system.").inverse();
+    }
+
+    pub fn from_params(
+        params: &IntegrationParameters,
+        joint_id: JointIndex,
+        rb1: &RigidBody,
+        rb2: &RigidBody,
+        joint: &GenericJoint,
+    ) -> Self {
+        let anchor1 = rb1.position * joint.local_anchor1;
+        let anchor2 = rb2.position * joint.local_anchor2;
+        let im1 = rb1.effective_inv_mass;
+        let im2 = rb2.effective_inv_mass;
+        let ii1 = rb1.effective_world_inv_inertia_sqrt.squared();
+        let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+        let r1 = anchor1.translation.vector - rb1.world_com.coords;
+        let r2 = anchor2.translation.vector - rb2.world_com.coords;
+
+        let lin_dvel = -rb1.linvel - rb1.angvel.gcross(r1) + rb2.linvel + rb2.angvel.gcross(r2);
+        let ang_dvel = -rb1.angvel + rb2.angvel;
+
+        let inv_lhs = Self::compute_mass_matrix(joint, im1, im2, ii1, ii2, r1, r2, true);
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        );
+
+        let impulse = (joint.impulse * params.warmstart_coeff)
+            .inf(&joint.max_positive_impulse)
+            .sup(&joint.max_negative_impulse);
+
+        GenericVelocityConstraint {
+            joint_id,
+            mj_lambda1: rb1.active_set_offset,
+            mj_lambda2: rb2.active_set_offset,
+            im1,
+            im2,
+            ii1,
+            ii2,
+            ii1_sqrt: rb1.effective_world_inv_inertia_sqrt,
+            ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
+            impulse,
+            max_positive_impulse: joint.max_positive_impulse,
+            max_negative_impulse: joint.max_negative_impulse,
+            inv_lhs,
+            r1,
+            r2,
+            rhs,
+        }
+    }
+
+    pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda1 = mj_lambdas[self.mj_lambda1 as usize];
+        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
+
+        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = self.impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda1.linear += self.im1 * lin_impulse;
+        mj_lambda1.angular += self
+            .ii1_sqrt
+            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
+
+        mj_lambda2.linear -= self.im2 * lin_impulse;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
+        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
+    }
+
+    pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda1 = mj_lambdas[self.mj_lambda1 as usize];
+        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
+
+        let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
+        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+        let dlinvel = -mj_lambda1.linear - ang_vel1.gcross(self.r1)
+            + mj_lambda2.linear
+            + ang_vel2.gcross(self.r2);
+        let dangvel = -ang_vel1 + ang_vel2;
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
+        #[cfg(feature = "dim3")]
+        let dvel = Vector6::new(
+            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
+        ) + self.rhs;
+
+        let new_impulse = (self.impulse + self.inv_lhs * dvel)
+            .sup(&self.max_negative_impulse)
+            .inf(&self.max_positive_impulse);
+        let effective_impulse = new_impulse - self.impulse;
+        self.impulse = new_impulse;
+
+        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = effective_impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda1.linear += self.im1 * lin_impulse;
+        mj_lambda1.angular += self
+            .ii1_sqrt
+            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
+
+        mj_lambda2.linear -= self.im2 * lin_impulse;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
+        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
+    }
+
+    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
+        let joint = &mut joints_all[self.joint_id].weight;
+        if let JointParams::GenericJoint(fixed) = &mut joint.params {
+            fixed.impulse = self.impulse;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GenericVelocityGroundConstraint {
+    mj_lambda2: usize,
+
+    joint_id: JointIndex,
+
+    impulse: SpacialVector<Real>,
+    max_positive_impulse: SpatialVector<Real>,
+    max_negative_impulse: SpatialVector<Real>,
+
+    #[cfg(feature = "dim3")]
+    inv_lhs: Matrix6<Real>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim3")]
+    rhs: Vector6<Real>,
+
+    #[cfg(feature = "dim2")]
+    inv_lhs: Matrix3<Real>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim2")]
+    rhs: Vector3<Real>,
+
+    im2: Real,
+    ii2: AngularInertia<Real>,
+    ii2_sqrt: AngularInertia<Real>,
+    r2: Vector<Real>,
+}
+
+impl GenericVelocityGroundConstraint {
+    #[inline(always)]
+    pub fn compute_mass_matrix(
+        joint: &GenericJoint,
+        im2: Real,
+        ii2: AngularInertia<Real>,
+        r2: Vector<Real>,
+        velocity_solver: bool,
+    ) -> Matrix6<Real> {
+        let rmat2 = r2.gcross_matrix();
+
+        #[allow(unused_mut)] // For 2D.
+        let mut lhs;
+
+        #[cfg(feature = "dim3")]
+        {
+            let lhs00 = ii2.quadform(&rmat2).add_diagonal(im2);
+            let lhs10 = ii2.transform_matrix(&rmat2);
+            let lhs11 = ii2.into_matrix();
+
+            // Note that Cholesky only reads the lower-triangular part of the matrix
+            // so we don't need to fill lhs01.
+            lhs = Matrix6::zeros();
+            lhs.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&lhs00.into_matrix());
+            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
+            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
+
+            // Adjust the mass matrix to take force limits into account.
+            // If a DoF has a force limit, then we need to make its
+            // constraint independent from the others because otherwise
+            // the force clamping will cause errors to propagate in the
+            // other constraints.
+            if velocity_solver {
+                for i in 0..6 {
+                    if joint.max_negative_impulse[i] > -Real::MAX
+                        || joint.max_positive_impulse[i] < Real::MAX
+                    {
+                        let diag = lhs[(i, i)];
+                        lhs.row_mut(i).fill(0.0);
+                        lhs[(i, i)] = diag;
+                    }
+                }
+            }
+        }
+
+        // In 2D we just unroll the computation because
+        // it's just easier that way.
+        #[cfg(feature = "dim2")]
+        {
+            let m11 = im2 + rmat2.x * rmat2.x * ii2;
+            let m12 = rmat2.x * rmat2.y * ii2;
+            let m22 = im2 + rmat2.y * rmat2.y * ii2;
+            let m13 = rmat2.x * ii2;
+            let m23 = rmat2.y * ii2;
+            let m33 = ii2;
+            lhs = Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
+        }
+
+        #[cfg(feature = "dim2")]
+        return lhs.try_inverse().expect("Singular system.");
+        #[cfg(feature = "dim3")]
+        return lhs.cholesky().expect("Singular system.").inverse();
+    }
+
+    pub fn from_params(
+        params: &IntegrationParameters,
+        joint_id: JointIndex,
+        rb1: &RigidBody,
+        rb2: &RigidBody,
+        joint: &GenericJoint,
+        flipped: bool,
+    ) -> Self {
+        let (anchor1, anchor2) = if flipped {
+            (
+                rb1.position * joint.local_anchor2,
+                rb2.position * joint.local_anchor1,
+            )
+        } else {
+            (
+                rb1.position * joint.local_anchor1,
+                rb2.position * joint.local_anchor2,
+            )
+        };
+
+        let r1 = anchor1.translation.vector - rb1.world_com.coords;
+        let im2 = rb2.effective_inv_mass;
+        let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+        let r2 = anchor2.translation.vector - rb2.world_com.coords;
+
+        let inv_lhs = Self::compute_mass_matrix(joint, im2, ii2, r2, true);
+
+        let lin_dvel = rb2.linvel + rb2.angvel.gcross(r2) - rb1.linvel - rb1.angvel.gcross(r1);
+        let ang_dvel = rb2.angvel - rb1.angvel;
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        );
+
+        let impulse = (joint.impulse * params.warmstart_coeff)
+            .inf(&joint.max_positive_impulse)
+            .sup(&joint.max_negative_impulse);
+
+        GenericVelocityGroundConstraint {
+            joint_id,
+            mj_lambda2: rb2.active_set_offset,
+            im2,
+            ii2,
+            ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
+            impulse,
+            max_positive_impulse: joint.max_positive_impulse,
+            max_negative_impulse: joint.max_negative_impulse,
+            inv_lhs,
+            r2,
+            rhs,
+        }
+    }
+
+    pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
+
+        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = self.impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda2.linear -= self.im2 * lin_impulse;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
+    }
+
+    pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
+
+        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+        let dlinvel = mj_lambda2.linear + ang_vel2.gcross(self.r2);
+        let dangvel = ang_vel2;
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
+        #[cfg(feature = "dim3")]
+        let dvel = Vector6::new(
+            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
+        ) + self.rhs;
+
+        let new_impulse = (self.impulse + self.inv_lhs * dvel)
+            .sup(&self.max_negative_impulse)
+            .inf(&self.max_positive_impulse);
+        let effective_impulse = new_impulse - self.impulse;
+        self.impulse = new_impulse;
+
+        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = effective_impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda2.linear -= self.im2 * lin_impulse;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
+    }
+
+    // FIXME: duplicated code with the non-ground constraint.
+    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
+        let joint = &mut joints_all[self.joint_id].weight;
+        if let JointParams::GenericJoint(fixed) = &mut joint.params {
+            fixed.impulse = self.impulse;
+        }
+    }
+}

--- a/src/dynamics/solver/joint_constraint/generic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/generic_velocity_constraint.rs
@@ -2,7 +2,8 @@ use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{
     GenericJoint, IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RigidBody,
 };
-use crate::math::{AngularInertia, Dim, Isometry, Real, SpacialVector, Vector, DIM};
+use crate::math::{AngularInertia, Dim, Isometry, Real, Rotation, SpacialVector, Vector, DIM};
+use crate::na::UnitQuaternion;
 use crate::parry::math::{AngDim, SpatialVector};
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
 #[cfg(feature = "dim2")]
@@ -17,23 +18,10 @@ pub(crate) struct GenericVelocityConstraint {
 
     joint_id: JointIndex,
 
-    impulse: SpacialVector<Real>,
-    pos_impulse: SpacialVector<Real>,
-
-    max_positive_impulse: SpatialVector<Real>,
-    max_negative_impulse: SpatialVector<Real>,
-
     #[cfg(feature = "dim3")]
-    inv_lhs: Matrix6<Real>, // FIXME: replace by Cholesky.
-    #[cfg(feature = "dim3")]
-    rhs: Vector6<Real>,
-
+    inv_lhs: Matrix6<Real>, // TODO: replace by Cholesky?
     #[cfg(feature = "dim2")]
-    inv_lhs: Matrix3<Real>, // FIXME: replace by Cholesky.
-    #[cfg(feature = "dim2")]
-    rhs: Vector3<Real>,
-
-    pos_rhs: Vector6<Real>,
+    inv_lhs: Matrix3<Real>,
 
     im1: Real,
     im2: Real,
@@ -46,79 +34,147 @@ pub(crate) struct GenericVelocityConstraint {
 
     r1: Vector<Real>,
     r2: Vector<Real>,
+    rot2: Rotation<Real>,
+
+    vel: GenericConstraintPart,
+    pos: GenericConstraintPart,
 }
 
 impl GenericVelocityConstraint {
     #[inline(always)]
-    pub fn compute_mass_matrix(
-        joint: &GenericJoint,
+    pub fn compute_delassus_matrix(
         im1: Real,
         im2: Real,
         ii1: AngularInertia<Real>,
         ii2: AngularInertia<Real>,
         r1: Vector<Real>,
         r2: Vector<Real>,
-        velocity_solver: bool,
+        rot2: Rotation<Real>,
     ) -> Matrix6<Real> {
-        let rmat1 = r1.gcross_matrix();
-        let rmat2 = r2.gcross_matrix();
-
-        #[allow(unused_mut)] // For 2D
-        let mut lhs;
+        let rotmat = rot2.to_rotation_matrix().into_inner();
+        let rmat1 = r1.gcross_matrix() * rotmat;
+        let rmat2 = r2.gcross_matrix() * rotmat;
 
         #[cfg(feature = "dim3")]
         {
-            let lhs00 =
+            let del00 =
                 ii1.quadform(&rmat1).add_diagonal(im1) + ii2.quadform(&rmat2).add_diagonal(im2);
-            let lhs10 = ii1.transform_matrix(&rmat1) + ii2.transform_matrix(&rmat2);
-            let lhs11 = (ii1 + ii2).into_matrix();
+            let del10 =
+                rotmat.transpose() * (ii1.transform_matrix(&rmat1) + ii2.transform_matrix(&rmat2));
+            let del11 = (ii1 + ii2).quadform(&rotmat).into_matrix();
 
             // Note that Cholesky only reads the lower-triangular part of the matrix
-            // so we don't need to fill lhs01.
-            lhs = Matrix6::zeros();
-            lhs.fixed_slice_mut::<U3, U3>(0, 0)
-                .copy_from(&lhs00.into_matrix());
-            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
-            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
-
-            // Adjust the mass matrix to take force limits into account.
-            // If a DoF has a force limit, then we need to make its
-            // constraint independent from the others because otherwise
-            // the force clamping will cause errors to propagate in the
-            // other constraints.
-            if velocity_solver {
-                for i in 0..6 {
-                    if joint.max_negative_impulse[i] > -Real::MAX
-                        || joint.max_positive_impulse[i] < Real::MAX
-                    {
-                        let diag = lhs[(i, i)];
-                        lhs.column_mut(i).fill(0.0);
-                        lhs.row_mut(i).fill(0.0);
-                        lhs[(i, i)] = diag;
-                    }
-                }
-            }
+            // so we don't need to fill del01.
+            let mut del = Matrix6::zeros();
+            del.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&del00.into_matrix());
+            del.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&del10);
+            del.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&del11);
+            del
         }
 
         // In 2D we just unroll the computation because
         // it's just easier that way.
         #[cfg(feature = "dim2")]
         {
+            panic!("Take the rotmat into account.");
             let m11 = im1 + im2 + rmat1.x * rmat1.x * ii1 + rmat2.x * rmat2.x * ii2;
             let m12 = rmat1.x * rmat1.y * ii1 + rmat2.x * rmat2.y * ii2;
             let m22 = im1 + im2 + rmat1.y * rmat1.y * ii1 + rmat2.y * rmat2.y * ii2;
             let m13 = rmat1.x * ii1 + rmat2.x * ii2;
             let m23 = rmat1.y * ii1 + rmat2.y * ii2;
             let m33 = ii1 + ii2;
-            lhs = Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
+            Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
         }
+    }
 
-        // NOTE: we don't use Cholesky in 2D because we only have a 3x3 matrix
-        // for which a textbook inverse is still efficient.
+    pub fn compute_velocity_error(
+        min_velocity: &SpatialVector<Real>,
+        max_velocity: &SpatialVector<Real>,
+        r1: &Vector<Real>,
+        r2: &Vector<Real>,
+        _anchor1: &Isometry<Real>,
+        anchor2: &Isometry<Real>,
+        rb1: &RigidBody,
+        rb2: &RigidBody,
+    ) -> SpatialVector<Real> {
+        let lin_dvel = -rb1.linvel - rb1.angvel.gcross(*r1) + rb2.linvel + rb2.angvel.gcross(*r2);
+        let ang_dvel = -rb1.angvel + rb2.angvel;
+
+        let lin_dvel2 = anchor2.inverse_transform_vector(&lin_dvel);
+        let ang_dvel2 = anchor2.inverse_transform_vector(&ang_dvel);
+
+        dbg!(lin_dvel);
+        dbg!(lin_dvel2);
+
+        let min_linvel = min_velocity.xyz();
+        let min_angvel = min_velocity.fixed_rows::<AngDim>(DIM).into_owned();
+        let max_linvel = max_velocity.xyz();
+        let max_angvel = max_velocity.fixed_rows::<AngDim>(DIM).into_owned();
+        let lin_rhs = lin_dvel2 - lin_dvel2.sup(&min_linvel).inf(&max_linvel);
+        let ang_rhs = ang_dvel2 - ang_dvel2.sup(&min_angvel).inf(&max_angvel);
+
         #[cfg(feature = "dim2")]
-        return lhs.try_inverse().expect("Singular system.");
+        return Vector3::new(lin_rhs.x, lin_rhs.y, ang_rhs);
+
         #[cfg(feature = "dim3")]
-        return lhs.cholesky().expect("Singular system.").inverse();
+        return Vector6::new(
+            lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y, ang_rhs.z,
+        );
+    }
+
+    pub fn compute_position_error(
+        joint: &GenericJoint,
+        anchor1: &Isometry<Real>,
+        anchor2: &Isometry<Real>,
+    ) -> SpatialVector<Real> {
+        let delta_pos = Isometry::from_parts(
+            anchor2.translation * anchor1.translation.inverse(),
+            anchor2.rotation * anchor1.rotation.inverse(),
+        );
+        let lin_dpos = anchor2.inverse_transform_vector(&delta_pos.translation.vector);
+        let ang_dpos = anchor2.inverse_transform_vector(&delta_pos.rotation.scaled_axis());
+
+        let dpos = Vector6::new(
+            lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
+        );
+
+        let error = dpos - dpos.sup(&joint.min_position).inf(&joint.max_position);
+        let error_code =
+            (error[3] == 0.0) as usize + (error[4] == 0.0) as usize + (error[5] == 0.0) as usize;
+
+        match error_code {
+            0 => error,
+            1 => {
+                let constrained_axis = error.rows(3, 3).iamin();
+                let axis1 = anchor1
+                    .rotation
+                    .to_rotation_matrix()
+                    .into_inner()
+                    .column(constrained_axis)
+                    .into_owned();
+                let axis2 = anchor2
+                    .rotation
+                    .to_rotation_matrix()
+                    .into_inner()
+                    .column(constrained_axis)
+                    .into_owned();
+                let rot_cross = UnitQuaternion::rotation_between(&axis1, &axis2)
+                    .unwrap_or(UnitQuaternion::identity());
+                let ang_dpos = anchor2.inverse_transform_vector(&rot_cross.scaled_axis());
+                let dpos = Vector6::new(
+                    lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
+                );
+
+                dpos - dpos.sup(&joint.min_position).inf(&joint.max_position)
+            }
+            2 => {
+                // TODO
+                error
+            }
+            3 => error,
+            _ => unreachable!(),
+        }
     }
 
     pub fn from_params(
@@ -136,48 +192,67 @@ impl GenericVelocityConstraint {
         let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
         let r1 = anchor1.translation.vector - rb1.world_com.coords;
         let r2 = anchor2.translation.vector - rb2.world_com.coords;
+        let mut min_impulse = joint.min_impulse;
+        let mut max_impulse = joint.max_impulse;
+        let mut min_pos_impulse = joint.min_pos_impulse;
+        let mut max_pos_impulse = joint.max_pos_impulse;
+        let mut min_velocity = joint.min_velocity;
+        let mut max_velocity = joint.max_velocity;
 
-        let lin_dvel = -rb1.linvel - rb1.angvel.gcross(r1) + rb2.linvel + rb2.angvel.gcross(r2);
-        let ang_dvel = -rb1.angvel + rb2.angvel;
+        let pos_rhs = Self::compute_position_error(joint, &anchor1, &anchor2)
+            * params.inv_dt()
+            * params.joint_erp;
 
-        let inv_lhs = Self::compute_mass_matrix(joint, im1, im2, ii1, ii2, r1, r2, true);
+        for i in 0..6 {
+            if pos_rhs[i] < 0.0 {
+                min_impulse[i] = -Real::MAX;
+                min_pos_impulse[i] = -Real::MAX;
+                min_velocity[i] = 0.0;
+            }
+            if pos_rhs[i] > 0.0 {
+                max_impulse[i] = Real::MAX;
+                max_pos_impulse[i] = Real::MAX;
+                max_velocity[i] = 0.0;
+            }
+        }
 
+        let rhs = Self::compute_velocity_error(
+            &min_velocity,
+            &max_velocity,
+            &r1,
+            &r2,
+            &anchor1,
+            &anchor2,
+            rb1,
+            rb2,
+        );
+
+        let mut delassus =
+            Self::compute_delassus_matrix(im1, im2, ii1, ii2, r1, r2, anchor2.rotation);
+
+        // Adjust the Delassus matrix to take force limits into account.
+        // If a DoF has a force limit, then we need to make its
+        // constraint independent from the others because otherwise
+        // the force clamping will cause errors to propagate in the
+        // other constraints.
+        for i in 0..6 {
+            if min_impulse[i] > -Real::MAX && max_impulse[i] < Real::MAX {
+                let diag = delassus[(i, i)];
+                delassus.column_mut(i).fill(0.0);
+                delassus.row_mut(i).fill(0.0);
+                delassus[(i, i)] = diag;
+            }
+        }
+
+        // NOTE: we don't use Cholesky in 2D because we only have a 3x3 matrix.
         #[cfg(feature = "dim2")]
-        let dvel = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
-
+        let inv_lhs = delassus.try_inverse().expect("Singular system.");
         #[cfg(feature = "dim3")]
-        let dvel = Vector6::new(
-            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
-        );
-
-        let target_linvel = anchor2 * joint.target_velocity.xyz();
-        let target_angvel = anchor2 * joint.target_velocity.fixed_rows::<AngDim>(DIM).into_owned();
-        let target_vel = Vector6::new(
-            target_linvel.x,
-            target_linvel.y,
-            target_linvel.z,
-            target_angvel.x,
-            target_angvel.y,
-            target_angvel.z,
-        );
-
-        let rhs = dvel - dvel.sup(&target_vel).inf(&target_vel);
-
-        let delta_pos = Isometry::from_parts(
-            anchor2.translation * anchor1.translation.inverse(),
-            anchor2.rotation * anchor1.rotation.inverse(),
-        );
-        let lin_dpos = delta_pos.translation.vector;
-        let ang_dpos = delta_pos.rotation.scaled_axis();
-        let dpos = Vector6::new(
-            lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
-        );
-        let err = dpos - dpos.sup(&joint.min_position).inf(&joint.max_position);
-        let pos_rhs = err * params.inv_dt() * params.joint_erp;
+        let inv_lhs = delassus.cholesky().expect("Singular system.").inverse();
 
         let impulse = (joint.impulse * params.warmstart_coeff)
-            .inf(&joint.max_positive_impulse)
-            .sup(&joint.max_negative_impulse);
+            .inf(&max_impulse)
+            .sup(&min_impulse);
 
         GenericVelocityConstraint {
             joint_id,
@@ -189,15 +264,22 @@ impl GenericVelocityConstraint {
             ii2,
             ii1_sqrt: rb1.effective_world_inv_inertia_sqrt,
             ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
-            impulse,
-            pos_impulse: na::zero(),
-            max_positive_impulse: joint.max_positive_impulse,
-            max_negative_impulse: joint.max_negative_impulse,
             inv_lhs,
             r1,
             r2,
-            rhs,
-            pos_rhs,
+            rot2: anchor2.rotation,
+            vel: GenericConstraintPart {
+                impulse,
+                min_impulse,
+                max_impulse,
+                rhs,
+            },
+            pos: GenericConstraintPart {
+                impulse: na::zero(),
+                min_impulse: min_pos_impulse,
+                max_impulse: max_pos_impulse,
+                rhs: pos_rhs,
+            },
         }
     }
 
@@ -205,11 +287,11 @@ impl GenericVelocityConstraint {
         let mut mj_lambda1 = mj_lambdas[self.mj_lambda1 as usize];
         let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
 
-        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        let lin_impulse = self.rot2 * self.vel.impulse.fixed_rows::<Dim>(0).into_owned();
         #[cfg(feature = "dim2")]
-        let ang_impulse = self.impulse[2];
+        let ang_impulse = self.rot2 * self.vel.impulse[2];
         #[cfg(feature = "dim3")]
-        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+        let ang_impulse = self.rot2 * self.vel.impulse.fixed_rows::<U3>(3).into_owned();
 
         mj_lambda1.linear += self.im1 * lin_impulse;
         mj_lambda1.angular += self
@@ -227,48 +309,6 @@ impl GenericVelocityConstraint {
 
     pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
         return;
-        let mut mj_lambda1 = mj_lambdas[self.mj_lambda1 as usize];
-        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
-
-        let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
-        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
-
-        let dlinvel = -mj_lambda1.linear - ang_vel1.gcross(self.r1)
-            + mj_lambda2.linear
-            + ang_vel2.gcross(self.r2);
-        let dangvel = -ang_vel1 + ang_vel2;
-
-        #[cfg(feature = "dim2")]
-        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
-        #[cfg(feature = "dim3")]
-        let dvel = Vector6::new(
-            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
-        ) + self.rhs;
-
-        let new_impulse = (self.impulse + self.inv_lhs * dvel)
-            .sup(&self.max_negative_impulse)
-            .inf(&self.max_positive_impulse);
-        let effective_impulse = new_impulse - self.impulse;
-        self.impulse = new_impulse;
-
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
-        #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
-        #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
-
-        mj_lambda1.linear += self.im1 * lin_impulse;
-        mj_lambda1.angular += self
-            .ii1_sqrt
-            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
-
-        mj_lambda2.linear -= self.im2 * lin_impulse;
-        mj_lambda2.angular -= self
-            .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
-
-        mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
-        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
     }
 
     pub fn solve2(
@@ -281,82 +321,10 @@ impl GenericVelocityConstraint {
         let mut mj_lambda_pos1 = mj_lambdas_pos[self.mj_lambda1 as usize];
         let mut mj_lambda_pos2 = mj_lambdas_pos[self.mj_lambda2 as usize];
 
-        /*
-         * Solve velocity.
-         */
-        let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
-        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
-
-        let dlinvel = -mj_lambda1.linear - ang_vel1.gcross(self.r1)
-            + mj_lambda2.linear
-            + ang_vel2.gcross(self.r2);
-        let dangvel = -ang_vel1 + ang_vel2;
-
-        #[cfg(feature = "dim2")]
-        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
-        #[cfg(feature = "dim3")]
-        let dvel = Vector6::new(
-            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
-        ) + self.rhs;
-
-        let new_impulse = (self.impulse + self.inv_lhs * dvel)
-            .sup(&self.max_negative_impulse)
-            .inf(&self.max_positive_impulse);
-        let effective_impulse = new_impulse - self.impulse;
-        self.impulse = new_impulse;
-
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
-        #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
-        #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
-
-        mj_lambda1.linear += self.im1 * lin_impulse;
-        mj_lambda1.angular += self
-            .ii1_sqrt
-            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
-
-        mj_lambda2.linear -= self.im2 * lin_impulse;
-        mj_lambda2.angular -= self
-            .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
-
-        /*
-         * Solve positions.
-         */
-
-        let ang_pos1 = self.ii1_sqrt.transform_vector(mj_lambda_pos1.angular);
-        let ang_pos2 = self.ii2_sqrt.transform_vector(mj_lambda_pos2.angular);
-
-        let dlinpos = -mj_lambda_pos1.linear - ang_pos1.gcross(self.r1)
-            + mj_lambda_pos2.linear
-            + ang_pos2.gcross(self.r2);
-        let dangpos = -ang_pos1 + ang_pos2;
-
-        #[cfg(feature = "dim3")]
-        let dpos = Vector6::new(
-            dlinpos.x, dlinpos.y, dlinpos.z, dangpos.x, dangpos.y, dangpos.z,
-        ) + self.pos_rhs;
-
-        let new_impulse = self.pos_impulse + self.inv_lhs * dpos;
-        let effective_impulse = new_impulse - self.pos_impulse;
-        self.pos_impulse = new_impulse;
-
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
-        #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
-        #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
-
-        mj_lambda_pos1.linear += self.im1 * lin_impulse;
-        mj_lambda_pos1.angular += self
-            .ii1_sqrt
-            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
-
-        mj_lambda_pos2.linear -= self.im2 * lin_impulse;
-        mj_lambda_pos2.angular -= self
-            .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+        self.vel.impulse = self.vel.solve(self, &mut mj_lambda1, &mut mj_lambda2);
+        self.pos.impulse = self
+            .pos
+            .solve(self, &mut mj_lambda_pos1, &mut mj_lambda_pos2);
 
         mj_lambdas[self.mj_lambda1 as usize] = mj_lambda1;
         mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
@@ -367,7 +335,7 @@ impl GenericVelocityConstraint {
     pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
         let joint = &mut joints_all[self.joint_id].weight;
         if let JointParams::GenericJoint(fixed) = &mut joint.params {
-            fixed.impulse = self.impulse;
+            fixed.impulse = self.vel.impulse;
         }
     }
 }
@@ -378,94 +346,61 @@ pub(crate) struct GenericVelocityGroundConstraint {
 
     joint_id: JointIndex,
 
-    impulse: SpacialVector<Real>,
-    pos_impulse: SpacialVector<Real>,
-
-    max_positive_impulse: SpatialVector<Real>,
-    max_negative_impulse: SpatialVector<Real>,
-
     #[cfg(feature = "dim3")]
-    inv_lhs: Matrix6<Real>, // FIXME: replace by Cholesky.
-    #[cfg(feature = "dim3")]
-    rhs: Vector6<Real>,
-
+    inv_lhs: Matrix6<Real>, // TODO: replace by Cholesky?
     #[cfg(feature = "dim2")]
-    inv_lhs: Matrix3<Real>, // FIXME: replace by Cholesky.
-    #[cfg(feature = "dim2")]
-    rhs: Vector3<Real>,
-
-    pos_rhs: Vector6<Real>,
+    inv_lhs: Matrix3<Real>,
 
     im2: Real,
     ii2: AngularInertia<Real>,
     ii2_sqrt: AngularInertia<Real>,
     r2: Vector<Real>,
+    rot2: Rotation<Real>,
+
+    vel: GenericConstraintPart,
+    pos: GenericConstraintPart,
 }
 
 impl GenericVelocityGroundConstraint {
     #[inline(always)]
-    pub fn compute_mass_matrix(
-        joint: &GenericJoint,
+    pub fn compute_delassus_matrix(
         im2: Real,
         ii2: AngularInertia<Real>,
         r2: Vector<Real>,
-        velocity_solver: bool,
+        rot2: Rotation<Real>,
     ) -> Matrix6<Real> {
-        let rmat2 = r2.gcross_matrix();
-
-        #[allow(unused_mut)] // For 2D.
-        let mut lhs;
+        let rotmat2 = rot2.to_rotation_matrix().into_inner();
+        let rmat2 = r2.gcross_matrix() * rotmat2;
 
         #[cfg(feature = "dim3")]
         {
-            let lhs00 = ii2.quadform(&rmat2).add_diagonal(im2);
-            let lhs10 = ii2.transform_matrix(&rmat2);
-            let lhs11 = ii2.into_matrix();
+            let del00 = ii2.quadform(&rmat2).add_diagonal(im2);
+            let del10 = rotmat2.transpose() * ii2.transform_matrix(&rmat2);
+            let del11 = ii2.quadform(&rotmat2).into_matrix();
 
             // Note that Cholesky only reads the lower-triangular part of the matrix
             // so we don't need to fill lhs01.
-            lhs = Matrix6::zeros();
-            lhs.fixed_slice_mut::<U3, U3>(0, 0)
-                .copy_from(&lhs00.into_matrix());
-            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
-            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
-
-            // Adjust the mass matrix to take force limits into account.
-            // If a DoF has a force limit, then we need to make its
-            // constraint independent from the others because otherwise
-            // the force clamping will cause errors to propagate in the
-            // other constraints.
-            if velocity_solver {
-                for i in 0..6 {
-                    if joint.max_negative_impulse[i] > -Real::MAX
-                        || joint.max_positive_impulse[i] < Real::MAX
-                    {
-                        let diag = lhs[(i, i)];
-                        lhs.column_mut(i).fill(0.0);
-                        lhs.row_mut(i).fill(0.0);
-                        lhs[(i, i)] = diag;
-                    }
-                }
-            }
+            let mut del = Matrix6::zeros();
+            del.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&del00.into_matrix());
+            del.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&del10);
+            del.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&del11);
+            del
         }
 
         // In 2D we just unroll the computation because
         // it's just easier that way.
         #[cfg(feature = "dim2")]
         {
+            panic!("Properly handle the rotmat2");
             let m11 = im2 + rmat2.x * rmat2.x * ii2;
             let m12 = rmat2.x * rmat2.y * ii2;
             let m22 = im2 + rmat2.y * rmat2.y * ii2;
             let m13 = rmat2.x * ii2;
             let m23 = rmat2.y * ii2;
             let m33 = ii2;
-            lhs = Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
+            Matrix3::new(m11, m12, m13, m12, m22, m23, m13, m23, m33)
         }
-
-        #[cfg(feature = "dim2")]
-        return lhs.try_inverse().expect("Singular system.");
-        #[cfg(feature = "dim3")]
-        return lhs.cholesky().expect("Singular system.").inverse();
     }
 
     pub fn from_params(
@@ -488,50 +423,70 @@ impl GenericVelocityGroundConstraint {
             )
         };
 
-        let r1 = anchor1.translation.vector - rb1.world_com.coords;
         let im2 = rb2.effective_inv_mass;
         let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
+        let r1 = anchor1.translation.vector - rb1.world_com.coords;
         let r2 = anchor2.translation.vector - rb2.world_com.coords;
+        let mut min_impulse = joint.min_impulse;
+        let mut max_impulse = joint.max_impulse;
+        let mut min_pos_impulse = joint.min_pos_impulse;
+        let mut max_pos_impulse = joint.max_pos_impulse;
+        let mut min_velocity = joint.min_velocity;
+        let mut max_velocity = joint.max_velocity;
 
-        let inv_lhs = Self::compute_mass_matrix(joint, im2, ii2, r2, true);
+        let pos_rhs = GenericVelocityConstraint::compute_position_error(joint, &anchor1, &anchor2)
+            * params.inv_dt()
+            * params.joint_erp;
 
-        let lin_dvel = rb2.linvel + rb2.angvel.gcross(r2) - rb1.linvel - rb1.angvel.gcross(r1);
-        let ang_dvel = rb2.angvel - rb1.angvel;
+        for i in 0..6 {
+            if pos_rhs[i] < 0.0 {
+                min_impulse[i] = -Real::MAX;
+                min_pos_impulse[i] = -Real::MAX;
+                min_velocity[i] = 0.0;
+            }
+            if pos_rhs[i] > 0.0 {
+                max_impulse[i] = Real::MAX;
+                max_pos_impulse[i] = Real::MAX;
+                max_velocity[i] = 0.0;
+            }
+        }
 
+        let rhs = GenericVelocityConstraint::compute_velocity_error(
+            &min_velocity,
+            &max_velocity,
+            &r1,
+            &r2,
+            &anchor1,
+            &anchor2,
+            rb1,
+            rb2,
+        );
+
+        let mut delassus = Self::compute_delassus_matrix(im2, ii2, r2, anchor2.rotation);
+
+        // Adjust the Delassus matrix to take force limits into account.
+        // If a DoF has a force limit, then we need to make its
+        // constraint independent from the others because otherwise
+        // the force clamping will cause errors to propagate in the
+        // other constraints.
+        for i in 0..6 {
+            if min_impulse[i] > -Real::MAX && max_impulse[i] < Real::MAX {
+                let diag = delassus[(i, i)];
+                delassus.column_mut(i).fill(0.0);
+                delassus.row_mut(i).fill(0.0);
+                delassus[(i, i)] = diag;
+            }
+        }
+
+        // NOTE: we don't use Cholesky in 2D because we only have a 3x3 matrix.
         #[cfg(feature = "dim2")]
-        let dvel = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+        let inv_lhs = delassus.try_inverse().expect("Singular system.");
         #[cfg(feature = "dim3")]
-        let dvel = Vector6::new(
-            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
-        );
-        let target_linvel = anchor2 * joint.target_velocity.xyz();
-        let target_angvel = anchor2 * joint.target_velocity.fixed_rows::<AngDim>(DIM).into_owned();
-        let target_vel = Vector6::new(
-            target_linvel.x,
-            target_linvel.y,
-            target_linvel.z,
-            target_angvel.x,
-            target_angvel.y,
-            target_angvel.z,
-        );
-
-        let mut rhs = dvel - dvel.sup(&target_vel).inf(&target_vel);
-
-        let delta_pos = Isometry::from_parts(
-            anchor2.translation * anchor1.translation.inverse(),
-            anchor2.rotation * anchor1.rotation.inverse(),
-        );
-        let lin_dpos = delta_pos.translation.vector;
-        let ang_dpos = delta_pos.rotation.scaled_axis();
-        let dpos = Vector6::new(
-            lin_dpos.x, lin_dpos.y, lin_dpos.z, ang_dpos.x, ang_dpos.y, ang_dpos.z,
-        );
-        let err = dpos - dpos.sup(&joint.min_position).inf(&joint.max_position);
-        let pos_rhs = err * params.inv_dt() * params.joint_erp;
+        let inv_lhs = delassus.cholesky().expect("Singular system.").inverse();
 
         let impulse = (joint.impulse * params.warmstart_coeff)
-            .inf(&joint.max_positive_impulse)
-            .sup(&joint.max_negative_impulse);
+            .inf(&max_impulse)
+            .sup(&min_impulse);
 
         GenericVelocityGroundConstraint {
             joint_id,
@@ -539,25 +494,32 @@ impl GenericVelocityGroundConstraint {
             im2,
             ii2,
             ii2_sqrt: rb2.effective_world_inv_inertia_sqrt,
-            impulse,
-            pos_impulse: na::zero(),
-            max_positive_impulse: joint.max_positive_impulse,
-            max_negative_impulse: joint.max_negative_impulse,
             inv_lhs,
             r2,
-            rhs,
-            pos_rhs,
+            rot2: anchor2.rotation,
+            vel: GenericConstraintPart {
+                impulse,
+                min_impulse,
+                max_impulse,
+                rhs,
+            },
+            pos: GenericConstraintPart {
+                impulse: na::zero(),
+                min_impulse: min_pos_impulse,
+                max_impulse: max_pos_impulse,
+                rhs: pos_rhs,
+            },
         }
     }
 
     pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
         let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
 
-        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        let lin_impulse = self.rot2 * self.vel.impulse.fixed_rows::<Dim>(0).into_owned();
         #[cfg(feature = "dim2")]
-        let ang_impulse = self.impulse[2];
+        let ang_impulse = self.rot2 * self.vel.impulse[2];
         #[cfg(feature = "dim3")]
-        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+        let ang_impulse = self.rot2 * self.vel.impulse.fixed_rows::<U3>(3).into_owned();
 
         mj_lambda2.linear -= self.im2 * lin_impulse;
         mj_lambda2.angular -= self
@@ -569,37 +531,6 @@ impl GenericVelocityGroundConstraint {
 
     pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
         return;
-        let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
-
-        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
-
-        let dlinvel = mj_lambda2.linear + ang_vel2.gcross(self.r2);
-        let dangvel = ang_vel2;
-        #[cfg(feature = "dim2")]
-        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
-        #[cfg(feature = "dim3")]
-        let dvel = Vector6::new(
-            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
-        ) + self.rhs;
-
-        let new_impulse = (self.impulse + self.inv_lhs * dvel)
-            .sup(&self.max_negative_impulse)
-            .inf(&self.max_positive_impulse);
-        let effective_impulse = new_impulse - self.impulse;
-        self.impulse = new_impulse;
-
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
-        #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
-        #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
-
-        mj_lambda2.linear -= self.im2 * lin_impulse;
-        mj_lambda2.angular -= self
-            .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
-
-        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
     }
 
     pub fn solve2(
@@ -610,13 +541,47 @@ impl GenericVelocityGroundConstraint {
         let mut mj_lambda2 = mj_lambdas[self.mj_lambda2 as usize];
         let mut mj_lambda_pos2 = mj_lambdas_pos[self.mj_lambda2 as usize];
 
-        /*
-         * Solve velocities.
-         */
-        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+        self.vel.impulse = self.vel.solve_ground(self, &mut mj_lambda2);
+        self.pos.impulse = self.pos.solve_ground(self, &mut mj_lambda_pos2);
 
-        let dlinvel = mj_lambda2.linear + ang_vel2.gcross(self.r2);
-        let dangvel = ang_vel2;
+        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
+        mj_lambdas_pos[self.mj_lambda2 as usize] = mj_lambda_pos2;
+    }
+
+    // TODO: duplicated code with the non-ground constraint.
+    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
+        let joint = &mut joints_all[self.joint_id].weight;
+        if let JointParams::GenericJoint(fixed) = &mut joint.params {
+            fixed.impulse = self.vel.impulse;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GenericConstraintPart {
+    impulse: SpacialVector<Real>,
+    max_impulse: SpatialVector<Real>,
+    min_impulse: SpatialVector<Real>,
+
+    #[cfg(feature = "dim3")]
+    rhs: Vector6<Real>,
+    #[cfg(feature = "dim2")]
+    rhs: Vector3<Real>,
+}
+
+impl GenericConstraintPart {
+    fn solve_ground(
+        &self,
+        parent: &GenericVelocityGroundConstraint,
+        mj_lambda2: &mut DeltaVel<Real>,
+    ) -> SpatialVector<Real> {
+        let ang_vel2 = parent.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+        let dlinvel = parent
+            .rot2
+            .inverse_transform_vector(&(mj_lambda2.linear + ang_vel2.gcross(parent.r2)));
+        let dangvel = parent.rot2.inverse_transform_vector(&ang_vel2);
+
         #[cfg(feature = "dim2")]
         let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
         #[cfg(feature = "dim3")]
@@ -624,61 +589,71 @@ impl GenericVelocityGroundConstraint {
             dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
         ) + self.rhs;
 
-        let new_impulse = (self.impulse + self.inv_lhs * dvel)
-            .sup(&self.max_negative_impulse)
-            .inf(&self.max_positive_impulse);
+        let new_impulse = (self.impulse + parent.inv_lhs * dvel)
+            .sup(&self.min_impulse)
+            .inf(&self.max_impulse);
         let effective_impulse = new_impulse - self.impulse;
-        self.impulse = new_impulse;
 
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
+        let lin_impulse = parent.rot2 * effective_impulse.fixed_rows::<Dim>(0).into_owned();
         #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
+        let ang_impulse = parent.rot2 * effective_impulse[2];
         #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
+        let ang_impulse = parent.rot2 * effective_impulse.fixed_rows::<U3>(3).into_owned();
 
-        mj_lambda2.linear -= self.im2 * lin_impulse;
-        mj_lambda2.angular -= self
+        mj_lambda2.linear -= parent.im2 * lin_impulse;
+        mj_lambda2.angular -= parent
             .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+            .transform_vector(ang_impulse + parent.r2.gcross(lin_impulse));
 
-        /*
-         * Solve positions.
-         */
-        let ang_pos2 = self.ii2_sqrt.transform_vector(mj_lambda_pos2.angular);
-
-        let dlinpos = mj_lambda_pos2.linear + ang_pos2.gcross(self.r2);
-        let dangpos = ang_pos2;
-        #[cfg(feature = "dim2")]
-        let rhs = Vector3::new(dlinpos.x, dlinpos.y, dangpos) + self.rhs;
-        #[cfg(feature = "dim3")]
-        let dpos = Vector6::new(
-            dlinpos.x, dlinpos.y, dlinpos.z, dangpos.x, dangpos.y, dangpos.z,
-        ) + self.pos_rhs;
-
-        let new_impulse = self.pos_impulse + self.inv_lhs * dpos;
-        let effective_impulse = new_impulse - self.pos_impulse;
-        self.pos_impulse = new_impulse;
-
-        let lin_impulse = effective_impulse.fixed_rows::<Dim>(0).into_owned();
-        #[cfg(feature = "dim2")]
-        let ang_impulse = effective_impulse[2];
-        #[cfg(feature = "dim3")]
-        let ang_impulse = effective_impulse.fixed_rows::<U3>(3).into_owned();
-
-        mj_lambda_pos2.linear -= self.im2 * lin_impulse;
-        mj_lambda_pos2.angular -= self
-            .ii2_sqrt
-            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
-
-        mj_lambdas[self.mj_lambda2 as usize] = mj_lambda2;
-        mj_lambdas_pos[self.mj_lambda2 as usize] = mj_lambda_pos2;
+        new_impulse
     }
 
-    // FIXME: duplicated code with the non-ground constraint.
-    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
-        let joint = &mut joints_all[self.joint_id].weight;
-        if let JointParams::GenericJoint(fixed) = &mut joint.params {
-            fixed.impulse = self.impulse;
-        }
+    fn solve(
+        &self,
+        parent: &GenericVelocityConstraint,
+        mj_lambda1: &mut DeltaVel<Real>,
+        mj_lambda2: &mut DeltaVel<Real>,
+    ) -> SpatialVector<Real> {
+        let ang_vel1 = parent.ii1_sqrt.transform_vector(mj_lambda1.angular);
+        let ang_vel2 = parent.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+        let dlinvel = parent.rot2.inverse_transform_vector(
+            &(-mj_lambda1.linear - ang_vel1.gcross(parent.r1)
+                + mj_lambda2.linear
+                + ang_vel2.gcross(parent.r2)),
+        );
+        let dangvel = parent
+            .rot2
+            .inverse_transform_vector(&(-ang_vel1 + ang_vel2));
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
+        #[cfg(feature = "dim3")]
+        let dvel = Vector6::new(
+            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
+        ) + self.rhs;
+
+        let new_impulse = (self.impulse + parent.inv_lhs * dvel)
+            .sup(&self.min_impulse)
+            .inf(&self.max_impulse);
+        let effective_impulse = new_impulse - self.impulse;
+
+        let lin_impulse = parent.rot2 * effective_impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = parent.rot2 * effective_impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = parent.rot2 * effective_impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda1.linear += parent.im1 * lin_impulse;
+        mj_lambda1.angular += parent
+            .ii1_sqrt
+            .transform_vector(ang_impulse + parent.r1.gcross(lin_impulse));
+
+        mj_lambda2.linear -= parent.im2 * lin_impulse;
+        mj_lambda2.angular -= parent
+            .ii2_sqrt
+            .transform_vector(ang_impulse + parent.r2.gcross(lin_impulse));
+
+        new_impulse
     }
 }

--- a/src/dynamics/solver/joint_constraint/generic_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/generic_velocity_constraint_wide.rs
@@ -1,0 +1,472 @@
+use simba::simd::SimdValue;
+
+use crate::dynamics::solver::DeltaVel;
+use crate::dynamics::{
+    GenericJoint, IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RigidBody,
+};
+use crate::math::{
+    AngVector, AngularInertia, CrossMatrix, Dim, Isometry, Point, Real, SimdReal, SpacialVector,
+    Vector, SIMD_WIDTH,
+};
+use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
+#[cfg(feature = "dim3")]
+use na::{Cholesky, Matrix6, Vector6, U3};
+#[cfg(feature = "dim2")]
+use {
+    na::{Matrix3, Vector3},
+    parry::utils::SdpMatrix3,
+};
+
+#[derive(Debug)]
+pub(crate) struct WGenericVelocityConstraint {
+    mj_lambda1: [usize; SIMD_WIDTH],
+    mj_lambda2: [usize; SIMD_WIDTH],
+
+    joint_id: [JointIndex; SIMD_WIDTH],
+
+    impulse: SpacialVector<SimdReal>,
+
+    #[cfg(feature = "dim3")]
+    inv_lhs: Matrix6<SimdReal>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim3")]
+    rhs: Vector6<SimdReal>,
+
+    #[cfg(feature = "dim2")]
+    inv_lhs: Matrix3<SimdReal>,
+    #[cfg(feature = "dim2")]
+    rhs: Vector3<SimdReal>,
+
+    im1: SimdReal,
+    im2: SimdReal,
+
+    ii1: AngularInertia<SimdReal>,
+    ii2: AngularInertia<SimdReal>,
+
+    ii1_sqrt: AngularInertia<SimdReal>,
+    ii2_sqrt: AngularInertia<SimdReal>,
+
+    r1: Vector<SimdReal>,
+    r2: Vector<SimdReal>,
+}
+
+impl WGenericVelocityConstraint {
+    pub fn from_params(
+        params: &IntegrationParameters,
+        joint_id: [JointIndex; SIMD_WIDTH],
+        rbs1: [&RigidBody; SIMD_WIDTH],
+        rbs2: [&RigidBody; SIMD_WIDTH],
+        cparams: [&GenericJoint; SIMD_WIDTH],
+    ) -> Self {
+        let position1 = Isometry::from(array![|ii| rbs1[ii].position; SIMD_WIDTH]);
+        let linvel1 = Vector::from(array![|ii| rbs1[ii].linvel; SIMD_WIDTH]);
+        let angvel1 = AngVector::<SimdReal>::from(array![|ii| rbs1[ii].angvel; SIMD_WIDTH]);
+        let world_com1 = Point::from(array![|ii| rbs1[ii].world_com; SIMD_WIDTH]);
+        let im1 = SimdReal::from(array![|ii| rbs1[ii].effective_inv_mass; SIMD_WIDTH]);
+        let ii1_sqrt = AngularInertia::<SimdReal>::from(
+            array![|ii| rbs1[ii].effective_world_inv_inertia_sqrt; SIMD_WIDTH],
+        );
+        let mj_lambda1 = array![|ii| rbs1[ii].active_set_offset; SIMD_WIDTH];
+
+        let position2 = Isometry::from(array![|ii| rbs2[ii].position; SIMD_WIDTH]);
+        let linvel2 = Vector::from(array![|ii| rbs2[ii].linvel; SIMD_WIDTH]);
+        let angvel2 = AngVector::<SimdReal>::from(array![|ii| rbs2[ii].angvel; SIMD_WIDTH]);
+        let world_com2 = Point::from(array![|ii| rbs2[ii].world_com; SIMD_WIDTH]);
+        let im2 = SimdReal::from(array![|ii| rbs2[ii].effective_inv_mass; SIMD_WIDTH]);
+        let ii2_sqrt = AngularInertia::<SimdReal>::from(
+            array![|ii| rbs2[ii].effective_world_inv_inertia_sqrt; SIMD_WIDTH],
+        );
+        let mj_lambda2 = array![|ii| rbs2[ii].active_set_offset; SIMD_WIDTH];
+
+        let local_anchor1 = Isometry::from(array![|ii| cparams[ii].local_anchor1; SIMD_WIDTH]);
+        let local_anchor2 = Isometry::from(array![|ii| cparams[ii].local_anchor2; SIMD_WIDTH]);
+        let impulse = SpacialVector::from(array![|ii| cparams[ii].impulse; SIMD_WIDTH]);
+
+        let anchor1 = position1 * local_anchor1;
+        let anchor2 = position2 * local_anchor2;
+        let ii1 = ii1_sqrt.squared();
+        let ii2 = ii2_sqrt.squared();
+        let r1 = anchor1.translation.vector - world_com1.coords;
+        let r2 = anchor2.translation.vector - world_com2.coords;
+        let rmat1: CrossMatrix<_> = r1.gcross_matrix();
+        let rmat2: CrossMatrix<_> = r2.gcross_matrix();
+
+        #[allow(unused_mut)] // For 2D.
+        let mut lhs;
+
+        #[cfg(feature = "dim3")]
+        {
+            let lhs00 =
+                ii1.quadform(&rmat1).add_diagonal(im1) + ii2.quadform(&rmat2).add_diagonal(im2);
+            let lhs10 = ii1.transform_matrix(&rmat1) + ii2.transform_matrix(&rmat2);
+            let lhs11 = (ii1 + ii2).into_matrix();
+
+            // Note that Cholesky only reads the lower-triangular part of the matrix
+            // so we don't need to fill lhs01.
+            lhs = Matrix6::zeros();
+            lhs.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&lhs00.into_matrix());
+            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
+            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
+        }
+
+        // In 2D we just unroll the computation because
+        // it's just easier that way.
+        #[cfg(feature = "dim2")]
+        {
+            let m11 = im1 + im2 + rmat1.x * rmat1.x * ii1 + rmat2.x * rmat2.x * ii2;
+            let m12 = rmat1.x * rmat1.y * ii1 + rmat2.x * rmat2.y * ii2;
+            let m22 = im1 + im2 + rmat1.y * rmat1.y * ii1 + rmat2.y * rmat2.y * ii2;
+            let m13 = rmat1.x * ii1 + rmat2.x * ii2;
+            let m23 = rmat1.y * ii1 + rmat2.y * ii2;
+            let m33 = ii1 + ii2;
+            lhs = SdpMatrix3::new(m11, m12, m13, m22, m23, m33)
+        }
+
+        // NOTE: we don't use cholesky in 2D because we only have a 3x3 matrix
+        // for which a textbook inverse is still efficient.
+        #[cfg(feature = "dim2")]
+        let inv_lhs = lhs.inverse_unchecked().into_matrix(); // FIXME: don't extract the matrix?
+        #[cfg(feature = "dim3")]
+        let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
+
+        let lin_dvel = -linvel1 - angvel1.gcross(r1) + linvel2 + angvel2.gcross(r2);
+        let ang_dvel = -angvel1 + angvel2;
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        );
+
+        WGenericVelocityConstraint {
+            joint_id,
+            mj_lambda1,
+            mj_lambda2,
+            im1,
+            im2,
+            ii1,
+            ii2,
+            ii1_sqrt,
+            ii2_sqrt,
+            impulse: impulse * SimdReal::splat(params.warmstart_coeff),
+            inv_lhs,
+            r1,
+            r2,
+            rhs,
+        }
+    }
+
+    pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda1 = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda1[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda1[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+        let mut mj_lambda2 = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+
+        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = self.impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda1.linear += lin_impulse * self.im1;
+        mj_lambda1.angular += self
+            .ii1_sqrt
+            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
+
+        mj_lambda2.linear -= lin_impulse * self.im2;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda1[ii] as usize].linear = mj_lambda1.linear.extract(ii);
+            mj_lambdas[self.mj_lambda1[ii] as usize].angular = mj_lambda1.angular.extract(ii);
+        }
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda2[ii] as usize].linear = mj_lambda2.linear.extract(ii);
+            mj_lambdas[self.mj_lambda2[ii] as usize].angular = mj_lambda2.angular.extract(ii);
+        }
+    }
+
+    pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda1: DeltaVel<SimdReal> = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda1[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda1[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+        let mut mj_lambda2: DeltaVel<SimdReal> = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+
+        let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
+        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+
+        let dlinvel = -mj_lambda1.linear - ang_vel1.gcross(self.r1)
+            + mj_lambda2.linear
+            + ang_vel2.gcross(self.r2);
+        let dangvel = -ang_vel1 + ang_vel2;
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
+        ) + self.rhs;
+
+        let impulse = self.inv_lhs * rhs;
+        self.impulse += impulse;
+        let lin_impulse = impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda1.linear += lin_impulse * self.im1;
+        mj_lambda1.angular += self
+            .ii1_sqrt
+            .transform_vector(ang_impulse + self.r1.gcross(lin_impulse));
+
+        mj_lambda2.linear -= lin_impulse * self.im2;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda1[ii] as usize].linear = mj_lambda1.linear.extract(ii);
+            mj_lambdas[self.mj_lambda1[ii] as usize].angular = mj_lambda1.angular.extract(ii);
+        }
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda2[ii] as usize].linear = mj_lambda2.linear.extract(ii);
+            mj_lambdas[self.mj_lambda2[ii] as usize].angular = mj_lambda2.angular.extract(ii);
+        }
+    }
+
+    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
+        for ii in 0..SIMD_WIDTH {
+            let joint = &mut joints_all[self.joint_id[ii]].weight;
+            if let JointParams::GenericJoint(fixed) = &mut joint.params {
+                fixed.impulse = self.impulse.extract(ii)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WGenericVelocityGroundConstraint {
+    mj_lambda2: [usize; SIMD_WIDTH],
+
+    joint_id: [JointIndex; SIMD_WIDTH],
+
+    impulse: SpacialVector<SimdReal>,
+
+    #[cfg(feature = "dim3")]
+    inv_lhs: Matrix6<SimdReal>, // FIXME: replace by Cholesky.
+    #[cfg(feature = "dim3")]
+    rhs: Vector6<SimdReal>,
+
+    #[cfg(feature = "dim2")]
+    inv_lhs: Matrix3<SimdReal>,
+    #[cfg(feature = "dim2")]
+    rhs: Vector3<SimdReal>,
+
+    im2: SimdReal,
+    ii2: AngularInertia<SimdReal>,
+    ii2_sqrt: AngularInertia<SimdReal>,
+    r2: Vector<SimdReal>,
+}
+
+impl WGenericVelocityGroundConstraint {
+    pub fn from_params(
+        params: &IntegrationParameters,
+        joint_id: [JointIndex; SIMD_WIDTH],
+        rbs1: [&RigidBody; SIMD_WIDTH],
+        rbs2: [&RigidBody; SIMD_WIDTH],
+        cparams: [&GenericJoint; SIMD_WIDTH],
+        flipped: [bool; SIMD_WIDTH],
+    ) -> Self {
+        let position1 = Isometry::from(array![|ii| rbs1[ii].position; SIMD_WIDTH]);
+        let linvel1 = Vector::from(array![|ii| rbs1[ii].linvel; SIMD_WIDTH]);
+        let angvel1 = AngVector::<SimdReal>::from(array![|ii| rbs1[ii].angvel; SIMD_WIDTH]);
+        let world_com1 = Point::from(array![|ii| rbs1[ii].world_com; SIMD_WIDTH]);
+
+        let position2 = Isometry::from(array![|ii| rbs2[ii].position; SIMD_WIDTH]);
+        let linvel2 = Vector::from(array![|ii| rbs2[ii].linvel; SIMD_WIDTH]);
+        let angvel2 = AngVector::<SimdReal>::from(array![|ii| rbs2[ii].angvel; SIMD_WIDTH]);
+        let world_com2 = Point::from(array![|ii| rbs2[ii].world_com; SIMD_WIDTH]);
+        let im2 = SimdReal::from(array![|ii| rbs2[ii].effective_inv_mass; SIMD_WIDTH]);
+        let ii2_sqrt = AngularInertia::<SimdReal>::from(
+            array![|ii| rbs2[ii].effective_world_inv_inertia_sqrt; SIMD_WIDTH],
+        );
+        let mj_lambda2 = array![|ii| rbs2[ii].active_set_offset; SIMD_WIDTH];
+
+        let local_anchor1 = Isometry::from(
+            array![|ii| if flipped[ii] { cparams[ii].local_anchor2 } else { cparams[ii].local_anchor1 }; SIMD_WIDTH],
+        );
+        let local_anchor2 = Isometry::from(
+            array![|ii| if flipped[ii] { cparams[ii].local_anchor1 } else { cparams[ii].local_anchor2 }; SIMD_WIDTH],
+        );
+        let impulse = SpacialVector::from(array![|ii| cparams[ii].impulse; SIMD_WIDTH]);
+
+        let anchor1 = position1 * local_anchor1;
+        let anchor2 = position2 * local_anchor2;
+        let ii2 = ii2_sqrt.squared();
+        let r1 = anchor1.translation.vector - world_com1.coords;
+        let r2 = anchor2.translation.vector - world_com2.coords;
+        let rmat2: CrossMatrix<_> = r2.gcross_matrix();
+
+        #[allow(unused_mut)] // For 2D.
+        let mut lhs;
+
+        #[cfg(feature = "dim3")]
+        {
+            let lhs00 = ii2.quadform(&rmat2).add_diagonal(im2);
+            let lhs10 = ii2.transform_matrix(&rmat2);
+            let lhs11 = ii2.into_matrix();
+
+            lhs = Matrix6::zeros();
+            lhs.fixed_slice_mut::<U3, U3>(0, 0)
+                .copy_from(&lhs00.into_matrix());
+            lhs.fixed_slice_mut::<U3, U3>(3, 0).copy_from(&lhs10);
+            lhs.fixed_slice_mut::<U3, U3>(3, 3).copy_from(&lhs11);
+        }
+
+        // In 2D we just unroll the computation because
+        // it's just easier that way.
+        #[cfg(feature = "dim2")]
+        {
+            let m11 = im2 + rmat2.x * rmat2.x * ii2;
+            let m12 = rmat2.x * rmat2.y * ii2;
+            let m22 = im2 + rmat2.y * rmat2.y * ii2;
+            let m13 = rmat2.x * ii2;
+            let m23 = rmat2.y * ii2;
+            let m33 = ii2;
+            lhs = SdpMatrix3::new(m11, m12, m13, m22, m23, m33)
+        }
+
+        #[cfg(feature = "dim2")]
+        let inv_lhs = lhs.inverse_unchecked().into_matrix(); // FIXME: don't do into_matrix?
+        #[cfg(feature = "dim3")]
+        let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
+
+        let lin_dvel = linvel2 + angvel2.gcross(r2) - linvel1 - angvel1.gcross(r1);
+        let ang_dvel = angvel2 - angvel1;
+
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(lin_dvel.x, lin_dvel.y, ang_dvel);
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y, ang_dvel.z,
+        );
+
+        WGenericVelocityGroundConstraint {
+            joint_id,
+            mj_lambda2,
+            im2,
+            ii2,
+            ii2_sqrt,
+            impulse: impulse * SimdReal::splat(params.warmstart_coeff),
+            inv_lhs,
+            r2,
+            rhs,
+        }
+    }
+
+    pub fn warmstart(&self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda2 = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+
+        let lin_impulse = self.impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = self.impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = self.impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda2.linear -= lin_impulse * self.im2;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda2[ii] as usize].linear = mj_lambda2.linear.extract(ii);
+            mj_lambdas[self.mj_lambda2[ii] as usize].angular = mj_lambda2.angular.extract(ii);
+        }
+    }
+
+    pub fn solve(&mut self, mj_lambdas: &mut [DeltaVel<Real>]) {
+        let mut mj_lambda2: DeltaVel<SimdReal> = DeltaVel {
+            linear: Vector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].linear; SIMD_WIDTH],
+            ),
+            angular: AngVector::from(
+                array![|ii| mj_lambdas[self.mj_lambda2[ii] as usize].angular; SIMD_WIDTH],
+            ),
+        };
+
+        let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
+        let dlinvel = mj_lambda2.linear + ang_vel2.gcross(self.r2);
+        let dangvel = ang_vel2;
+        #[cfg(feature = "dim2")]
+        let rhs = Vector3::new(dlinvel.x, dlinvel.y, dangvel) + self.rhs;
+        #[cfg(feature = "dim3")]
+        let rhs = Vector6::new(
+            dlinvel.x, dlinvel.y, dlinvel.z, dangvel.x, dangvel.y, dangvel.z,
+        ) + self.rhs;
+
+        let impulse = self.inv_lhs * rhs;
+
+        self.impulse += impulse;
+        let lin_impulse = impulse.fixed_rows::<Dim>(0).into_owned();
+        #[cfg(feature = "dim2")]
+        let ang_impulse = impulse[2];
+        #[cfg(feature = "dim3")]
+        let ang_impulse = impulse.fixed_rows::<U3>(3).into_owned();
+
+        mj_lambda2.linear -= lin_impulse * self.im2;
+        mj_lambda2.angular -= self
+            .ii2_sqrt
+            .transform_vector(ang_impulse + self.r2.gcross(lin_impulse));
+
+        for ii in 0..SIMD_WIDTH {
+            mj_lambdas[self.mj_lambda2[ii] as usize].linear = mj_lambda2.linear.extract(ii);
+            mj_lambdas[self.mj_lambda2[ii] as usize].angular = mj_lambda2.angular.extract(ii);
+        }
+    }
+
+    // FIXME: duplicated code with the non-ground constraint.
+    pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
+        for ii in 0..SIMD_WIDTH {
+            let joint = &mut joints_all[self.joint_id[ii]].weight;
+            if let JointParams::GenericJoint(fixed) = &mut joint.params {
+                fixed.impulse = self.impulse.extract(ii)
+            }
+        }
+    }
+}

--- a/src/dynamics/solver/joint_constraint/joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint.rs
@@ -14,9 +14,9 @@ use super::{
 #[cfg(feature = "dim3")]
 #[cfg(feature = "simd-is-enabled")]
 use super::{WRevoluteVelocityConstraint, WRevoluteVelocityGroundConstraint};
-use crate::dynamics::solver::joint_constraint::generic_velocity_constraint::{
-    GenericVelocityConstraint, GenericVelocityGroundConstraint,
-};
+// use crate::dynamics::solver::joint_constraint::generic_velocity_constraint::{
+//     GenericVelocityConstraint, GenericVelocityGroundConstraint,
+// };
 use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{
     IntegrationParameters, Joint, JointGraphEdge, JointIndex, JointParams, RigidBodySet,
@@ -38,12 +38,12 @@ pub(crate) enum AnyJointVelocityConstraint {
     WFixedConstraint(WFixedVelocityConstraint),
     #[cfg(feature = "simd-is-enabled")]
     WFixedGroundConstraint(WFixedVelocityGroundConstraint),
-    GenericConstraint(GenericVelocityConstraint),
-    GenericGroundConstraint(GenericVelocityGroundConstraint),
-    #[cfg(feature = "simd-is-enabled")]
-    WGenericConstraint(WGenericVelocityConstraint),
-    #[cfg(feature = "simd-is-enabled")]
-    WGenericGroundConstraint(WGenericVelocityGroundConstraint),
+    // GenericConstraint(GenericVelocityConstraint),
+    // GenericGroundConstraint(GenericVelocityGroundConstraint),
+    // #[cfg(feature = "simd-is-enabled")]
+    // WGenericConstraint(WGenericVelocityConstraint),
+    // #[cfg(feature = "simd-is-enabled")]
+    // WGenericGroundConstraint(WGenericVelocityGroundConstraint),
     PrismaticConstraint(PrismaticVelocityConstraint),
     PrismaticGroundConstraint(PrismaticVelocityGroundConstraint),
     #[cfg(feature = "simd-is-enabled")]
@@ -89,9 +89,9 @@ impl AnyJointVelocityConstraint {
             JointParams::PrismaticJoint(p) => AnyJointVelocityConstraint::PrismaticConstraint(
                 PrismaticVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
             ),
-            JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericConstraint(
-                GenericVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
-            ),
+            // JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericConstraint(
+            //     GenericVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
+            // ),
             #[cfg(feature = "dim3")]
             JointParams::RevoluteJoint(p) => AnyJointVelocityConstraint::RevoluteConstraint(
                 RevoluteVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
@@ -167,11 +167,11 @@ impl AnyJointVelocityConstraint {
             JointParams::FixedJoint(p) => AnyJointVelocityConstraint::FixedGroundConstraint(
                 FixedVelocityGroundConstraint::from_params(params, joint_id, rb1, rb2, p, flipped),
             ),
-            JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericGroundConstraint(
-                GenericVelocityGroundConstraint::from_params(
-                    params, joint_id, rb1, rb2, p, flipped,
-                ),
-            ),
+            // JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericGroundConstraint(
+            //     GenericVelocityGroundConstraint::from_params(
+            //         params, joint_id, rb1, rb2, p, flipped,
+            //     ),
+            // ),
             JointParams::PrismaticJoint(p) => {
                 AnyJointVelocityConstraint::PrismaticGroundConstraint(
                     PrismaticVelocityGroundConstraint::from_params(
@@ -180,10 +180,8 @@ impl AnyJointVelocityConstraint {
                 )
             }
             #[cfg(feature = "dim3")]
-            JointParams::RevoluteJoint(p) => AnyJointVelocityConstraint::RevoluteGroundConstraint(
-                RevoluteVelocityGroundConstraint::from_params(
-                    params, joint_id, rb1, rb2, p, flipped,
-                ),
+            JointParams::RevoluteJoint(p) => RevoluteVelocityGroundConstraint::from_params(
+                params, joint_id, rb1, rb2, p, flipped,
             ),
         }
     }
@@ -267,12 +265,12 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedConstraint(c) => c.warmstart(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => c.warmstart(mj_lambdas),
-            AnyJointVelocityConstraint::GenericConstraint(c) => c.warmstart(mj_lambdas),
-            AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.warmstart(mj_lambdas),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericConstraint(c) => c.warmstart(mj_lambdas),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.warmstart(mj_lambdas),
+            // AnyJointVelocityConstraint::GenericConstraint(c) => c.warmstart(mj_lambdas),
+            // AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.warmstart(mj_lambdas),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericConstraint(c) => c.warmstart(mj_lambdas),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.warmstart(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.warmstart(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticGroundConstraint(c) => c.warmstart(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
@@ -307,12 +305,12 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedConstraint(c) => c.solve(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => c.solve(mj_lambdas),
-            AnyJointVelocityConstraint::GenericConstraint(c) => c.solve(mj_lambdas),
-            AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.solve(mj_lambdas),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericConstraint(c) => c.solve(mj_lambdas),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.solve(mj_lambdas),
+            // AnyJointVelocityConstraint::GenericConstraint(c) => c.solve(mj_lambdas),
+            // AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.solve(mj_lambdas),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericConstraint(c) => c.solve(mj_lambdas),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.solve(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.solve(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticGroundConstraint(c) => c.solve(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
@@ -355,16 +353,16 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => {
                 c.writeback_impulses(joints_all)
             }
-            AnyJointVelocityConstraint::GenericConstraint(c) => c.writeback_impulses(joints_all),
-            AnyJointVelocityConstraint::GenericGroundConstraint(c) => {
-                c.writeback_impulses(joints_all)
-            }
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericConstraint(c) => c.writeback_impulses(joints_all),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => {
-                c.writeback_impulses(joints_all)
-            }
+            // AnyJointVelocityConstraint::GenericConstraint(c) => c.writeback_impulses(joints_all),
+            // AnyJointVelocityConstraint::GenericGroundConstraint(c) => {
+            //     c.writeback_impulses(joints_all)
+            // }
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericConstraint(c) => c.writeback_impulses(joints_all),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointVelocityConstraint::WGenericGroundConstraint(c) => {
+            //     c.writeback_impulses(joints_all)
+            // }
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.writeback_impulses(joints_all),
             AnyJointVelocityConstraint::PrismaticGroundConstraint(c) => {
                 c.writeback_impulses(joints_all)

--- a/src/dynamics/solver/joint_constraint/joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint.rs
@@ -333,23 +333,6 @@ impl AnyJointVelocityConstraint {
         }
     }
 
-    pub fn solve2(
-        &mut self,
-        mj_lambdas: &mut [DeltaVel<Real>],
-        mj_lambdas_pos: &mut [DeltaVel<Real>],
-    ) {
-        match self {
-            AnyJointVelocityConstraint::GenericConstraint(c) => {
-                c.solve2(mj_lambdas, mj_lambdas_pos)
-            }
-            AnyJointVelocityConstraint::GenericGroundConstraint(c) => {
-                c.solve2(mj_lambdas, mj_lambdas_pos)
-            }
-            AnyJointVelocityConstraint::Empty => unreachable!(),
-            _ => {}
-        }
-    }
-
     pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
         match self {
             AnyJointVelocityConstraint::BallConstraint(c) => c.writeback_impulses(joints_all),

--- a/src/dynamics/solver/joint_constraint/joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint.rs
@@ -7,8 +7,7 @@ use super::{RevoluteVelocityConstraint, RevoluteVelocityGroundConstraint};
 #[cfg(feature = "simd-is-enabled")]
 use super::{
     WBallVelocityConstraint, WBallVelocityGroundConstraint, WFixedVelocityConstraint,
-    WFixedVelocityGroundConstraint, WGenericPositionConstraint, WGenericPositionGroundConstraint,
-    WGenericVelocityConstraint, WGenericVelocityGroundConstraint, WPrismaticVelocityConstraint,
+    WFixedVelocityGroundConstraint, WPrismaticVelocityConstraint,
     WPrismaticVelocityGroundConstraint,
 };
 #[cfg(feature = "dim3")]
@@ -122,12 +121,12 @@ impl AnyJointVelocityConstraint {
                     params, joint_id, rbs1, rbs2, joints,
                 ))
             }
-            JointParams::GenericJoint(_) => {
-                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
-                AnyJointVelocityConstraint::WGenericConstraint(
-                    WGenericVelocityConstraint::from_params(params, joint_id, rbs1, rbs2, joints),
-                )
-            }
+            // JointParams::GenericJoint(_) => {
+            //     let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+            //     AnyJointVelocityConstraint::WGenericConstraint(
+            //         WGenericVelocityConstraint::from_params(params, joint_id, rbs1, rbs2, joints),
+            //     )
+            // }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];
@@ -221,14 +220,14 @@ impl AnyJointVelocityConstraint {
                     ),
                 )
             }
-            JointParams::GenericJoint(_) => {
-                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
-                AnyJointVelocityConstraint::WGenericGroundConstraint(
-                    WGenericVelocityGroundConstraint::from_params(
-                        params, joint_id, rbs1, rbs2, joints, flipped,
-                    ),
-                )
-            }
+            // JointParams::GenericJoint(_) => {
+            //     let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+            //     AnyJointVelocityConstraint::WGenericGroundConstraint(
+            //         WGenericVelocityGroundConstraint::from_params(
+            //             params, joint_id, rbs1, rbs2, joints, flipped,
+            //         ),
+            //     )
+            // }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];

--- a/src/dynamics/solver/joint_constraint/joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint.rs
@@ -333,6 +333,23 @@ impl AnyJointVelocityConstraint {
         }
     }
 
+    pub fn solve2(
+        &mut self,
+        mj_lambdas: &mut [DeltaVel<Real>],
+        mj_lambdas_pos: &mut [DeltaVel<Real>],
+    ) {
+        match self {
+            AnyJointVelocityConstraint::GenericConstraint(c) => {
+                c.solve2(mj_lambdas, mj_lambdas_pos)
+            }
+            AnyJointVelocityConstraint::GenericGroundConstraint(c) => {
+                c.solve2(mj_lambdas, mj_lambdas_pos)
+            }
+            AnyJointVelocityConstraint::Empty => unreachable!(),
+            _ => {}
+        }
+    }
+
     pub fn writeback_impulses(&self, joints_all: &mut [JointGraphEdge]) {
         match self {
             AnyJointVelocityConstraint::BallConstraint(c) => c.writeback_impulses(joints_all),

--- a/src/dynamics/solver/joint_constraint/joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint.rs
@@ -7,12 +7,16 @@ use super::{RevoluteVelocityConstraint, RevoluteVelocityGroundConstraint};
 #[cfg(feature = "simd-is-enabled")]
 use super::{
     WBallVelocityConstraint, WBallVelocityGroundConstraint, WFixedVelocityConstraint,
-    WFixedVelocityGroundConstraint, WPrismaticVelocityConstraint,
+    WFixedVelocityGroundConstraint, WGenericPositionConstraint, WGenericPositionGroundConstraint,
+    WGenericVelocityConstraint, WGenericVelocityGroundConstraint, WPrismaticVelocityConstraint,
     WPrismaticVelocityGroundConstraint,
 };
 #[cfg(feature = "dim3")]
 #[cfg(feature = "simd-is-enabled")]
 use super::{WRevoluteVelocityConstraint, WRevoluteVelocityGroundConstraint};
+use crate::dynamics::solver::joint_constraint::generic_velocity_constraint::{
+    GenericVelocityConstraint, GenericVelocityGroundConstraint,
+};
 use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{
     IntegrationParameters, Joint, JointGraphEdge, JointIndex, JointParams, RigidBodySet,
@@ -34,6 +38,12 @@ pub(crate) enum AnyJointVelocityConstraint {
     WFixedConstraint(WFixedVelocityConstraint),
     #[cfg(feature = "simd-is-enabled")]
     WFixedGroundConstraint(WFixedVelocityGroundConstraint),
+    GenericConstraint(GenericVelocityConstraint),
+    GenericGroundConstraint(GenericVelocityGroundConstraint),
+    #[cfg(feature = "simd-is-enabled")]
+    WGenericConstraint(WGenericVelocityConstraint),
+    #[cfg(feature = "simd-is-enabled")]
+    WGenericGroundConstraint(WGenericVelocityGroundConstraint),
     PrismaticConstraint(PrismaticVelocityConstraint),
     PrismaticGroundConstraint(PrismaticVelocityGroundConstraint),
     #[cfg(feature = "simd-is-enabled")]
@@ -79,6 +89,9 @@ impl AnyJointVelocityConstraint {
             JointParams::PrismaticJoint(p) => AnyJointVelocityConstraint::PrismaticConstraint(
                 PrismaticVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
             ),
+            JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericConstraint(
+                GenericVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
+            ),
             #[cfg(feature = "dim3")]
             JointParams::RevoluteJoint(p) => AnyJointVelocityConstraint::RevoluteConstraint(
                 RevoluteVelocityConstraint::from_params(params, joint_id, rb1, rb2, p),
@@ -108,6 +121,12 @@ impl AnyJointVelocityConstraint {
                 AnyJointVelocityConstraint::WFixedConstraint(WFixedVelocityConstraint::from_params(
                     params, joint_id, rbs1, rbs2, joints,
                 ))
+            }
+            JointParams::GenericJoint(_) => {
+                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+                AnyJointVelocityConstraint::WGenericConstraint(
+                    WGenericVelocityConstraint::from_params(params, joint_id, rbs1, rbs2, joints),
+                )
             }
             JointParams::PrismaticJoint(_) => {
                 let joints =
@@ -147,6 +166,11 @@ impl AnyJointVelocityConstraint {
             ),
             JointParams::FixedJoint(p) => AnyJointVelocityConstraint::FixedGroundConstraint(
                 FixedVelocityGroundConstraint::from_params(params, joint_id, rb1, rb2, p, flipped),
+            ),
+            JointParams::GenericJoint(p) => AnyJointVelocityConstraint::GenericGroundConstraint(
+                GenericVelocityGroundConstraint::from_params(
+                    params, joint_id, rb1, rb2, p, flipped,
+                ),
             ),
             JointParams::PrismaticJoint(p) => {
                 AnyJointVelocityConstraint::PrismaticGroundConstraint(
@@ -199,6 +223,14 @@ impl AnyJointVelocityConstraint {
                     ),
                 )
             }
+            JointParams::GenericJoint(_) => {
+                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+                AnyJointVelocityConstraint::WGenericGroundConstraint(
+                    WGenericVelocityGroundConstraint::from_params(
+                        params, joint_id, rbs1, rbs2, joints, flipped,
+                    ),
+                )
+            }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];
@@ -235,6 +267,12 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedConstraint(c) => c.warmstart(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => c.warmstart(mj_lambdas),
+            AnyJointVelocityConstraint::GenericConstraint(c) => c.warmstart(mj_lambdas),
+            AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.warmstart(mj_lambdas),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericConstraint(c) => c.warmstart(mj_lambdas),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.warmstart(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.warmstart(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticGroundConstraint(c) => c.warmstart(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
@@ -269,6 +307,12 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedConstraint(c) => c.solve(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => c.solve(mj_lambdas),
+            AnyJointVelocityConstraint::GenericConstraint(c) => c.solve(mj_lambdas),
+            AnyJointVelocityConstraint::GenericGroundConstraint(c) => c.solve(mj_lambdas),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericConstraint(c) => c.solve(mj_lambdas),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => c.solve(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.solve(mj_lambdas),
             AnyJointVelocityConstraint::PrismaticGroundConstraint(c) => c.solve(mj_lambdas),
             #[cfg(feature = "simd-is-enabled")]
@@ -309,6 +353,16 @@ impl AnyJointVelocityConstraint {
             AnyJointVelocityConstraint::WFixedConstraint(c) => c.writeback_impulses(joints_all),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointVelocityConstraint::WFixedGroundConstraint(c) => {
+                c.writeback_impulses(joints_all)
+            }
+            AnyJointVelocityConstraint::GenericConstraint(c) => c.writeback_impulses(joints_all),
+            AnyJointVelocityConstraint::GenericGroundConstraint(c) => {
+                c.writeback_impulses(joints_all)
+            }
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericConstraint(c) => c.writeback_impulses(joints_all),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointVelocityConstraint::WGenericGroundConstraint(c) => {
                 c.writeback_impulses(joints_all)
             }
             AnyJointVelocityConstraint::PrismaticConstraint(c) => c.writeback_impulses(joints_all),

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -1,7 +1,6 @@
 use super::{
     BallPositionConstraint, BallPositionGroundConstraint, FixedPositionConstraint,
-    FixedPositionGroundConstraint, GenericPositionConstraint, GenericPositionGroundConstraint,
-    PrismaticPositionConstraint, PrismaticPositionGroundConstraint,
+    FixedPositionGroundConstraint, PrismaticPositionConstraint, PrismaticPositionGroundConstraint,
 };
 #[cfg(feature = "dim3")]
 use super::{RevolutePositionConstraint, RevolutePositionGroundConstraint};
@@ -33,12 +32,12 @@ pub(crate) enum AnyJointPositionConstraint {
     WFixedJoint(WFixedPositionConstraint),
     #[cfg(feature = "simd-is-enabled")]
     WFixedGroundConstraint(WFixedPositionGroundConstraint),
-    GenericJoint(GenericPositionConstraint),
-    GenericGroundConstraint(GenericPositionGroundConstraint),
-    #[cfg(feature = "simd-is-enabled")]
-    WGenericJoint(WGenericPositionConstraint),
-    #[cfg(feature = "simd-is-enabled")]
-    WGenericGroundConstraint(WGenericPositionGroundConstraint),
+    // GenericJoint(GenericPositionConstraint),
+    // GenericGroundConstraint(GenericPositionGroundConstraint),
+    // #[cfg(feature = "simd-is-enabled")]
+    // WGenericJoint(WGenericPositionConstraint),
+    // #[cfg(feature = "simd-is-enabled")]
+    // WGenericGroundConstraint(WGenericPositionGroundConstraint),
     PrismaticJoint(PrismaticPositionConstraint),
     PrismaticGroundConstraint(PrismaticPositionGroundConstraint),
     #[cfg(feature = "simd-is-enabled")]
@@ -69,9 +68,9 @@ impl AnyJointPositionConstraint {
             JointParams::FixedJoint(p) => AnyJointPositionConstraint::FixedJoint(
                 FixedPositionConstraint::from_params(rb1, rb2, p),
             ),
-            JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericJoint(
-                GenericPositionConstraint::from_params(rb1, rb2, p),
-            ),
+            // JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericJoint(
+            //     GenericPositionConstraint::from_params(rb1, rb2, p),
+            // ),
             JointParams::PrismaticJoint(p) => AnyJointPositionConstraint::PrismaticJoint(
                 PrismaticPositionConstraint::from_params(rb1, rb2, p),
             ),
@@ -140,9 +139,9 @@ impl AnyJointPositionConstraint {
             JointParams::FixedJoint(p) => AnyJointPositionConstraint::FixedGroundConstraint(
                 FixedPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
             ),
-            JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericGroundConstraint(
-                GenericPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
-            ),
+            // JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericGroundConstraint(
+            //     GenericPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
+            // ),
             JointParams::PrismaticJoint(p) => {
                 AnyJointPositionConstraint::PrismaticGroundConstraint(
                     PrismaticPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
@@ -219,12 +218,12 @@ impl AnyJointPositionConstraint {
             AnyJointPositionConstraint::WFixedJoint(c) => c.solve(params, positions),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointPositionConstraint::WFixedGroundConstraint(c) => c.solve(params, positions),
-            AnyJointPositionConstraint::GenericJoint(c) => c.solve(params, positions),
-            AnyJointPositionConstraint::GenericGroundConstraint(c) => c.solve(params, positions),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointPositionConstraint::WGenericJoint(c) => c.solve(params, positions),
-            #[cfg(feature = "simd-is-enabled")]
-            AnyJointPositionConstraint::WGenericGroundConstraint(c) => c.solve(params, positions),
+            // AnyJointPositionConstraint::GenericJoint(c) => c.solve(params, positions),
+            // AnyJointPositionConstraint::GenericGroundConstraint(c) => c.solve(params, positions),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointPositionConstraint::WGenericJoint(c) => c.solve(params, positions),
+            // #[cfg(feature = "simd-is-enabled")]
+            // AnyJointPositionConstraint::WGenericGroundConstraint(c) => c.solve(params, positions),
             AnyJointPositionConstraint::PrismaticJoint(c) => c.solve(params, positions),
             AnyJointPositionConstraint::PrismaticGroundConstraint(c) => c.solve(params, positions),
             #[cfg(feature = "simd-is-enabled")]

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -14,6 +14,7 @@ use super::{
     WFixedPositionGroundConstraint, WGenericPositionConstraint, WGenericPositionGroundConstraint,
     WPrismaticPositionConstraint, WPrismaticPositionGroundConstraint,
 };
+use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{IntegrationParameters, Joint, JointParams, RigidBodySet};
 #[cfg(feature = "simd-is-enabled")]
 use crate::math::SIMD_WIDTH;
@@ -238,6 +239,22 @@ impl AnyJointPositionConstraint {
             AnyJointPositionConstraint::WRevoluteJoint(c) => c.solve(params, positions),
             #[cfg(all(feature = "dim3", feature = "simd-is-enabled"))]
             AnyJointPositionConstraint::WRevoluteGroundConstraint(c) => c.solve(params, positions),
+            AnyJointPositionConstraint::Empty => unreachable!(),
+        }
+    }
+
+    pub fn solve2(
+        &self,
+        params: &IntegrationParameters,
+        positions: &mut [Isometry<Real>],
+        dpos: &mut [DeltaVel<Real>],
+    ) {
+        match self {
+            AnyJointPositionConstraint::GenericJoint(c) => c.solve2(params, positions, dpos),
+            AnyJointPositionConstraint::GenericGroundConstraint(c) => {
+                c.solve2(params, positions, dpos)
+            }
+            _ => {}
             AnyJointPositionConstraint::Empty => unreachable!(),
         }
     }

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -10,8 +10,8 @@ use super::{WRevolutePositionConstraint, WRevolutePositionGroundConstraint};
 #[cfg(feature = "simd-is-enabled")]
 use super::{
     WBallPositionConstraint, WBallPositionGroundConstraint, WFixedPositionConstraint,
-    WFixedPositionGroundConstraint, WGenericPositionConstraint, WGenericPositionGroundConstraint,
-    WPrismaticPositionConstraint, WPrismaticPositionGroundConstraint,
+    WFixedPositionGroundConstraint, WPrismaticPositionConstraint,
+    WPrismaticPositionGroundConstraint,
 };
 use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{IntegrationParameters, Joint, JointParams, RigidBodySet};
@@ -99,12 +99,12 @@ impl AnyJointPositionConstraint {
                     rbs1, rbs2, joints,
                 ))
             }
-            JointParams::GenericJoint(_) => {
-                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
-                AnyJointPositionConstraint::WGenericJoint(WGenericPositionConstraint::from_params(
-                    rbs1, rbs2, joints,
-                ))
-            }
+            // JointParams::GenericJoint(_) => {
+            //     let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+            //     AnyJointPositionConstraint::WGenericJoint(WGenericPositionConstraint::from_params(
+            //         rbs1, rbs2, joints,
+            //     ))
+            // }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];
@@ -180,12 +180,12 @@ impl AnyJointPositionConstraint {
                     WFixedPositionGroundConstraint::from_params(rbs1, rbs2, joints, flipped),
                 )
             }
-            JointParams::GenericJoint(_) => {
-                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
-                AnyJointPositionConstraint::WGenericGroundConstraint(
-                    WGenericPositionGroundConstraint::from_params(rbs1, rbs2, joints, flipped),
-                )
-            }
+            // JointParams::GenericJoint(_) => {
+            //     let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+            //     AnyJointPositionConstraint::WGenericGroundConstraint(
+            //         WGenericPositionGroundConstraint::from_params(rbs1, rbs2, joints, flipped),
+            //     )
+            // }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -1,6 +1,7 @@
 use super::{
     BallPositionConstraint, BallPositionGroundConstraint, FixedPositionConstraint,
-    FixedPositionGroundConstraint, PrismaticPositionConstraint, PrismaticPositionGroundConstraint,
+    FixedPositionGroundConstraint, GenericPositionConstraint, GenericPositionGroundConstraint,
+    PrismaticPositionConstraint, PrismaticPositionGroundConstraint,
 };
 #[cfg(feature = "dim3")]
 use super::{RevolutePositionConstraint, RevolutePositionGroundConstraint};
@@ -10,8 +11,8 @@ use super::{WRevolutePositionConstraint, WRevolutePositionGroundConstraint};
 #[cfg(feature = "simd-is-enabled")]
 use super::{
     WBallPositionConstraint, WBallPositionGroundConstraint, WFixedPositionConstraint,
-    WFixedPositionGroundConstraint, WPrismaticPositionConstraint,
-    WPrismaticPositionGroundConstraint,
+    WFixedPositionGroundConstraint, WGenericPositionConstraint, WGenericPositionGroundConstraint,
+    WPrismaticPositionConstraint, WPrismaticPositionGroundConstraint,
 };
 use crate::dynamics::{IntegrationParameters, Joint, JointParams, RigidBodySet};
 #[cfg(feature = "simd-is-enabled")]
@@ -31,6 +32,12 @@ pub(crate) enum AnyJointPositionConstraint {
     WFixedJoint(WFixedPositionConstraint),
     #[cfg(feature = "simd-is-enabled")]
     WFixedGroundConstraint(WFixedPositionGroundConstraint),
+    GenericJoint(GenericPositionConstraint),
+    GenericGroundConstraint(GenericPositionGroundConstraint),
+    #[cfg(feature = "simd-is-enabled")]
+    WGenericJoint(WGenericPositionConstraint),
+    #[cfg(feature = "simd-is-enabled")]
+    WGenericGroundConstraint(WGenericPositionGroundConstraint),
     PrismaticJoint(PrismaticPositionConstraint),
     PrismaticGroundConstraint(PrismaticPositionGroundConstraint),
     #[cfg(feature = "simd-is-enabled")]
@@ -61,6 +68,9 @@ impl AnyJointPositionConstraint {
             JointParams::FixedJoint(p) => AnyJointPositionConstraint::FixedJoint(
                 FixedPositionConstraint::from_params(rb1, rb2, p),
             ),
+            JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericJoint(
+                GenericPositionConstraint::from_params(rb1, rb2, p),
+            ),
             JointParams::PrismaticJoint(p) => AnyJointPositionConstraint::PrismaticJoint(
                 PrismaticPositionConstraint::from_params(rb1, rb2, p),
             ),
@@ -86,6 +96,12 @@ impl AnyJointPositionConstraint {
             JointParams::FixedJoint(_) => {
                 let joints = array![|ii| joints[ii].params.as_fixed_joint().unwrap(); SIMD_WIDTH];
                 AnyJointPositionConstraint::WFixedJoint(WFixedPositionConstraint::from_params(
+                    rbs1, rbs2, joints,
+                ))
+            }
+            JointParams::GenericJoint(_) => {
+                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+                AnyJointPositionConstraint::WGenericJoint(WGenericPositionConstraint::from_params(
                     rbs1, rbs2, joints,
                 ))
             }
@@ -122,6 +138,9 @@ impl AnyJointPositionConstraint {
             ),
             JointParams::FixedJoint(p) => AnyJointPositionConstraint::FixedGroundConstraint(
                 FixedPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
+            ),
+            JointParams::GenericJoint(p) => AnyJointPositionConstraint::GenericGroundConstraint(
+                GenericPositionGroundConstraint::from_params(rb1, rb2, p, flipped),
             ),
             JointParams::PrismaticJoint(p) => {
                 AnyJointPositionConstraint::PrismaticGroundConstraint(
@@ -161,6 +180,12 @@ impl AnyJointPositionConstraint {
                     WFixedPositionGroundConstraint::from_params(rbs1, rbs2, joints, flipped),
                 )
             }
+            JointParams::GenericJoint(_) => {
+                let joints = array![|ii| joints[ii].params.as_generic_joint().unwrap(); SIMD_WIDTH];
+                AnyJointPositionConstraint::WGenericGroundConstraint(
+                    WGenericPositionGroundConstraint::from_params(rbs1, rbs2, joints, flipped),
+                )
+            }
             JointParams::PrismaticJoint(_) => {
                 let joints =
                     array![|ii| joints[ii].params.as_prismatic_joint().unwrap(); SIMD_WIDTH];
@@ -193,6 +218,12 @@ impl AnyJointPositionConstraint {
             AnyJointPositionConstraint::WFixedJoint(c) => c.solve(params, positions),
             #[cfg(feature = "simd-is-enabled")]
             AnyJointPositionConstraint::WFixedGroundConstraint(c) => c.solve(params, positions),
+            AnyJointPositionConstraint::GenericJoint(c) => c.solve(params, positions),
+            AnyJointPositionConstraint::GenericGroundConstraint(c) => c.solve(params, positions),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointPositionConstraint::WGenericJoint(c) => c.solve(params, positions),
+            #[cfg(feature = "simd-is-enabled")]
+            AnyJointPositionConstraint::WGenericGroundConstraint(c) => c.solve(params, positions),
             AnyJointPositionConstraint::PrismaticJoint(c) => c.solve(params, positions),
             AnyJointPositionConstraint::PrismaticGroundConstraint(c) => c.solve(params, positions),
             #[cfg(feature = "simd-is-enabled")]

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -242,20 +242,4 @@ impl AnyJointPositionConstraint {
             AnyJointPositionConstraint::Empty => unreachable!(),
         }
     }
-
-    pub fn solve2(
-        &self,
-        params: &IntegrationParameters,
-        positions: &mut [Isometry<Real>],
-        dpos: &mut [DeltaVel<Real>],
-    ) {
-        match self {
-            AnyJointPositionConstraint::GenericJoint(c) => c.solve2(params, positions, dpos),
-            AnyJointPositionConstraint::GenericGroundConstraint(c) => {
-                c.solve2(params, positions, dpos)
-            }
-            _ => {}
-            AnyJointPositionConstraint::Empty => unreachable!(),
-        }
-    }
 }

--- a/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_position_constraint.rs
@@ -13,7 +13,6 @@ use super::{
     WFixedPositionGroundConstraint, WPrismaticPositionConstraint,
     WPrismaticPositionGroundConstraint,
 };
-use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{IntegrationParameters, Joint, JointParams, RigidBodySet};
 #[cfg(feature = "simd-is-enabled")]
 use crate::math::SIMD_WIDTH;

--- a/src/dynamics/solver/joint_constraint/mod.rs
+++ b/src/dynamics/solver/joint_constraint/mod.rs
@@ -18,20 +18,20 @@ pub(self) use fixed_velocity_constraint::{FixedVelocityConstraint, FixedVelocity
 pub(self) use fixed_velocity_constraint_wide::{
     WFixedVelocityConstraint, WFixedVelocityGroundConstraint,
 };
-pub(self) use generic_position_constraint::{
-    GenericPositionConstraint, GenericPositionGroundConstraint,
-};
-#[cfg(feature = "simd-is-enabled")]
-pub(self) use generic_position_constraint_wide::{
-    WGenericPositionConstraint, WGenericPositionGroundConstraint,
-};
-pub(self) use generic_velocity_constraint::{
-    GenericVelocityConstraint, GenericVelocityGroundConstraint,
-};
-#[cfg(feature = "simd-is-enabled")]
-pub(self) use generic_velocity_constraint_wide::{
-    WGenericVelocityConstraint, WGenericVelocityGroundConstraint,
-};
+// pub(self) use generic_position_constraint::{
+//     GenericPositionConstraint, GenericPositionGroundConstraint,
+// };
+// #[cfg(feature = "simd-is-enabled")]
+// pub(self) use generic_position_constraint_wide::{
+//     WGenericPositionConstraint, WGenericPositionGroundConstraint,
+// };
+// pub(self) use generic_velocity_constraint::{
+//     GenericVelocityConstraint, GenericVelocityGroundConstraint,
+// };
+// #[cfg(feature = "simd-is-enabled")]
+// pub(self) use generic_velocity_constraint_wide::{
+//     WGenericVelocityConstraint, WGenericVelocityGroundConstraint,
+// };
 
 pub(crate) use joint_constraint::AnyJointVelocityConstraint;
 pub(crate) use joint_position_constraint::AnyJointPositionConstraint;
@@ -78,12 +78,12 @@ mod fixed_position_constraint_wide;
 mod fixed_velocity_constraint;
 #[cfg(feature = "simd-is-enabled")]
 mod fixed_velocity_constraint_wide;
-mod generic_position_constraint;
-#[cfg(feature = "simd-is-enabled")]
-mod generic_position_constraint_wide;
-mod generic_velocity_constraint;
-#[cfg(feature = "simd-is-enabled")]
-mod generic_velocity_constraint_wide;
+// mod generic_position_constraint;
+// #[cfg(feature = "simd-is-enabled")]
+// mod generic_position_constraint_wide;
+// mod generic_velocity_constraint;
+// #[cfg(feature = "simd-is-enabled")]
+// mod generic_velocity_constraint_wide;
 mod joint_constraint;
 mod joint_position_constraint;
 mod prismatic_position_constraint;

--- a/src/dynamics/solver/joint_constraint/mod.rs
+++ b/src/dynamics/solver/joint_constraint/mod.rs
@@ -18,6 +18,21 @@ pub(self) use fixed_velocity_constraint::{FixedVelocityConstraint, FixedVelocity
 pub(self) use fixed_velocity_constraint_wide::{
     WFixedVelocityConstraint, WFixedVelocityGroundConstraint,
 };
+pub(self) use generic_position_constraint::{
+    GenericPositionConstraint, GenericPositionGroundConstraint,
+};
+#[cfg(feature = "simd-is-enabled")]
+pub(self) use generic_position_constraint_wide::{
+    WGenericPositionConstraint, WGenericPositionGroundConstraint,
+};
+pub(self) use generic_velocity_constraint::{
+    GenericVelocityConstraint, GenericVelocityGroundConstraint,
+};
+#[cfg(feature = "simd-is-enabled")]
+pub(self) use generic_velocity_constraint_wide::{
+    WGenericVelocityConstraint, WGenericVelocityGroundConstraint,
+};
+
 pub(crate) use joint_constraint::AnyJointVelocityConstraint;
 pub(crate) use joint_position_constraint::AnyJointPositionConstraint;
 pub(self) use prismatic_position_constraint::{
@@ -63,6 +78,12 @@ mod fixed_position_constraint_wide;
 mod fixed_velocity_constraint;
 #[cfg(feature = "simd-is-enabled")]
 mod fixed_velocity_constraint_wide;
+mod generic_position_constraint;
+#[cfg(feature = "simd-is-enabled")]
+mod generic_position_constraint_wide;
+mod generic_velocity_constraint;
+#[cfg(feature = "simd-is-enabled")]
+mod generic_velocity_constraint_wide;
 mod joint_constraint;
 mod joint_position_constraint;
 mod prismatic_position_constraint;

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint_wide.rs
@@ -7,7 +7,7 @@ use crate::dynamics::{
 use crate::math::{
     AngVector, AngularInertia, Isometry, Point, Real, SimdBool, SimdReal, Vector, SIMD_WIDTH,
 };
-use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
+use crate::utils::{WAngularInertia, WCross, WCrossMatrix, WDot};
 #[cfg(feature = "dim3")]
 use na::{Cholesky, Matrix3x2, Matrix5, Vector5, U2, U3};
 #[cfg(feature = "dim2")]
@@ -223,8 +223,8 @@ impl WPrismaticVelocityConstraint {
                 limits_inv_lhs = SimdReal::splat(1.0)
                     / (im1
                         + im2
-                        + gcross1.dot(&ii1.transform_vector(gcross1))
-                        + gcross2.dot(&ii2.transform_vector(gcross2)));
+                        + gcross1.gdot(ii1.transform_vector(gcross1))
+                        + gcross2.gdot(ii2.transform_vector(gcross2)));
             }
         }
 

--- a/src/dynamics/solver/joint_constraint/revolute_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_position_constraint.rs
@@ -1,7 +1,7 @@
 use crate::dynamics::{IntegrationParameters, RevoluteJoint, RigidBody};
 use crate::math::{AngularInertia, Isometry, Point, Real, Rotation, Vector};
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
-use na::{Matrix3x2, Matrix5, Unit};
+use na::Unit;
 
 #[derive(Debug)]
 pub(crate) struct RevolutePositionConstraint {

--- a/src/dynamics/solver/joint_constraint/revolute_position_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_position_constraint.rs
@@ -1,12 +1,15 @@
 use crate::dynamics::{IntegrationParameters, RevoluteJoint, RigidBody};
 use crate::math::{AngularInertia, Isometry, Point, Real, Rotation, Vector};
-use crate::utils::WAngularInertia;
-use na::Unit;
+use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
+use na::{Matrix3x2, Matrix5, Unit};
 
 #[derive(Debug)]
 pub(crate) struct RevolutePositionConstraint {
     position1: usize,
     position2: usize,
+
+    local_com1: Point<Real>,
+    local_com2: Point<Real>,
 
     im1: Real,
     im2: Real,
@@ -14,7 +17,6 @@ pub(crate) struct RevolutePositionConstraint {
     ii1: AngularInertia<Real>,
     ii2: AngularInertia<Real>,
 
-    lin_inv_lhs: Real,
     ang_inv_lhs: AngularInertia<Real>,
 
     local_anchor1: Point<Real>,
@@ -22,6 +24,8 @@ pub(crate) struct RevolutePositionConstraint {
 
     local_axis1: Unit<Vector<Real>>,
     local_axis2: Unit<Vector<Real>>,
+    local_basis1: [Vector<Real>; 2],
+    local_basis2: [Vector<Real>; 2],
 }
 
 impl RevolutePositionConstraint {
@@ -30,7 +34,6 @@ impl RevolutePositionConstraint {
         let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
         let im1 = rb1.effective_inv_mass;
         let im2 = rb2.effective_inv_mass;
-        let lin_inv_lhs = 1.0 / (im1 + im2);
         let ang_inv_lhs = (ii1 + ii2).inverse();
 
         Self {
@@ -38,14 +41,17 @@ impl RevolutePositionConstraint {
             im2,
             ii1,
             ii2,
-            lin_inv_lhs,
             ang_inv_lhs,
+            local_com1: rb1.mass_properties.local_com,
+            local_com2: rb2.mass_properties.local_com,
             local_anchor1: cparams.local_anchor1,
             local_anchor2: cparams.local_anchor2,
             local_axis1: cparams.local_axis1,
             local_axis2: cparams.local_axis2,
             position1: rb1.active_set_offset,
             position2: rb2.active_set_offset,
+            local_basis1: cparams.basis1,
+            local_basis2: cparams.basis2,
         }
     }
 
@@ -53,27 +59,122 @@ impl RevolutePositionConstraint {
         let mut position1 = positions[self.position1 as usize];
         let mut position2 = positions[self.position2 as usize];
 
-        let axis1 = position1 * self.local_axis1;
-        let axis2 = position2 * self.local_axis2;
-        let delta_rot =
-            Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
-        let ang_error = delta_rot.scaled_axis() * params.joint_erp;
-        let ang_impulse = self.ang_inv_lhs.transform_vector(ang_error);
-
-        position1.rotation =
-            Rotation::new(self.ii1.transform_vector(ang_impulse)) * position1.rotation;
-        position2.rotation =
-            Rotation::new(self.ii2.transform_vector(-ang_impulse)) * position2.rotation;
-
         let anchor1 = position1 * self.local_anchor1;
         let anchor2 = position2 * self.local_anchor2;
+        let axis1 = position1 * self.local_axis1;
+        let axis2 = position2 * self.local_axis2;
+
+        let basis1 = Matrix3x2::from_columns(&[
+            position1 * self.local_basis1[0],
+            position1 * self.local_basis1[1],
+        ]);
+        let basis2 = Matrix3x2::from_columns(&[
+            position2 * self.local_basis2[0],
+            position2 * self.local_basis2[1],
+        ]);
+
+        let basis_filter1 = basis1 * basis1.transpose();
+        let basis_filter2 = basis2 * basis2.transpose();
+        let basis2 = basis_filter2 * basis1;
+
+        let r1 = anchor1 - position1 * self.local_com1;
+        let r2 = anchor2 - position2 * self.local_com2;
+        let r1_mat = basis_filter1 * r1.gcross_matrix();
+        let r2_mat = basis_filter2 * r2.gcross_matrix();
+
+        let mut lhs = Matrix5::zeros();
+        let lhs00 = self.ii2.quadform(&r2_mat).add_diagonal(self.im2)
+            + self.ii1.quadform(&r1_mat).add_diagonal(self.im1);
+        let lhs10 = basis2.tr_mul(&(self.ii2 * r2_mat)) + basis1.tr_mul(&(self.ii1 * r1_mat));
+        let lhs11 = (self.ii1.quadform3x2(&basis1) + self.ii2.quadform3x2(&basis2)).into_matrix();
+
+        // Note that cholesky won't read the upper-right part
+        // of lhs so we don't have to fill it.
+        lhs.fixed_slice_mut::<na::U3, na::U3>(0, 0)
+            .copy_from(&lhs00.into_matrix());
+        lhs.fixed_slice_mut::<na::U2, na::U3>(3, 0)
+            .copy_from(&lhs10);
+        lhs.fixed_slice_mut::<na::U2, na::U2>(3, 3)
+            .copy_from(&lhs11);
+
+        let inv_lhs = na::Cholesky::new_unchecked(lhs).inverse();
 
         let delta_tra = anchor2 - anchor1;
         let lin_error = delta_tra * params.joint_erp;
-        let lin_impulse = self.lin_inv_lhs * lin_error;
+        let delta_rot =
+            Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
 
+        let ang_error = basis1.tr_mul(&delta_rot.scaled_axis()) * params.joint_erp;
+        let error = na::Vector5::new(
+            lin_error.x,
+            lin_error.y,
+            lin_error.z,
+            ang_error.x,
+            ang_error.y,
+        );
+        let impulse = inv_lhs * error;
+        let lin_impulse = impulse.fixed_rows::<na::U3>(0).into_owned();
+        let ang_impulse1 = basis1 * impulse.fixed_rows::<na::U2>(3).into_owned();
+        let ang_impulse2 = basis2 * impulse.fixed_rows::<na::U2>(3).into_owned();
+
+        let rot1 = self.ii1 * (r1_mat * lin_impulse + ang_impulse1);
+        let rot2 = self.ii2 * (r2_mat * lin_impulse + ang_impulse2);
+        position1.rotation = Rotation::new(rot1) * position1.rotation;
+        position2.rotation = Rotation::new(-rot2) * position2.rotation;
         position1.translation.vector += self.im1 * lin_impulse;
         position2.translation.vector -= self.im2 * lin_impulse;
+
+        /*
+        /*
+         * Linear part.
+         */
+        {
+            let anchor1 = position1 * self.local_anchor1;
+            let anchor2 = position2 * self.local_anchor2;
+
+            let r1 = anchor1 - position1 * self.local_com1;
+            let r2 = anchor2 - position2 * self.local_com2;
+            // TODO: don't the the "to_matrix".
+            let lhs = (self
+                .ii2
+                .quadform(&r2.gcross_matrix())
+                .add_diagonal(self.im2)
+                + self
+                    .ii1
+                    .quadform(&r1.gcross_matrix())
+                    .add_diagonal(self.im1))
+            .into_matrix();
+            let inv_lhs = lhs.try_inverse().unwrap();
+
+            let delta_tra = anchor2 - anchor1;
+            let lin_error = delta_tra * params.joint_erp;
+            let lin_impulse = inv_lhs * lin_error;
+
+            let rot1 = self.ii1 * r1.gcross(lin_impulse);
+            let rot2 = self.ii2 * r2.gcross(lin_impulse);
+            position1.rotation = Rotation::new(rot1) * position1.rotation;
+            position2.rotation = Rotation::new(-rot2) * position2.rotation;
+            position1.translation.vector += self.im1 * lin_impulse;
+            position2.translation.vector -= self.im2 * lin_impulse;
+        }
+
+        /*
+         * Angular part.
+         */
+        {
+            let axis1 = position1 * self.local_axis1;
+            let axis2 = position2 * self.local_axis2;
+            let delta_rot =
+                Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
+            let ang_error = delta_rot.scaled_axis() * params.joint_erp;
+            let ang_impulse = self.ang_inv_lhs.transform_vector(ang_error);
+
+            position1.rotation =
+                Rotation::new(self.ii1.transform_vector(ang_impulse)) * position1.rotation;
+            position2.rotation =
+                Rotation::new(self.ii2.transform_vector(-ang_impulse)) * position2.rotation;
+        }
+         */
 
         positions[self.position1 as usize] = position1;
         positions[self.position2 as usize] = position2;
@@ -83,10 +184,16 @@ impl RevolutePositionConstraint {
 #[derive(Debug)]
 pub(crate) struct RevolutePositionGroundConstraint {
     position2: usize,
+    local_com2: Point<Real>,
+    im2: Real,
+    ii2: AngularInertia<Real>,
     anchor1: Point<Real>,
     local_anchor2: Point<Real>,
     axis1: Unit<Vector<Real>>,
     local_axis2: Unit<Vector<Real>>,
+
+    basis1: [Vector<Real>; 2],
+    local_basis2: [Vector<Real>; 2],
 }
 
 impl RevolutePositionGroundConstraint {
@@ -100,42 +207,138 @@ impl RevolutePositionGroundConstraint {
         let local_anchor2;
         let axis1;
         let local_axis2;
+        let basis1;
+        let local_basis2;
 
         if flipped {
             anchor1 = rb1.predicted_position * cparams.local_anchor2;
             local_anchor2 = cparams.local_anchor1;
             axis1 = rb1.predicted_position * cparams.local_axis2;
             local_axis2 = cparams.local_axis1;
+            basis1 = [
+                rb1.predicted_position * cparams.basis2[0],
+                rb1.predicted_position * cparams.basis2[1],
+            ];
+            local_basis2 = cparams.basis1;
         } else {
             anchor1 = rb1.predicted_position * cparams.local_anchor1;
             local_anchor2 = cparams.local_anchor2;
             axis1 = rb1.predicted_position * cparams.local_axis1;
             local_axis2 = cparams.local_axis2;
+            basis1 = [
+                rb1.predicted_position * cparams.basis1[0],
+                rb1.predicted_position * cparams.basis1[1],
+            ];
+            local_basis2 = cparams.basis2;
         };
 
         Self {
             anchor1,
             local_anchor2,
+            im2: rb2.effective_inv_mass,
+            ii2: rb2.effective_world_inv_inertia_sqrt.squared(),
+            local_com2: rb2.mass_properties.local_com,
             axis1,
             local_axis2,
             position2: rb2.active_set_offset,
+            basis1,
+            local_basis2,
         }
     }
 
     pub fn solve(&self, params: &IntegrationParameters, positions: &mut [Isometry<Real>]) {
         let mut position2 = positions[self.position2 as usize];
 
+        let anchor1 = self.anchor1;
+        let anchor2 = position2 * self.local_anchor2;
+        let axis1 = self.axis1;
         let axis2 = position2 * self.local_axis2;
 
-        let delta_rot =
-            Rotation::scaled_rotation_between_axis(&axis2, &self.axis1, params.joint_erp)
-                .unwrap_or_else(Rotation::identity);
-        position2.rotation = delta_rot * position2.rotation;
+        let basis1 = Matrix3x2::from_columns(&self.basis1[..]);
+        let basis2 = Matrix3x2::from_columns(&[
+            position2 * self.local_basis2[0],
+            position2 * self.local_basis2[1],
+        ]);
 
-        let anchor2 = position2 * self.local_anchor2;
-        let delta_tra = anchor2 - self.anchor1;
+        let basis_filter2 = basis2 * basis2.transpose();
+        let basis2 = basis_filter2 * basis1;
+
+        let r2 = anchor2 - position2 * self.local_com2;
+        let r2_mat = basis_filter2 * r2.gcross_matrix();
+
+        let mut lhs = Matrix5::zeros();
+        let lhs00 = self.ii2.quadform(&r2_mat).add_diagonal(self.im2);
+        let lhs10 = basis2.tr_mul(&(self.ii2 * r2_mat));
+        let lhs11 = self.ii2.quadform3x2(&basis2).into_matrix();
+
+        // Note that cholesky won't read the upper-right part
+        // of lhs so we don't have to fill it.
+        lhs.fixed_slice_mut::<na::U3, na::U3>(0, 0)
+            .copy_from(&lhs00.into_matrix());
+        lhs.fixed_slice_mut::<na::U2, na::U3>(3, 0)
+            .copy_from(&lhs10);
+        lhs.fixed_slice_mut::<na::U2, na::U2>(3, 3)
+            .copy_from(&lhs11);
+
+        let inv_lhs = na::Cholesky::new_unchecked(lhs).inverse();
+
+        let delta_tra = anchor2 - anchor1;
         let lin_error = delta_tra * params.joint_erp;
-        position2.translation.vector -= lin_error;
+        let delta_rot =
+            Rotation::rotation_between_axis(&axis1, &axis2).unwrap_or_else(Rotation::identity);
+
+        let ang_error = basis1.tr_mul(&delta_rot.scaled_axis()) * params.joint_erp;
+        let error = na::Vector5::new(
+            lin_error.x,
+            lin_error.y,
+            lin_error.z,
+            ang_error.x,
+            ang_error.y,
+        );
+        let impulse = inv_lhs * error;
+        let lin_impulse = impulse.fixed_rows::<na::U3>(0).into_owned();
+        let ang_impulse2 = basis2 * impulse.fixed_rows::<na::U2>(3).into_owned();
+
+        let rot2 = self.ii2 * (r2_mat * lin_impulse + ang_impulse2);
+        position2.rotation = Rotation::new(-rot2) * position2.rotation;
+        position2.translation.vector -= self.im2 * lin_impulse;
+
+        /*
+        /*
+         * Linear part.
+         */
+        {
+            let anchor2 = position2 * self.local_anchor2;
+
+            let r2 = anchor2 - position2 * self.local_com2;
+            // TODO: don't the the "to_matrix".
+            let lhs = self
+                .ii2
+                .quadform(&r2.gcross_matrix())
+                .add_diagonal(self.im2)
+                .into_matrix();
+            let inv_lhs = lhs.try_inverse().unwrap();
+
+            let delta_tra = anchor2 - self.anchor1;
+            let lin_error = delta_tra * params.joint_erp;
+            let lin_impulse = inv_lhs * lin_error;
+
+            let rot2 = self.ii2 * r2.gcross(lin_impulse);
+            position2.rotation = Rotation::new(-rot2) * position2.rotation;
+            position2.translation.vector -= self.im2 * lin_impulse;
+        }
+
+        /*
+         * Angular part.
+         */
+        {
+            let axis2 = position2 * self.local_axis2;
+            let delta_rot = Rotation::rotation_between_axis(&self.axis1, &axis2)
+                .unwrap_or_else(Rotation::identity);
+            let ang_error = delta_rot.scaled_axis() * params.joint_erp;
+            position2.rotation = Rotation::new(-ang_error) * position2.rotation;
+        }
+        */
 
         positions[self.position2 as usize] = position2;
     }

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -56,24 +56,25 @@ impl RevoluteVelocityConstraint {
             rb1.position * joint.basis1[0],
             rb1.position * joint.basis1[1],
         ]);
-        let basis_filter1 = basis1 * basis1.transpose();
-        let basis2 = Matrix3x2::from_columns(&[
+        let basis_projection1 = basis1 * basis1.transpose();
+
+        let basis_projection_half2 = Matrix3x2::from_columns(&[
             rb2.position * joint.basis2[0],
             rb2.position * joint.basis2[1],
         ]);
-        let basis_filter2 = basis2 * basis2.transpose();
-        let basis2 = basis_filter2 * basis1;
+        let basis_projection2 = basis_projection_half2 * basis_projection_half2.transpose();
+        let basis2 = basis_projection2 * basis1;
 
         let im1 = rb1.effective_inv_mass;
         let im2 = rb2.effective_inv_mass;
 
         let ii1 = rb1.effective_world_inv_inertia_sqrt.squared();
         let r1 = anchor1 - rb1.world_com;
-        let r1_mat = basis_filter1 * r1.gcross_matrix();
+        let r1_mat = basis_projection1 * r1.gcross_matrix();
 
         let ii2 = rb2.effective_world_inv_inertia_sqrt.squared();
         let r2 = anchor2 - rb2.world_com;
-        let r2_mat = basis_filter2 * r2.gcross_matrix();
+        let r2_mat = basis_projection2 * r2.gcross_matrix();
 
         let mut lhs = Matrix5::zeros();
         let lhs00 =
@@ -318,15 +319,15 @@ impl RevoluteVelocityGroundConstraint {
             anchor1 = rb1.position * joint.local_anchor2;
             anchor2 = rb2.position * joint.local_anchor1;
             basis2 = Matrix3x2::from_columns(&[
-                rb2.position * joint.basis2[0],
-                rb2.position * joint.basis2[1],
+                rb2.position * joint.basis1[0],
+                rb2.position * joint.basis1[1],
             ]);
         } else {
             anchor1 = rb1.position * joint.local_anchor1;
             anchor2 = rb2.position * joint.local_anchor2;
             basis2 = Matrix3x2::from_columns(&[
-                rb2.position * joint.basis1[0],
-                rb2.position * joint.basis1[1],
+                rb2.position * joint.basis2[0],
+                rb2.position * joint.basis2[1],
             ]);
         };
 

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -1,12 +1,11 @@
-use crate::dynamics::solver::{AnyJointVelocityConstraint, AnyVelocityConstraint, DeltaVel};
+use crate::dynamics::solver::{AnyJointVelocityConstraint, DeltaVel};
 use crate::dynamics::{
     IntegrationParameters, JointGraphEdge, JointIndex, JointParams, RevoluteJoint, RigidBody,
 };
 use crate::math::{AngularInertia, Real, Rotation, Vector};
 use crate::na::UnitQuaternion;
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
-use downcast_rs::Downcast;
-use na::{Cholesky, Matrix3, Matrix3x2, Matrix5, RealField, Vector5, U2, U3};
+use na::{Cholesky, Matrix3x2, Matrix5, Vector5, U2, U3};
 
 #[derive(Debug)]
 pub(crate) struct RevoluteVelocityConstraint {
@@ -93,7 +92,7 @@ impl RevoluteVelocityConstraint {
 
         let lin_rhs = (rb2.linvel + rb2.angvel.gcross(r2)) - (rb1.linvel + rb1.angvel.gcross(r1));
         let ang_rhs = basis2.tr_mul(&rb2.angvel) - basis1.tr_mul(&rb1.angvel);
-        let mut rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
+        let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
 
         /*
          * Motor.
@@ -102,8 +101,8 @@ impl RevoluteVelocityConstraint {
         let motor_axis2 = rb2.position * *joint.local_axis2;
         let mut motor_rhs = 0.0;
         let mut motor_inv_lhs = 0.0;
-        let mut motor_max_impulse = joint.motor_max_impulse;
         let mut motor_angle = 0.0;
+        let motor_max_impulse = joint.motor_max_impulse;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
             params.dt,
@@ -381,8 +380,8 @@ impl RevoluteVelocityGroundConstraint {
          */
         let mut motor_rhs = 0.0;
         let mut motor_inv_lhs = 0.0;
-        let mut motor_max_impulse = joint.motor_max_impulse;
         let mut motor_angle = 0.0;
+        let motor_max_impulse = joint.motor_max_impulse;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
             params.dt,

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
@@ -17,8 +17,8 @@ pub(crate) struct WRevoluteVelocityConstraint {
 
     joint_id: [JointIndex; SIMD_WIDTH],
 
-    r1_mat: Matrix3<SimdReal>,
-    r2_mat: Matrix3<SimdReal>,
+    r1: Vector<SimdReal>,
+    r2: Vector<SimdReal>,
 
     inv_lhs: Matrix5<SimdReal>,
     rhs: Vector5<SimdReal>,
@@ -79,26 +79,18 @@ impl WRevoluteVelocityConstraint {
         let anchor2 = position2 * local_anchor2;
         let basis1 =
             Matrix3x2::from_columns(&[position1 * local_basis1[0], position1 * local_basis1[1]]);
-        let basis_projection1 = basis1 * basis1.transpose();
-        let basis_projection_half2 =
+        let basis2 =
             Matrix3x2::from_columns(&[position2 * local_basis2[0], position2 * local_basis2[1]]);
-        let basis_projection2 = basis_projection_half2 * basis_projection_half2.transpose();
+        let basis_projection2 = basis2 * basis2.transpose();
         let basis2 = basis_projection2 * basis1;
 
-        //        let r21 = Rotation::rotation_between_axis(&axis1, &axis2)
-        //            .unwrap_or_else(Rotation::identity)
-        //            .to_rotation_matrix()
-        //            .into_inner();
-        //        let basis2 = r21 * basis1;
-        // NOTE: to simplify, we use basis2 = basis1.
-        // Though we may want to test if that does not introduce any instability.
         let ii1 = ii1_sqrt.squared();
         let r1 = anchor1 - world_com1;
-        let r1_mat = basis_projection1 * r1.gcross_matrix();
+        let r1_mat = r1.gcross_matrix();
 
         let ii2 = ii2_sqrt.squared();
         let r2 = anchor2 - world_com2;
-        let r2_mat = basis_projection2 * r2.gcross_matrix();
+        let r2_mat = r2.gcross_matrix();
 
         let mut lhs = Matrix5::zeros();
         let lhs00 =
@@ -154,8 +146,8 @@ impl WRevoluteVelocityConstraint {
             impulse,
             inv_lhs,
             rhs,
-            r1_mat,
-            r2_mat,
+            r1,
+            r2,
         }
     }
 
@@ -185,12 +177,12 @@ impl WRevoluteVelocityConstraint {
         mj_lambda1.linear += lin_impulse1 * self.im1;
         mj_lambda1.angular += self
             .ii1_sqrt
-            .transform_vector(ang_impulse1 + self.r1_mat * lin_impulse1);
+            .transform_vector(ang_impulse1 + self.r1.gcross(lin_impulse1));
 
         mj_lambda2.linear -= lin_impulse2 * self.im2;
         mj_lambda2.angular -= self
             .ii2_sqrt
-            .transform_vector(ang_impulse2 + self.r2_mat * lin_impulse2);
+            .transform_vector(ang_impulse2 + self.r2.gcross(lin_impulse2));
 
         for ii in 0..SIMD_WIDTH {
             mj_lambdas[self.mj_lambda1[ii] as usize].linear = mj_lambda1.linear.extract(ii);
@@ -223,8 +215,8 @@ impl WRevoluteVelocityConstraint {
         let ang_vel1 = self.ii1_sqrt.transform_vector(mj_lambda1.angular);
         let ang_vel2 = self.ii2_sqrt.transform_vector(mj_lambda2.angular);
 
-        let lin_dvel = (mj_lambda2.linear - self.r2_mat * ang_vel2)
-            - (mj_lambda1.linear - self.r1_mat * ang_vel1);
+        let lin_dvel = (mj_lambda2.linear + ang_vel2.gcross(self.r2))
+            - (mj_lambda1.linear + ang_vel1.gcross(self.r1));
         let ang_dvel = self.basis2.tr_mul(&ang_vel2) - self.basis1.tr_mul(&ang_vel1);
         let rhs =
             Vector5::new(lin_dvel.x, lin_dvel.y, lin_dvel.z, ang_dvel.x, ang_dvel.y) + self.rhs;
@@ -238,12 +230,12 @@ impl WRevoluteVelocityConstraint {
         mj_lambda1.linear += lin_impulse1 * self.im1;
         mj_lambda1.angular += self
             .ii1_sqrt
-            .transform_vector(ang_impulse1 + self.r1_mat * lin_impulse1);
+            .transform_vector(ang_impulse1 + self.r1.gcross(lin_impulse1));
 
         mj_lambda2.linear -= lin_impulse2 * self.im2;
         mj_lambda2.angular -= self
             .ii2_sqrt
-            .transform_vector(ang_impulse2 + self.r2_mat * lin_impulse2);
+            .transform_vector(ang_impulse2 + self.r2.gcross(lin_impulse2));
 
         for ii in 0..SIMD_WIDTH {
             mj_lambdas[self.mj_lambda1[ii] as usize].linear = mj_lambda1.linear.extract(ii);
@@ -320,6 +312,16 @@ impl WRevoluteVelocityGroundConstraint {
         let local_anchor2 = Point::from(
             array![|ii| if flipped[ii] { joints[ii].local_anchor1 } else { joints[ii].local_anchor2 }; SIMD_WIDTH],
         );
+        let basis1 = Matrix3x2::from_columns(&[
+            position1
+                * Vector::from(
+                    array![|ii| if flipped[ii] { joints[ii].basis2[0] } else { joints[ii].basis1[0] }; SIMD_WIDTH],
+                ),
+            position1
+                * Vector::from(
+                    array![|ii| if flipped[ii] { joints[ii].basis2[1] } else { joints[ii].basis1[1] }; SIMD_WIDTH],
+                ),
+        ]);
         let basis2 = Matrix3x2::from_columns(&[
             position2
                 * Vector::from(
@@ -330,15 +332,12 @@ impl WRevoluteVelocityGroundConstraint {
                     array![|ii| if flipped[ii] { joints[ii].basis1[1] } else { joints[ii].basis2[1] }; SIMD_WIDTH],
                 ),
         ]);
+        let basis_projection2 = basis2 * basis2.transpose();
+        let basis2 = basis_projection2 * basis1;
 
         let anchor1 = position1 * local_anchor1;
         let anchor2 = position2 * local_anchor2;
 
-        //        let r21 = Rotation::rotation_between_axis(&axis1, &axis2)
-        //            .unwrap_or_else(Rotation::identity)
-        //            .to_rotation_matrix()
-        //            .into_inner();
-        //        let basis2 = /*r21 * */ basis1;
         let ii2 = ii2_sqrt.squared();
         let r1 = anchor1 - world_com1;
         let r2 = anchor2 - world_com2;
@@ -358,8 +357,8 @@ impl WRevoluteVelocityGroundConstraint {
 
         let inv_lhs = Cholesky::new_unchecked(lhs).inverse();
 
-        let lin_rhs = linvel2 + angvel2.gcross(r2) - linvel1 - angvel1.gcross(r1);
-        let ang_rhs = basis2.tr_mul(&(angvel2 - angvel1));
+        let lin_rhs = (linvel2 + angvel2.gcross(r2)) - (linvel1 + angvel1.gcross(r1));
+        let ang_rhs = basis2.tr_mul(&angvel2) - basis1.tr_mul(&angvel1);
         let rhs = Vector5::new(lin_rhs.x, lin_rhs.y, lin_rhs.z, ang_rhs.x, ang_rhs.y);
 
         WRevoluteVelocityGroundConstraint {

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint_wide.rs
@@ -8,7 +8,7 @@ use crate::math::{
     AngVector, AngularInertia, Isometry, Point, Real, Rotation, SimdReal, Vector, SIMD_WIDTH,
 };
 use crate::utils::{WAngularInertia, WCross, WCrossMatrix};
-use na::{Cholesky, Matrix3, Matrix3x2, Matrix5, Vector5, U2, U3};
+use na::{Cholesky, Matrix3x2, Matrix5, Vector5, U2, U3};
 
 #[derive(Debug)]
 pub(crate) struct WRevoluteVelocityConstraint {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,10 +148,4 @@ pub mod math {
     /// single contact constraint.
     #[cfg(feature = "dim3")]
     pub const MAX_MANIFOLD_POINTS: usize = 4;
-
-    #[cfg(feature = "dim2")]
-    pub const SPATIAL_DIM: usize = 3;
-
-    #[cfg(feature = "dim3")]
-    pub const SPATIAL_DIM: usize = 6;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,4 +148,10 @@ pub mod math {
     /// single contact constraint.
     #[cfg(feature = "dim3")]
     pub const MAX_MANIFOLD_POINTS: usize = 4;
+
+    #[cfg(feature = "dim2")]
+    pub const SPATIAL_DIM: usize = 3;
+
+    #[cfg(feature = "dim3")]
+    pub const SPATIAL_DIM: usize = 6;
 }

--- a/src_testbed/nphysics_backend.rs
+++ b/src_testbed/nphysics_backend.rs
@@ -122,6 +122,11 @@ impl NPhysicsWorld {
 
                     nphysics_joints.insert(c);
                 }
+                JointParams::GenericJoint(_) => {
+                    eprintln!(
+                        "Joint type currently unsupported by the nphysics backend: GenericJoint."
+                    )
+                }
             }
         }
 

--- a/src_testbed/nphysics_backend.rs
+++ b/src_testbed/nphysics_backend.rs
@@ -121,12 +121,11 @@ impl NPhysicsWorld {
                     }
 
                     nphysics_joints.insert(c);
-                }
-                JointParams::GenericJoint(_) => {
-                    eprintln!(
-                        "Joint type currently unsupported by the nphysics backend: GenericJoint."
-                    )
-                }
+                } // JointParams::GenericJoint(_) => {
+                  //     eprintln!(
+                  //         "Joint type currently unsupported by the nphysics backend: GenericJoint."
+                  //     )
+                  // }
             }
         }
 

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -344,13 +344,27 @@ impl PhysxWorld {
                             .into_physx()
                             .into();
 
-                        physx_sys::phys_PxRevoluteJointCreate(
+                        let revolute_joint = physx_sys::phys_PxRevoluteJointCreate(
                             physics.as_mut_ptr(),
                             actor1,
                             &frame1 as *const _,
                             actor2,
                             &frame2 as *const _,
                         );
+
+                        physx_sys::PxRevoluteJoint_setDriveVelocity_mut(
+                            revolute_joint,
+                            params.motor_target_vel,
+                            true,
+                        );
+
+                        if params.motor_damping != 0.0 {
+                            physx_sys::PxRevoluteJoint_setRevoluteJointFlag_mut(
+                                revolute_joint,
+                                physx_sys::PxRevoluteJointFlag::eDRIVE_ENABLED,
+                                true,
+                            );
+                        }
                     }
 
                     JointParams::PrismaticJoint(params) => {
@@ -420,12 +434,11 @@ impl PhysxWorld {
                             actor2,
                             &frame2 as *const _,
                         );
-                    }
-                    JointParams::GenericJoint(_) => {
-                        eprintln!(
-                            "Joint type currently unsupported by the nphysics backend: GenericJoint."
-                        )
-                    }
+                    } // JointParams::GenericJoint(_) => {
+                      //     eprintln!(
+                      //         "Joint type currently unsupported by the PhysX backend: GenericJoint."
+                      //     )
+                      // }
                 }
             }
         }

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -421,6 +421,11 @@ impl PhysxWorld {
                             &frame2 as *const _,
                         );
                     }
+                    JointParams::GenericJoint(_) => {
+                        eprintln!(
+                            "Joint type currently unsupported by the nphysics backend: GenericJoint."
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
This adds motors to the prismatic, revolute, and ball joints. The motor acts as a spring-like constraint, configurable as described in #87. As such, it is possible to give the motor a target velocity as well as a target position.

Multiple spring-like equations (velocity-based, acceleration-based, or force-based) can be chosen by the user in a per-joint basis.

The `joint3` demo has been updated to add motorized joint examples.

This PR also includes some preliminary work on a generic 6DoF joint as suggest in #87. However it's not implemented in a very satisfying way yet so its sources are commented out right now.

Fix #87 