### PR TITLE
Add InteractionGroups::test_or, increase to 64 bits

### DIFF
--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -3,30 +3,45 @@
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 /// Pairwise filtering using bit masks.
 ///
-/// This filtering method is based on two 16-bit values:
-/// - The interaction groups (the 16 left-most bits of `self.0`).
-/// - The interaction mask (the 16 right-most bits of `self.0`).
+/// This filtering method is based on two 32-bit values:
+/// - The interaction groups (the 32 left-most bits of `self.0`).
+/// - The interaction mask (the 32 right-most bits of `self.0`).
 ///
 /// An interaction is allowed between two filters `a` and `b` when two conditions
-/// are met simultaneously:
+/// are met simultaneously for [`Self::test_and`] or individually for [`Self::test_or`]:
 /// - The interaction groups of `a` has at least one bit set to `1` in common with the interaction mask of `b`.
 /// - The interaction groups of `b` has at least one bit set to `1` in common with the interaction mask of `a`.
 ///
-/// In other words, interactions are allowed between two filter iff. the following condition is met:
+/// In other words, interactions are allowed between two filter iff. the following condition is met
+/// for [`Self::test_and`]:
 /// ```ignore
-/// ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
+/// ((self.0 >> 32) & rhs.0) != 0 && ((rhs.0 >> 32) & self.0) != 0
 /// ```
-pub struct InteractionGroups(pub u32);
+/// or for [`Self::test_or`]:
+/// ```ignore
+/// ((self.0 >> 32) & rhs.0) != 0 || ((rhs.0 >> 32) & self.0) != 0
+/// ```
+pub struct InteractionGroups(pub u64);
+
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+/// Specifies which method should be used to test interactions
+pub enum InteractionTestMode {
+    /// Use [`InteractionGroups::test_and`].
+    AND,
+    /// Use [`InteractionGroups::test_or`].
+    OR,
+}
 
 impl InteractionGroups {
     /// Initializes with the given interaction groups and interaction mask.
-    pub const fn new(groups: u16, masks: u16) -> Self {
+    pub const fn new(groups: u32, masks: u32) -> Self {
         Self::none().with_groups(groups).with_mask(masks)
     }
 
     /// Allow interaction with everything.
     pub const fn all() -> Self {
-        Self(u32::MAX)
+        Self(u64::MAX)
     }
 
     /// Prevent all interactions.
@@ -35,22 +50,42 @@ impl InteractionGroups {
     }
 
     /// Sets the group this filter is part of.
-    pub const fn with_groups(self, groups: u16) -> Self {
-        Self((self.0 & 0x0000ffff) | ((groups as u32) << 16))
+    pub const fn with_groups(self, groups: u32) -> Self {
+        Self((self.0 & 0x0000_0000_ffff_ffff) | ((groups as u64) << 32))
     }
 
     /// Sets the interaction mask of this filter.
-    pub const fn with_mask(self, mask: u16) -> Self {
-        Self((self.0 & 0xffff0000) | (mask as u32))
+    pub const fn with_mask(self, mask: u32) -> Self {
+        Self((self.0 & 0xffff_ffff_0000_0000) | (mask as u64))
     }
 
     /// Check if interactions should be allowed based on the interaction groups and mask.
     ///
     /// An interaction is allowed iff. the groups of `self` contain at least one bit set to 1 in common
-    /// with the mask of `rhs`, and vice-versa.
+    /// with the mask of `rhs`, **and** vice-versa.
     #[inline]
-    pub const fn test(self, rhs: Self) -> bool {
-        ((self.0 >> 16) & rhs.0) != 0 && ((rhs.0 >> 16) & self.0) != 0
+    pub const fn test_and(self, rhs: Self) -> bool {
+        ((self.0 >> 32) & rhs.0) != 0 && ((rhs.0 >> 32) & self.0) != 0
+    }
+
+    /// Check if interactions should be allowed based on the interaction groups and mask.
+    ///
+    /// An interaction is allowed iff. the groups of `self` contain at least one bit set to 1 in common
+    /// with the mask of `rhs`, **or** vice-versa.
+    #[inline]
+    pub const fn test_or(self, rhs: Self) -> bool {
+        ((self.0 >> 32) & rhs.0) != 0 || ((rhs.0 >> 32) & self.0) != 0
+    }
+
+    /// Check if interactions should be allowed based on the interaction groups and mask.
+    ///
+    /// See [`InteractionTestMode`] for more info.
+    #[inline]
+    pub const fn test(self, rhs: Self, mode: InteractionTestMode) -> bool {
+        match mode {
+            InteractionTestMode::AND => self.test_and(rhs),
+            InteractionTestMode::OR => self.test_or(rhs),
+        }
     }
 }
 

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -8,7 +8,7 @@ pub use self::contact_pair::{ContactPair, SolverContact, SolverFlags};
 pub use self::interaction_graph::{
     ColliderGraphIndex, InteractionGraph, RigidBodyGraphIndex, TemporaryInteractionIndex,
 };
-pub use self::interaction_groups::InteractionGroups;
+pub use self::interaction_groups::{InteractionGroups, InteractionTestMode};
 pub use self::narrow_phase::NarrowPhase;
 
 pub use parry::query::TrackedContact;


### PR DESCRIPTION
The `InteractionTestMode` is analogous to Bullet's `collisionFilterMode` (see their [PyBullet quickstart guide][pyb], page 39).

Increasing the bits from 32 to 64 is useful when porting Rapier to other engines that already use 64 bit filters (e.g. Godot).

[pyb]: https://raw.githubusercontent.com/bulletphysics/bullet3/master/docs/pybullet_quickstartguide.pdf