### PR TITLE
Fix failure in collision pipeline stepping due to hardcoded island size

### DIFF
--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -43,6 +43,7 @@ impl CollisionPipeline {
         colliders: &mut ColliderSet,
         hooks: &dyn PhysicsHooks,
         events: &dyn EventHandler,
+        min_island_size: usize,
     ) {
         bodies.maintain(colliders);
         self.broadphase_collider_pairs.clear();
@@ -61,7 +62,7 @@ impl CollisionPipeline {
             colliders,
             narrow_phase,
             self.empty_joints.joint_graph(),
-            0,
+            min_island_size,
         );
 
         // // Update kinematic bodies velocities.


### PR DESCRIPTION
The min island size was hardcoded as 0 which was causing the assertion
that the min_island_size > 0 to always fail. Added a min island size
param to the step function to prevent this error.

Closes #143 