### PR TITLE
Fix various removal issues

### DIFF
--- a/src/data/coarena.rs
+++ b/src/data/coarena.rs
@@ -21,6 +21,20 @@ impl<T> Coarena<T> {
         self.data.get(index as usize).map(|(_, t)| t)
     }
 
+    /// Deletes an element for the coarena and returns its value.
+    ///
+    /// We can't really remove an element from the coarena. So instead of actually removing
+    /// it, this method will reset the value to the given `removed_value`.
+    pub fn remove(&mut self, index: Index, removed_value: T) -> Option<T> {
+        let (i, g) = index.into_raw_parts();
+        let data = self.data.get_mut(i as usize)?;
+        if g == data.0 {
+            Some(std::mem::replace(&mut data.1, removed_value))
+        } else {
+            None
+        }
+    }
+
     /// Gets a specific element from the coarena, if it exists.
     pub fn get(&self, index: Index) -> Option<&T> {
         let (i, g) = index.into_raw_parts();
@@ -49,6 +63,27 @@ impl<T> Coarena<T> {
         }
 
         self.data[i1 as usize] = (g1, value);
+    }
+
+    /// Ensure that the given element exists in thihs coarena, and return its mutable reference.
+    pub fn ensure_element_exist(&mut self, a: Index, default: T) -> &mut T
+    where
+        T: Clone,
+    {
+        let (i1, g1) = a.into_raw_parts();
+
+        if self.data.len() <= i1 as usize {
+            self.data
+                .resize(i1 as usize + 1, (u32::MAX, default.clone()));
+        }
+
+        let data = &mut self.data[i1 as usize];
+
+        if data.0 != g1 {
+            *data = (g1, default);
+        }
+
+        &mut data.1
     }
 
     /// Ensure that elements at the two given indices exist in this coarena, and return their reference.

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -2,7 +2,7 @@ use crate::data::{ComponentSetMut, ComponentSetOption};
 use crate::dynamics::MassProperties;
 use crate::geometry::{
     ColliderChanges, ColliderHandle, ColliderMassProps, ColliderParent, ColliderPosition,
-    ColliderShape, InteractionGraph, RigidBodyGraphIndex,
+    ColliderShape,
 };
 use crate::math::{AngVector, AngularInertia, Isometry, Point, Real, Translation, Vector};
 use crate::parry::partitioning::IndexedData;
@@ -620,7 +620,6 @@ impl RigidBodyCcd {
 #[derive(Clone, Debug, Copy)]
 /// Internal identifiers used by the physics engine.
 pub struct RigidBodyIds {
-    pub(crate) joint_graph_index: RigidBodyGraphIndex,
     pub(crate) active_island_id: usize,
     pub(crate) active_set_id: usize,
     pub(crate) active_set_offset: usize,
@@ -630,7 +629,6 @@ pub struct RigidBodyIds {
 impl Default for RigidBodyIds {
     fn default() -> Self {
         Self {
-            joint_graph_index: InteractionGraph::<(), ()>::invalid_graph_index(),
             active_island_id: 0,
             active_set_id: 0,
             active_set_offset: 0,

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -156,7 +156,7 @@ impl RigidBodySet {
         /*
          * Remove joints attached to this rigid-body.
          */
-        joints.remove_rigid_body(rb.rb_ids.joint_graph_index, islands, self);
+        joints.remove_joints_attached_to_rigid_body(handle, islands, self);
 
         Some(rb)
     }

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -270,7 +270,10 @@ impl NarrowPhase {
         for collider in removed_colliders {
             // NOTE: if the collider does not have any graph indices currently, there is nothing
             // to remove in the narrow-phase for this collider.
-            if let Some(graph_idx) = self.graph_indices.get(collider.0) {
+            if let Some(graph_idx) = self
+                .graph_indices
+                .remove(collider.0, ColliderGraphIndices::invalid())
+            {
                 let intersection_graph_id = prox_id_remap
                     .get(collider)
                     .copied()
@@ -330,6 +333,10 @@ impl NarrowPhase {
                 replacement.intersection_graph_index = intersection_graph_id;
             } else {
                 prox_id_remap.insert(replacement, intersection_graph_id);
+                // I feel like this should never happen now that the narrow-phase is the one owning
+                // the graph_indices. Let's put an unreachable in there and see if anybody still manages
+                // to reach it. If nobody does, we will remove this.
+                unreachable!();
             }
         }
 
@@ -338,6 +345,10 @@ impl NarrowPhase {
                 replacement.contact_graph_index = contact_graph_id;
             } else {
                 contact_id_remap.insert(replacement, contact_graph_id);
+                // I feel like this should never happen now that the narrow-phase is the one owning
+                // the graph_indices. Let's put an unreachable in there and see if anybody still manages
+                // to reach it. If nobody does, we will remove this.
+                unreachable!();
             }
         }
     }

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -235,7 +235,7 @@ impl PhysicsPipeline {
             bodies,
             colliders,
             narrow_phase,
-            joints.joint_graph(),
+            joints,
             integration_parameters.min_island_size,
         );
         self.counters.stages.island_construction_time.pause();


### PR DESCRIPTION
- Make the method `JointSet::remove_joints_attached_to_rigid_body` public so that it can can be called externally for letting component-based Rapier integration call it to cleanup joints after a rigid-body removal.
- Fix a panic that could happen when the same collider is listed twice in the `removed_colliders` array.