### PR TITLE
Clamp motor strength to prevent instabilities

### DIFF
--- a/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/ball_velocity_constraint.rs
@@ -91,7 +91,7 @@ impl BallVelocityConstraint {
 
         if motor_max_impulse > 0.0 {
             let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-                params.dt,
+                params,
                 joint.motor_stiffness,
                 joint.motor_damping,
             );
@@ -321,7 +321,7 @@ impl BallVelocityGroundConstraint {
 
         if motor_max_impulse > 0.0 {
             let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-                params.dt,
+                params,
                 joint.motor_stiffness,
                 joint.motor_damping,
             );

--- a/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/prismatic_velocity_constraint.rs
@@ -150,7 +150,7 @@ impl PrismaticVelocityConstraint {
         let mut motor_inv_lhs = 0.0;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-            params.dt,
+            params,
             joint.motor_stiffness,
             joint.motor_damping,
         );
@@ -535,7 +535,7 @@ impl PrismaticVelocityGroundConstraint {
         let mut motor_inv_lhs = 0.0;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-            params.dt,
+            params,
             joint.motor_stiffness,
             joint.motor_damping,
         );

--- a/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/revolute_velocity_constraint.rs
@@ -105,7 +105,7 @@ impl RevoluteVelocityConstraint {
         let motor_max_impulse = joint.motor_max_impulse;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-            params.dt,
+            params,
             joint.motor_stiffness,
             joint.motor_damping,
         );
@@ -384,7 +384,7 @@ impl RevoluteVelocityGroundConstraint {
         let motor_max_impulse = joint.motor_max_impulse;
 
         let (stiffness, damping, gamma, keep_lhs) = joint.motor_model.combine_coefficients(
-            params.dt,
+            params,
             joint.motor_stiffness,
             joint.motor_damping,
         );


### PR DESCRIPTION
Fix https://github.com/dimforge/rapier/issues/125

An alternative is to leave the clamping to the user, but then the safe ranges for stiffness and damping should be clearly documented for each `SpringModel` type. Maybe that's a better idea. 🤷 

I'm not quite sure what is the right thing to do here for `SpringModel::ForceBased` since I'm a bit unsure how it works, or should work. Seems to me `ForceBased` should mean that e.g. two revolute joints with the same motor settings attached to two bodies of different inertia's should lead to different angular accelerations, but afaict there is nothing taking inertia into account for `ForceBased` and in a test I wrote I couldn't get `SpringModel::ForceBased` to work as expected. (personally I think I will stick to using `VelocityBased`)
