### PR TITLE
Add #[must_use] to builders, expose more fields

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -564,7 +564,7 @@ impl RigidBody {
 }
 
 /// A builder for rigid-bodies.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[must_use = "Builder functions return the updated builder"]
 pub struct RigidBodyBuilder {
     /// The initial position of the rigid-body to be built.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -567,19 +567,31 @@ impl RigidBody {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[must_use = "Builder functions return the updated builder"]
 pub struct RigidBodyBuilder {
+    /// The initial position of the rigid-body to be built.
     pub position: Isometry<Real>,
+    /// The linear velocity of the rigid-body to be built.
     pub linvel: Vector<Real>,
+    /// The angular velocity of the rigid-body to be built.
     pub angvel: AngVector<Real>,
+    /// The scale factor applied to the gravity affecting the rigid-body to be built, `1.0` by default.
     pub gravity_scale: Real,
+    /// Damping factor for gradually slowing down the translational motion of the rigid-body, `0.0` by default.
     pub linear_damping: Real,
+    /// Damping factor for gradually slowing down the angular motion of the rigid-body, `0.0` by default.
     pub angular_damping: Real,
-    pub rb_type: RigidBodyType,
-    pub mprops_flags: RigidBodyMassPropsFlags,
+    rb_type: RigidBodyType,
+    mprops_flags: RigidBodyMassPropsFlags,
+    /// The additional mass properties of the rigid-body being built. See [`RigidBodyBuilder::additional_mass_properties`] for more information.
     pub mass_properties: MassProperties,
+    /// Whether or not the rigid-body to be created can sleep if it reaches a dynamic equilibrium.
     pub can_sleep: bool,
+    /// Whether or not the rigid-body is to be created asleep.
     pub sleeping: bool,
+    /// Whether continuous collision-detection is enabled for the rigid-body to be built.
     pub ccd_enabled: bool,
+    /// The dominance group of the rigid-body to be built.
     pub dominance_group: i8,
+    /// An arbitrary user-defined 128-bit integer associated to the rigid-bodies built by this builder.
     pub user_data: u128,
 }
 
@@ -838,7 +850,7 @@ impl RigidBodyBuilder {
         self
     }
 
-    /// Enabled continuous collision-detection for this rigid-body.
+    /// Sets whether or not continuous collision-detection is enabled for this rigid-body.
     pub fn ccd_enabled(mut self, enabled: bool) -> Self {
         self.ccd_enabled = enabled;
         self

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -564,21 +564,23 @@ impl RigidBody {
 }
 
 /// A builder for rigid-bodies.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[must_use = "Builder functions return the updated builder"]
 pub struct RigidBodyBuilder {
-    position: Isometry<Real>,
-    linvel: Vector<Real>,
-    angvel: AngVector<Real>,
-    gravity_scale: Real,
-    linear_damping: Real,
-    angular_damping: Real,
-    rb_type: RigidBodyType,
-    mprops_flags: RigidBodyMassPropsFlags,
-    mass_properties: MassProperties,
-    can_sleep: bool,
-    sleeping: bool,
-    ccd_enabled: bool,
-    dominance_group: i8,
-    user_data: u128,
+    pub position: Isometry<Real>,
+    pub linvel: Vector<Real>,
+    pub angvel: AngVector<Real>,
+    pub gravity_scale: Real,
+    pub linear_damping: Real,
+    pub angular_damping: Real,
+    pub rb_type: RigidBodyType,
+    pub mprops_flags: RigidBodyMassPropsFlags,
+    pub mass_properties: MassProperties,
+    pub can_sleep: bool,
+    pub sleeping: bool,
+    pub ccd_enabled: bool,
+    pub dominance_group: i8,
+    pub user_data: u128,
 }
 
 impl RigidBodyBuilder {

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -197,6 +197,7 @@ impl Collider {
 /// A structure responsible for building a new collider.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[must_use = "Builder functions return the updated builder"]
 pub struct ColliderBuilder {
     /// The shape of the collider to be built.
     pub shape: SharedShape,


### PR DESCRIPTION
I nearly forgot that `RigidBodyBuilder` and `ColliderBuilder` use `mut self` semantics in their parameters setting functions, so a `#[must_use]` seems appropriate.

Also, `RigidBodyBuilder` seemed surprisingly locked-down in terms of field visibilities compared to `ColliderBuilder`. `body_status` is set upfront from the builder's new_* constructors, and `flags` appears to be a crate-private type, so everything else was made public by this PR.

`RigidBodyBuilder` seems like it contains pretty plain data, which permits deriving Copy. Debug should be fine as well as the flags are nicely formatted by `bitflags`.

For my use-case, the builders also serve as creation templates, so having (read-)access to everything is nicer than recreation.

Please let me know if making these fields private was a conscious design decision.