### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The user-guide has been fully rewritten and is now exhaustive! Check it out on [
 - Add `RigidBody::set_next_rotation` for setting the next rotation of a position-based kinematic body.
 - Add kinematic bodies controlled at the velocity level: use `RigidBodyBuilder::new_kinematic_velocity_based` or
   `RigidBodyType::KinematicVelocityBased`.
+- Add the cargo feature `debug-disable-legitimate-fe-exceptions` that can be enabled for debugging purpose. This will
+  disable floating point exceptions whenever they happen at places where we do expect them to happen (for example
+  some SIMD code do generate NaNs which are filtered out by lane-wise selection).
 
 ### Modified
 The use of `RigidBodySet, ColliderSet, RigidBody, Collider` is no longer mandatory. Rigid-bodies and colliders have

--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -20,7 +20,6 @@ default = [ "dim2", "f64", "default-sets" ]
 dim2    = [ ]
 f64     = [ ]
 default-sets = [ ]
-avoid-fe-exceptions = [ ]
 parallel = [ "rayon" ]
 simd-stable = [ "simba/wide", "simd-is-enabled" ]
 simd-nightly = [ "simba/packed_simd", "simd-is-enabled" ]
@@ -30,6 +29,9 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d-f64/enhanced-determinism", "indexmap" ]
+
+# Feature used for debugging only.
+debug-disable-legitimate-fe-exceptions = [ ]
 
 # Feature used for development and debugging only.
 # Do not enable this unless you are working on the engine internals.

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -20,7 +20,6 @@ default = [ "dim2", "f32", "default-sets" ]
 dim2    = [ ]
 f32     = [ ]
 default-sets = [ ]
-avoid-fe-exceptions = [ ]
 parallel = [ "rayon" ]
 simd-stable = [ "simba/wide", "simd-is-enabled" ]
 simd-nightly = [ "simba/packed_simd", "simd-is-enabled" ]
@@ -30,6 +29,9 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry2d/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d/enhanced-determinism", "indexmap" ]
+
+# Feature used for debugging only.
+debug-disable-legitimate-fe-exceptions = [ ]
 
 # Feature used for development and debugging only.
 # Do not enable this unless you are working on the engine internals.

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -20,7 +20,6 @@ default = [ "dim3", "f64", "default-sets" ]
 dim3    = [ ]
 f64     = [ ]
 default-sets = [ ]
-avoid-fe-exceptions = [ ]
 parallel = [ "rayon" ]
 simd-stable = [ "parry3d-f64/simd-stable", "simba/wide", "simd-is-enabled" ]
 simd-nightly = [ "parry3d-f64/simd-nightly", "simba/packed_simd", "simd-is-enabled" ]
@@ -30,6 +29,9 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d-f64/enhanced-determinism" ]
+
+# Feature used for debugging only.
+debug-disable-legitimate-fe-exceptions = [ ]
 
 # Feature used for development and debugging only.
 # Do not enable this unless you are working on the engine internals.

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -20,7 +20,6 @@ default = [ "dim3", "f32", "default-sets" ]
 dim3    = [ ]
 f32     = [ ]
 default-sets = [ ]
-avoid-fe-exceptions = [ ]
 parallel = [ "rayon" ]
 simd-stable = [ "parry3d/simd-stable", "simba/wide", "simd-is-enabled" ]
 simd-nightly = [ "parry3d/simd-nightly", "simba/packed_simd", "simd-is-enabled" ]
@@ -30,6 +29,9 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry3d/serde-serialize", "serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d/enhanced-determinism" ]
+
+# Feature used for debugging only.
+debug-disable-legitimate-fe-exceptions = [ ]
 
 # Feature used for development and debugging only.
 # Do not enable this unless you are working on the engine internals.

--- a/build/rapier_testbed2d/Cargo.toml
+++ b/build/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -54,5 +54,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier2d]
 path = "../rapier2d"
-version = "0.8"
+version = "0.9"
 features = [ "serde-serialize" ]

--- a/build/rapier_testbed3d/Cargo.toml
+++ b/build/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.8.0"
+version = "0.9.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -56,5 +56,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier3d]
 path = "../rapier3d"
-version = "0.8"
+version = "0.9"
 features = [ "serde-serialize" ]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -17,7 +17,7 @@ rand       = "0.8"
 Inflector  = "0.11"
 nalgebra   = "0.27"
 lyon       = "0.17"
