### PR TITLE
Call update_world_mass_properties from RigidBody::set_mass_properties

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -187,6 +187,7 @@ impl RigidBody {
         }
 
         self.mass_properties = props;
+        self.update_world_mass_properties();
     }
 
     /// The handles of colliders attached to this rigid body.


### PR DESCRIPTION
I think this was a bug. Related to https://github.com/dimforge/rapier/issues/132