### PR TITLE
Implement dominance groups

### DIFF
--- a/src/dynamics/solver/categorization.rs
+++ b/src/dynamics/solver/categorization.rs
@@ -2,6 +2,7 @@ use crate::dynamics::{JointGraphEdge, JointIndex, RigidBodySet};
 use crate::geometry::{ContactManifold, ContactManifoldIndex};
 
 pub(crate) fn categorize_contacts(
+    _bodies: &RigidBodySet, // Unused but useful to simplify the parallel code.
     manifolds: &[&mut ContactManifold],
     manifold_indices: &[ContactManifoldIndex],
     out_ground: &mut Vec<ContactManifoldIndex>,

--- a/src/dynamics/solver/categorization.rs
+++ b/src/dynamics/solver/categorization.rs
@@ -2,7 +2,6 @@ use crate::dynamics::{JointGraphEdge, JointIndex, RigidBodySet};
 use crate::geometry::{ContactManifold, ContactManifoldIndex};
 
 pub(crate) fn categorize_contacts(
-    bodies: &RigidBodySet,
     manifolds: &[&mut ContactManifold],
     manifold_indices: &[ContactManifoldIndex],
     out_ground: &mut Vec<ContactManifoldIndex>,
@@ -10,10 +9,8 @@ pub(crate) fn categorize_contacts(
 ) {
     for manifold_i in manifold_indices {
         let manifold = &manifolds[*manifold_i];
-        let rb1 = &bodies[manifold.data.body_pair.body1];
-        let rb2 = &bodies[manifold.data.body_pair.body2];
 
-        if !rb1.is_dynamic() || !rb2.is_dynamic() {
+        if manifold.data.relative_dominance != 0 {
             out_ground.push(*manifold_i)
         } else {
             out_not_ground.push(*manifold_i)

--- a/src/dynamics/solver/position_ground_constraint.rs
+++ b/src/dynamics/solver/position_ground_constraint.rs
@@ -30,7 +30,7 @@ impl PositionGroundConstraint {
     ) {
         let mut rb1 = &bodies[manifold.data.body_pair.body1];
         let mut rb2 = &bodies[manifold.data.body_pair.body2];
-        let flip = !rb2.is_dynamic();
+        let flip = manifold.data.relative_dominance < 0;
 
         let n1 = if flip {
             std::mem::swap(&mut rb1, &mut rb2);

--- a/src/dynamics/solver/position_ground_constraint_wide.rs
+++ b/src/dynamics/solver/position_ground_constraint_wide.rs
@@ -39,7 +39,7 @@ impl WPositionGroundConstraint {
         let mut flipped = [false; SIMD_WIDTH];
 
         for ii in 0..SIMD_WIDTH {
-            if !rbs2[ii].is_dynamic() {
+            if manifolds[ii].data.relative_dominance < 0 {
                 flipped[ii] = true;
                 std::mem::swap(&mut rbs1[ii], &mut rbs2[ii]);
             }

--- a/src/dynamics/solver/solver_constraints.rs
+++ b/src/dynamics/solver/solver_constraints.rs
@@ -51,6 +51,7 @@ impl SolverConstraints<AnyVelocityConstraint, AnyPositionConstraint> {
         self.not_ground_interactions.clear();
         self.ground_interactions.clear();
         categorize_contacts(
+            bodies,
             manifolds,
             manifold_indices,
             &mut self.ground_interactions,

--- a/src/dynamics/solver/solver_constraints.rs
+++ b/src/dynamics/solver/solver_constraints.rs
@@ -51,7 +51,6 @@ impl SolverConstraints<AnyVelocityConstraint, AnyPositionConstraint> {
         self.not_ground_interactions.clear();
         self.ground_interactions.clear();
         categorize_contacts(
-            bodies,
             manifolds,
             manifold_indices,
             &mut self.ground_interactions,

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -144,6 +144,8 @@ impl VelocityConstraint {
         out_constraints: &mut Vec<AnyVelocityConstraint>,
         push: bool,
     ) {
+        assert_eq!(manifold.data.relative_dominance, 0);
+
         let inv_dt = params.inv_dt();
         let rb1 = &bodies[manifold.data.body_pair.body1];
         let rb2 = &bodies[manifold.data.body_pair.body2];

--- a/src/dynamics/solver/velocity_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_constraint_wide.rs
@@ -67,6 +67,10 @@ impl WVelocityConstraint {
         out_constraints: &mut Vec<AnyVelocityConstraint>,
         push: bool,
     ) {
+        for ii in 0..SIMD_WIDTH {
+            assert_eq!(manifolds[ii].data.relative_dominance, 0);
+        }
+
         let inv_dt = SimdReal::splat(params.inv_dt());
         let rbs1 = array![|ii| &bodies[manifolds[ii].data.body_pair.body1]; SIMD_WIDTH];
         let rbs2 = array![|ii| &bodies[manifolds[ii].data.body_pair.body2]; SIMD_WIDTH];

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -66,7 +66,7 @@ impl VelocityGroundConstraint {
         let inv_dt = params.inv_dt();
         let mut rb1 = &bodies[manifold.data.body_pair.body1];
         let mut rb2 = &bodies[manifold.data.body_pair.body2];
-        let flipped = !rb2.is_dynamic();
+        let flipped = manifold.data.relative_dominance < 0;
 
         let (force_dir1, flipped_multiplier) = if flipped {
             std::mem::swap(&mut rb1, &mut rb2);

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -69,7 +69,7 @@ impl WVelocityGroundConstraint {
         let mut flipped = [1.0; SIMD_WIDTH];
 
         for ii in 0..SIMD_WIDTH {
-            if !rbs2[ii].is_dynamic() {
+            if manifolds[ii].data.relative_dominance < 0 {
                 std::mem::swap(&mut rbs1[ii], &mut rbs2[ii]);
                 flipped[ii] = -1.0;
             }

--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -113,6 +113,8 @@ pub struct ContactManifoldData {
     /// The contacts that will be seen by the constraints solver for computing forces.
     #[cfg_attr(feature = "serde-serialize", serde(skip))]
     pub solver_contacts: Vec<SolverContact>,
+    /// The relative dominance of the bodies involved in this contact manifold.
+    pub relative_dominance: i16,
     /// A user-defined piece of data.
     pub user_data: u32,
 }
@@ -122,7 +124,7 @@ pub struct ContactManifoldData {
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct SolverContact {
     /// The index of the manifold contact used to generate this solver contact.
-    pub contact_id: u8,
+    pub(crate) contact_id: u8,
     /// The world-space contact point.
     pub point: Point<Real>,
     /// The distance between the two original contacts points along the contact normal.
@@ -177,6 +179,7 @@ impl ContactManifoldData {
             solver_flags,
             normal: Vector::zeros(),
             solver_contacts: Vec::new(),
+            relative_dominance: 0,
             user_data: 0,
         }
     }

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -555,6 +555,8 @@ impl NarrowPhase {
                 manifold.data.solver_contacts.clear();
                 manifold.data.body_pair = BodyPair::new(co1.parent(), co2.parent());
                 manifold.data.solver_flags = solver_flags;
+                manifold.data.relative_dominance =
+                    rb1.effective_dominance_group() - rb2.effective_dominance_group();
                 manifold.data.normal = world_pos1 * manifold.local_n1;
 
                 // Generate solver contacts.


### PR DESCRIPTION
This PR adds the support for dominance groups. Each rigid-body is part of a dominance group in `[-127; 127]` (the default is 0). If two rigid-body are in contact, the one with the highest dominance will act as if it has an infinite mass, making it immune to the forces the other body would apply on it. 

For example, if a dynamic body A is in the dominance group 10, and a dynamic body B in the dominance group -20, then a contact between A and B will result in A remaining immobile and B being pushed by A.

If both bodies are part of the same dominance group, then their contacts will work in the usual way (both are affected by opposite forces with the same magnitude).

A non-dynamic rigid-body is always considered as being part of a dominance group greater than any dynamic rigid-body. This means that dynamic/static and dynamic/kinematic contacts will continue to work normally, independently from the dominance group they were given by the user.

Dominance is a completely non-realistic feature. But it can be used to simulate specific effects in games. For example, a player represented as a dynamic rigid-body that cannot be "pushed back" by any, or some, other dynamic rigid-bodies part of the environment.