### PR TITLE
Add the ability to pass a custom filter to all the QueryPipeline queries.

### DIFF
--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1000,6 +1000,7 @@ impl Testbed {
             f32::MAX,
             true,
             InteractionGroups::all(),
+            None,
         );
 
         if let Some((handle, _)) = hit {


### PR DESCRIPTION
Currently, the only way to filter-out some colliders from a query with the `QueryPipeline` is to use an `InteractionGroups`. This group-based solution may not be flexible enough for all use-cases. This PR adds to all the queries arguments a closure that user can use to filter the colliders affected by the queries using custom rules.