### PR TITLE
Add nalgebra to the prelude to make the macros work out of the box

### DIFF
--- a/benchmarks2d/Cargo.toml
+++ b/benchmarks2d/Cargo.toml
@@ -14,7 +14,6 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 [dependencies]
 rand       = "0.8"
 Inflector  = "0.11"
-nalgebra   = "0.27"
 
 [dependencies.rapier_testbed2d]
 path = "../build/rapier_testbed2d"

--- a/benchmarks2d/all_benchmarks2.rs
+++ b/benchmarks2d/all_benchmarks2.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-extern crate nalgebra as na;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/benchmarks2d/heightfield2.rs
+++ b/benchmarks2d/heightfield2.rs
@@ -1,4 +1,4 @@
-use na::DVector;
+use rapier2d::na::DVector;
 use rapier2d::prelude::*;
 use rapier_testbed2d::Testbed;
 

--- a/benchmarks3d/Cargo.toml
+++ b/benchmarks3d/Cargo.toml
@@ -14,7 +14,6 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 [dependencies]
 rand       = "0.8"
 Inflector  = "0.11"
-nalgebra   = "0.27"
 
 [dependencies.rapier_testbed3d]
 path = "../build/rapier_testbed3d"

--- a/benchmarks3d/all_benchmarks3.rs
+++ b/benchmarks3d/all_benchmarks3.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-extern crate nalgebra as na;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/benchmarks3d/heightfield3.rs
+++ b/benchmarks3d/heightfield3.rs
@@ -1,4 +1,4 @@
-use na::ComplexField;
+use rapier3d::na::ComplexField;
 use rapier3d::prelude::*;
 use rapier_testbed3d::Testbed;
 

--- a/benchmarks3d/trimesh3.rs
+++ b/benchmarks3d/trimesh3.rs
@@ -1,4 +1,4 @@
-use na::ComplexField;
+use rapier3d::na::ComplexField;
 use rapier3d::prelude::*;
 use rapier_testbed3d::Testbed;
 

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -15,7 +15,6 @@ enhanced-determinism = [ "rapier2d/enhanced-determinism" ]
 [dependencies]
 rand       = "0.8"
 Inflector  = "0.11"
-nalgebra   = "0.27"
 lyon       = "0.17"
 usvg       = "0.14"
 

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-extern crate nalgebra as na;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/examples2d/heightfield2.rs
+++ b/examples2d/heightfield2.rs
@@ -1,4 +1,4 @@
-use na::DVector;
+use rapier2d::na::DVector;
 use rapier2d::prelude::*;
 use rapier_testbed2d::Testbed;
 

--- a/examples2d/polyline2.rs
+++ b/examples2d/polyline2.rs
@@ -1,4 +1,4 @@
-use na::ComplexField;
+use rapier2d::na::ComplexField;
 use rapier2d::prelude::*;
 use rapier_testbed2d::Testbed;
 

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -16,7 +16,6 @@ enhanced-determinism = [ "rapier3d/enhanced-determinism" ]
 rand = "0.8"
 getrandom = { version = "0.2", features = [ "js" ] } 
 Inflector  = "0.11"
-nalgebra   = "0.27"
 wasm-bindgen = "0.2"
 obj-rs = { version =  "0.6", default-features = false }
 

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-extern crate nalgebra as na;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/examples3d/all_examples3_wasm.rs
+++ b/examples3d/all_examples3_wasm.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-extern crate nalgebra as na;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 

--- a/examples3d/convex_decomposition3.rs
+++ b/examples3d/convex_decomposition3.rs
@@ -40,7 +40,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let shift = 5.0f32;
 
     for (igeom, obj_path) in geoms.into_iter().enumerate() {
-        let deltas = na::one();
+        let deltas = Isometry::identity();
 
         let mut shapes = Vec::new();
         println!("Parsing and decomposing: {}", obj_path);

--- a/examples3d/heightfield3.rs
+++ b/examples3d/heightfield3.rs
@@ -1,4 +1,4 @@
-use na::ComplexField;
+use rapier3d::na::ComplexField;
 use rapier3d::prelude::*;
 use rapier_testbed3d::Testbed;
 

--- a/examples3d/trimesh3.rs
+++ b/examples3d/trimesh3.rs
@@ -1,4 +1,4 @@
-use na::ComplexField;
+use rapier3d::na::ComplexField;
 use rapier3d::prelude::*;
 use rapier_testbed3d::Testbed;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,4 +157,5 @@ pub mod prelude {
     pub use crate::math::*;
     pub use crate::pipeline::*;
     pub use na::{point, vector, DMatrix, DVector};
+    pub extern crate nalgebra;
 }


### PR DESCRIPTION
Without this, using `vector!` and `point!` won't work because they need `nalgebra` to be in scope. To avoid forcing the user to add an explicit dependency to nalgebra, this PR imports `nalgebra` in `use rapier::prelude::*`.