### PR TITLE
Per collider mass props

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -154,7 +154,7 @@ pub struct ColliderBuilder {
     /// The uniform density of the collider to be built.
     density: Option<Real>,
     /// Overrides automatic computation of `MassProperties`.
-    /// If None, it will be computed based on shape and desnity.
+    /// If None, it will be computed based on shape and density.
     mass_properties: Option<MassProperties>,
     /// The friction coefficient of the collider to be built.
     pub friction: Real,

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -465,8 +465,9 @@ impl ColliderBuilder {
     }
 
     /// Sets whether or not the collider built by this builder is a sensor.
+    ///
     /// Sensors will have a default density of zero,
-    /// but if you call [`Self::mass_properties`] you can assigna a mass to a sensor.
+    /// but if you call [`Self::mass_properties`] you can assign a mass to a sensor.
     pub fn sensor(mut self, is_sensor: bool) -> Self {
         self.is_sensor = is_sensor;
         self

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -505,6 +505,7 @@ impl ColliderBuilder {
     }
 
     /// Sets the uniform density of the collider this builder will build.
+    ///
     /// This will be overridden by a call to [`Self::mass_properties`] so it only makes sense to call
     /// either [`Self::density`] or [`Self::mass_properties`].
     pub fn density(mut self, density: Real) -> Self {

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -513,6 +513,7 @@ impl ColliderBuilder {
     }
 
     /// Sets the mass properties of the collider this builder will build.
+    ///
     /// If this is set, [`Self::density`] will be ignored, so it only makes sense to call
     /// either [`Self::density`] or [`Self::mass_properties`].
     pub fn mass_properties(mut self, mass_properties: MassProperties) -> Self {


### PR DESCRIPTION
Fix https://github.com/dimforge/rapier/issues/132

This uses the `Option<Box<MassProperties>>` idea to save memory in the common case.