### PR TITLE
Testbed: check if the egui context wants pointer focus, disable orbit camera if so.

### DIFF
--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -423,6 +423,7 @@ impl TestbedApp {
                 .insert_non_send_resource(self.plugins)
                 .add_stage_before(CoreStage::Update, "physics", SystemStage::single_threaded())
                 .add_system_to_stage("physics", update_testbed.system())
+                .add_system(egui_focus.system())
                 .run();
         }
     }
@@ -839,6 +840,16 @@ fn setup_graphics_environment(mut commands: Commands) {
             pan_sensitivity: 0.02,
             ..OrbitCamera::default()
         });
+}
+
+fn egui_focus(ui_context: Res<EguiContext>, mut cameras: Query<&mut OrbitCamera>) {
+    let mut camera_enabled = true;
+    if ui_context.ctx().wants_pointer_input() {
+        camera_enabled = false;
+    }
+    for mut camera in cameras.iter_mut() {
+        camera.enabled = camera_enabled;
+    }
 }
 
 fn update_testbed(


### PR DESCRIPTION
This disables egui interactions being sent to the orbital camera if mouse events happen within egui.

i.e. scrolling on the egui doesnt affect the orbitalcamera's zoom.

This may also want to check for 

```
|| ui_context.ctx().wants_keyboard_input()

```

not sure about this.