### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+## v0.7.0
+### Added
+- Add the support of **Continuous Collision Detection** (CCD) to
+make sure that some fast-moving objects (chosen by the user) don't miss any contacts.
+This is done by using motion-clamping, i.e., each fast-moving rigid-body with CCD enabled will
+be stopped at the time where their first contact happen. This will result in some "time loss" for that
+rigid-body. This loss of time can be reduced by increasing the maximum number  of CCD substeps executed
+(the default being 1).
+- Add the support of **collider modification**. Now, most of the characteristics of a collider can be
+modified after the collider has been created.
+- We now use an **implicit friction cone** for handling friction, instead of a pyramidal approximation
+of the friction cone. This means that friction will now  behave in a more isotropic way (i.e. more realistic
+Coulomb friction).
+- Add the support of **custom filters** for the `QueryPipeline`. So far, interaction groups (bit masks)
+had to be used to exclude from colliders from a query made with the `QueryPipeline`. Now it is also
+possible to provide a custom closures to apply arbitrary user-defined filters.
+- It is now possible to solve penetrations using the velocity solver instead of (or alongside) the
+position solver (this is disabled by default, set `IntegrationParameters::velocity_based_erp` to
+  a value `> 0.0` to enable.).
+
+Added the methods:
+- `ColliderBuilder::halfspace` to create a collider with an unbounded plane shape.
+- `Collider::shape_mut` to get a mutable reference to its shape.
+- `Collider::set_shape`, `::set_restitution_combine_rule`, `::set_position_wrt_parent`, `::set_collision_groups`
+`::set_solver_groups` to change various properties of a collider after its creation.
+- `RigidBodyBuilder::ccd_enabled` to enable CCD for a rigid-body.
+
+### Modified
+- The `target_dist` argument of `QueryPipeline::cast_shape` was removed.
+- `RigidBodyBuilder::mass_properties` has been deprecated, replaced by `::additional_mass_properties`.
+- `RigidBodyBuilder::mass` has been deprecated, replaced by `::additional_mass`.
+- `RigidBodyBuilder::principal_angular_inertia` has been deprecated, replaced by `::additional_principal_angular_inertia`.
+- The field `SolveContact::data` has been replaced by the fields `SolverContact::warmstart_impulse`, 
+  `SolverContact::warmstart_tangent_impulse`, and `SolverContact::prev_rhs`.
+- All the fields of `IntegrationParameters` that we don't use have been removed.
+
+### Fixed
+- The Broad-Phase algorithm has been completely reworked to support large colliders properly (until now
+they could result in very large memory and CPU usage).
+
 ## v0.6.1
 ### Fixed
 - Fix a determinism problem that may happen after snapshot restoration, if a rigid-body is sleeping at
@@ -5,17 +45,15 @@
 
 ## v0.6.0
 ### Added
