### PR TITLE
Created a method to retrieve the SharedShape from a collider

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -244,6 +244,11 @@ impl Collider {
         self.shape = shape;
     }
 
+    /// Retrieve the SharedShape. Also see the `shape()` function
+    pub fn shared_shape(&self) -> &SharedShape {
+        &self.shape
+    }
+
     /// Compute the axis-aligned bounding box of this collider.
     pub fn compute_aabb(&self) -> AABB {
         self.shape.compute_aabb(&self.position)


### PR DESCRIPTION
In my case this is for creating a compound shape from a set of existing colliders.


I do find if confusing that the `Collider.shape()` method returns a `dyn Shape`, the `Collider.set_shape()` requires a `SharedShape`, but fixing this such that `shape()`  returns a SharedShape would be a breaking change. Perhaps adding a `Collider.set_shared_shape()` method and deprecating `Collider.set_shape()`?