-usvg       = "0.13"
+usvg       = "0.14"
 
 [dependencies.rapier_testbed2d]
 path = "../build/rapier_testbed2d"

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -248,7 +248,7 @@ impl Collider {
 
     /// Retrieve the SharedShape. Also see the `shape()` function
     pub fn shared_shape(&self) -> &SharedShape {
-        &self.shape
+        &self.co_shape
     }
 
     /// Compute the axis-aligned bounding box of this collider.


### PR DESCRIPTION
## v0.9.0
The user-guide has been fully rewritten and is now exhaustive! It will be uploaded soon on [rapier.rs](https://rapier.rs/) 

### Added
- A prelude has been added in order to simplify the most common imports. For example: `use rapier3d::prelude::*`
- Add `RigidBody::set_translation` and `RigidBody.translation()`.
- Add `RigidBody::set_rotation` and `RigidBody.rotation().
- Add `RigidBody::set_next_translation` for setting the next translation of a position-based kinematic body.
- Add `RigidBody::set_next_rotation` for setting the next rotation of a position-based kinematic body.
- Add kinematic bodies controlled at the velocity level: use `RigidBodyBuilder::new_kinematic_velocity_based` or
  `RigidBodyType::KinematicVelocityBased`.
- Add the cargo feature `debug-disable-legitimate-fe-exceptions` that can be enabled for debugging purpose. This will
  disable floating point exceptions whenever they happen at places where we do expect them to happen (for example
  some SIMD code do generate NaNs which are filtered out by lane-wise selection).

### Modified
The use of `RigidBodySet, ColliderSet, RigidBody, Collider` is no longer mandatory. Rigid-bodies and colliders have
been split into multiple components that can be stored in a user-defined set. This is useful for integrating Rapier
with other engines (for example this allows use to use Bevy's Query as our rigid-body/collider sets).

The `RigidBodySet, ColliderSet, RigidBody, Collider` are still the best option for whoever doesn't want to
provide their own component sets.

#### Rigid-bodies
- Renamed `BodyStatus` to `RigidBodyType`.
- `RigidBodyBuilder::translation` now takes a vector instead of individual components.
- `RigidBodyBuilder::linvel` now takes a vector instead of individual components.
- The `RigidBodyBuilder::new_kinematic` has be replaced by the `RigidBodyBuilder::new_kinematic_position_based` and
  `RigidBodyBuilder::new_kinematic_velocity_based` constructors.
- The `RigidBodyType::Kinematic` variant has been replaced by two variants: `RigidBodyType::KinematicVelocityBased` and
  `RigidBodyType::KinematicPositionBased`.
  
#### Colliders
- `Colliderbuilder::translation` now takes a vector instead of individual components.
- The way `PhysicsHooks` are enabled changed. Now, a physics hooks is executed if any of the two
  colliders involved in the contact/intersection pair contains the related `PhysicsHooksFlag`.
  These flags are configured on each collider with `ColliderBuilder::active_hooks`. As a result,
  there is no `PhysicsHooks::active_hooks` method any more.
- All events are now disabled for all colliders by default. Enable events for specific colliders by setting its
  `active_events` bit mask to `ActiveEvents::CONTACT_EVENTS` and/or `ActiveEvents::PROXIMITY_EVENTS`.
- Add a simpler way of enabling collision-detection between colliders attached to two non-dynamic rigid-bodies: see
  `ColliderBuilder::active_collision_types`.
- The `InteractionGroups` is now a structures with two `u32` integers: one integers for the groups
  membership and one for the group filter mask. (Before, both were only 16-bits wide, and were
  packed into a single `u32`).
- Before, sensor colliders had a default density  set to 0.0 whereas non-sensor colliders had a
  default density of 1.0. This has been unified by setting the default density to 1.0 for both
  sensor and non-sensor colliders.
- Colliders are no longer required to be attached to a rigid-body. Therefore, `ColliderSet::insert`
  only takes the collider as argument now. In order to attach the collider to a rigid-body,
  (i.e., the old behavior of `ColliderSet::insert`), use `ColliderSet::insert_with_parent`.
- Fixed a bug where collision groups were ignored by CCD.

#### Joints
- The fields `FixedJoint::local_anchor1` and `FixedJoint::local_anchor2` have been renamed to
  `FixedJoint::local_frame1` and `FixedJoint::local_frame2`.
  
#### Pipelines and others
- The field `ContactPair::pair` (which contained two collider handles) has been replaced by two
  fields: `ContactPair::collider1` and `ContactPair::collider2`.
- The list of active dynamic bodies is no retrieved with `IslandManager::active_dynamic_bodies`
  instead of `RigidBodySet::iter_active_dynamic`.
- The list of active kinematic bodies is no retrieved with `IslandManager::active_kinematic_bodies`
  instead of `RigidBodySet::iter_active_kinematic`.
- `NarrowPhase::contacts_with` now returns an `impl Iterator<Item = &ContactPair>` instead of 
  an `Option<impl Iterator<Item = (ColliderHandle, ColliderHandle, &ContactPair)>>`. The colliders
  handles can be read from the contact-pair itself.
- `NarrowPhase::intersections_with` now returns an iterator directly instead of an `Option<impl Iterator>`.
- Rename `PhysicsHooksFlags` to `ActiveHooks`.
- Add the contact pair as an argument to `EventHandler::handle_contact_event`