-The support of **dominance groups** have been added. Each rigid-body is part of a dominance group in [-127; 127]
+- The support of **dominance groups** have been added. Each rigid-body is part of a dominance group in [-127; 127]
 (the default is 0). If two rigid-body are in contact, the one with the highest dominance will act as if it has
 an infinite mass, making it immune to the forces the other body would apply on it. See [#122](https://github.com/dimforge/rapier/pull/122)
 for further details.
-
-The support for **contact modification** has been added. This can bee used to simulate conveyor belts,
+- The support for **contact modification** has been added. This can bee used to simulate conveyor belts,
 one-way platforms and other non-physical effects. It can also be used to simulate materials with
 variable friction and restitution coefficient on a single collider. See [#120](https://github.com/dimforge/rapier/pull/120)
 for further details.
-
-The support for **joint motors** have been added. This can be used to control the position and/or
+- The support for **joint motors** have been added. This can be used to control the position and/or
 velocity of a joint based on a spring-like equation. See [#119](https://github.com/dimforge/rapier/pull/119)
 for further details.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ members = [ "build/rapier2d", "build/rapier2d-f64", "build/rapier_testbed2d", "e
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
-parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
-parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
+#parry2d = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
+#parry3d = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
+#parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
+#parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "special_cases" }
 #ncollide2d = { git = "https://github.com/dimforge/ncollide" }
 #ncollide3d = { git = "https://github.com/dimforge/ncollide" }
 #nphysics2d = { git = "https://github.com/dimforge/nphysics" }

--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -44,12 +44,12 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
 nalgebra = "0.25"
-parry2d-f64 = "0.2"
+parry2d-f64 = "0.3"
 simba = "0.4"
 approx = "0.4"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"
-arrayvec = "0.5"
+arrayvec = "0.6"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -44,12 +44,12 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
 nalgebra = "0.25"
-parry2d = "0.2"
+parry2d = "0.3"
 simba = "0.4"
 approx = "0.4"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"
-arrayvec = "0.5"
+arrayvec = "0.6"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -44,12 +44,12 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
 nalgebra = "^0.25.3"
-parry3d-f64 = "0.2"
+parry3d-f64 = "0.3"
 simba = "0.4"
 approx = "0.4"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"
-arrayvec = "0.5"
+arrayvec = "0.6"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -44,12 +44,12 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
 nalgebra = "^0.25.3"
-parry3d = "0.2"
+parry3d = "0.3"
 simba = "0.4"
 approx = "0.4"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"
-arrayvec = "0.5"
+arrayvec = "0.6"
 bit-vec = "0.6"
 rustc-hash = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }

--- a/build/rapier_testbed2d/Cargo.toml
+++ b/build/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -34,7 +34,7 @@ instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 num_cpus   = { version = "1", optional = true }
 wrapped2d  = { version = "0.4", optional = true }
-parry2d = "0.2"
+parry2d = "0.3"
 ncollide2d = "0.28"
 nphysics2d = { version = "0.20", optional = true }
 crossbeam = "0.8"
@@ -44,5 +44,5 @@ md5 = "0.7"
 
 [dependencies.rapier2d]
 path = "../rapier2d"
-version = "0.6"
+version = "0.7"
 features = [ "serde-serialize" ]

--- a/build/rapier_testbed3d/Cargo.toml
+++ b/build/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.6.1"
+version = "0.7.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -33,7 +33,7 @@ instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 glam       = { version = "0.12", optional = true }
 num_cpus   = { version = "1", optional = true }
-parry3d = "0.2"
+parry3d = "0.3"
 ncollide3d = "0.28"
 nphysics3d = { version = "0.20", optional = true }
 physx      = { version = "0.11", optional = true }
@@ -46,5 +46,5 @@ serde = { version = "1", features = [ "derive" ] }
 
 [dependencies.rapier3d]
 path = "../rapier3d"
-version = "0.6"
+version = "0.7"
 features = [ "serde-serialize" ]

--- a/src/dynamics/ccd/toi_entry.rs
+++ b/src/dynamics/ccd/toi_entry.rs
@@ -130,7 +130,6 @@ impl TOIEntry {
     fn body_motion(body: &RigidBody) -> NonlinearRigidMotion {
         if body.is_ccd_active() {
             NonlinearRigidMotion::new(
-                0.0,
                 body.position,
                 body.mass_properties.local_com,
                 body.linvel,

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -1,6 +1,9 @@
 //! Structures related to dynamics: bodies, joints, etc.
 
+pub use self::ccd::CCDSolver;
+pub use self::coefficient_combine_rule::CoefficientCombineRule;
 pub use self::integration_parameters::IntegrationParameters;
+pub(crate) use self::joint::JointGraphEdge;
 pub(crate) use self::joint::JointIndex;
 #[cfg(feature = "dim3")]
 pub use self::joint::RevoluteJoint;
@@ -14,18 +17,14 @@ pub use self::joint::{
     PrismaticJoint,
     SpringModel, // GenericJoint
 };
+pub(crate) use self::rigid_body::RigidBodyChanges;
 pub use self::rigid_body::{ActivationStatus, BodyStatus, RigidBody, RigidBodyBuilder};
 pub use self::rigid_body_set::{BodyPair, RigidBodyHandle, RigidBodySet};
-pub use parry::mass_properties::MassProperties;
-// #[cfg(not(feature = "parallel"))]
-pub use self::ccd::CCDSolver;
-pub use self::coefficient_combine_rule::CoefficientCombineRule;
-pub(crate) use self::joint::JointGraphEdge;
-pub(crate) use self::rigid_body::RigidBodyChanges;
 #[cfg(not(feature = "parallel"))]
 pub(crate) use self::solver::IslandSolver;
 #[cfg(feature = "parallel")]
 pub(crate) use self::solver::ParallelIslandSolver;
+pub use parry::mass_properties::MassProperties;
 
 mod ccd;
 mod coefficient_combine_rule;

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -234,6 +234,7 @@ impl Collider {
     /// cloned first so that `self` contains a unique copy of that
     /// shape that you can modify.
     pub fn shape_mut(&mut self) -> &mut dyn Shape {
+        self.changes.insert(ColliderChanges::SHAPE);
         self.shape.make_mut()
     }
 

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -500,7 +500,6 @@ impl QueryPipeline {
         shape_vel: &Vector<Real>,
         shape: &dyn Shape,
         max_toi: Real,
-        target_distance: Real,
         query_groups: InteractionGroups,
         filter: Option<&dyn Fn(ColliderHandle, &Collider) -> bool>,
     ) -> Option<(ColliderHandle, TOI)> {
@@ -512,7 +511,6 @@ impl QueryPipeline {
             &pipeline_shape,
             shape,
             max_toi,
-            target_distance,
         );
         self.quadtree.traverse_best_first(&mut visitor).map(|h| h.1)
     }


### PR DESCRIPTION
## v0.7.0
### Added
- Add the support of **Continuous Collision Detection** (CCD) to make sure that some fast-moving objects (chosen by the user) don't miss any contacts. This is done by using motion-clamping, i.e., each fast-moving rigid-body with CCD enabled will be stopped at the time where their first contact happen. This will result in some "time loss" for that rigid-body. This loss of time can be reduced by increasing the maximum number  of CCD substeps executed (the default being 1).
- Add the support of **collider modification**. Now, most of the characteristics of a collider can be modified after the collider has been created.
- We now use an **implicit friction cone** for handling friction, instead of a pyramidal approximation of the friction cone. This means that friction will now  behave in a more isotropic way (i.e. more realistic Coulomb friction).
- Add the support of **custom filters** for the `QueryPipeline`. So far, interaction groups (bit masks) had to be used to exclude from colliders from a query made with the `QueryPipeline`. Now it is also possible to provide a custom closures to apply arbitrary user-defined filters.
- It is now possible to solve penetrations using the velocity solver instead of (or alongside) the
position solver (this is disabled by default, set `IntegrationParameters::velocity_based_erp` to
  a value `> 0.0` to enable.).
  
Added the methods:
- `ColliderBuilder::halfspace` to create a collider with an unbounded plane shape.
- `Collider::shape_mut` to get a mutable reference to its shape.
- `Collider::set_shape`, `::set_restitution_combine_rule`, `::set_position_wrt_parent`, `::set_collision_groups`
`::set_solver_groups` to change various properties of a collider after its creation.
- `RigidBodyBuilder::ccd_enabled` to enable CCD for a rigid-body.

### Modified
- The `target_dist` argument of `QueryPipeline::cast_shape` was removed.
- `RigidBodyBuilder::mass_properties` has been deprecated, replaced by `::additional_mass_properties`.
- `RigidBodyBuilder::mass` has been deprecated, replaced by `::additional_mass`.
- `RigidBodyBuilder::principal_angular_inertia` has been deprecated, replaced by `::additional_principal_angular_inertia`.
- The field `SolveContact::data` has been replaced by the fields `SolverContact::warmstart_impulse`, 
  `SolverContact::warmstart_tangent_impulse`, and `SolverContact::prev_rhs`.
- All the fields of `IntegrationParameters` that we don't use have been removed.

### Fixed
- The Broad-Phase algorithm has been completely reworked to support large colliders properly (until now
they could result in very large memory and CPU usage).