### PR TITLE
WIP: Enable plugin graphics

### DIFF
--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -195,9 +195,9 @@ impl GraphicsManager {
             .cloned()
             .unwrap_or_else(|| self.alloc_color(materials, handle, !body.is_dynamic()));
 
-        self.add_with_color(
+        let _ = self.add_with_color(
             commands, meshes, materials, components, handle, bodies, colliders, color,
-        )
+        );
     }
 
     pub fn add_with_color(
@@ -210,8 +210,7 @@ impl GraphicsManager {
         bodies: &RigidBodySet,
         colliders: &ColliderSet,
         color: Point3<f32>,
-    ) {
-        //        let body = bodies.get(handle).unwrap();
+    ) -> Vec<EntityWithGraphics> {
         let mut new_nodes = Vec::new();
 
         for collider_handle in bodies[handle].colliders() {
@@ -246,7 +245,10 @@ impl GraphicsManager {
         // }
 
         let nodes = self.b2sn.entry(handle).or_insert_with(Vec::new);
-        nodes.append(&mut new_nodes);
+
+        nodes.append(&mut new_nodes.clone());
+
+        new_nodes
     }
 
     pub fn add_collider(

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -27,7 +27,7 @@ pub use crate::graphics::GraphicsManager;
 pub use crate::harness::plugin::HarnessPlugin;
 pub use crate::physics::PhysicsState;
 pub use crate::plugin::TestbedPlugin;
-pub use crate::testbed::{Testbed, TestbedApp, TestbedGraphics};
+pub use crate::testbed::{Testbed, TestbedApp, TestbedGraphics, TestbedState};
 
 #[cfg(all(feature = "dim2", feature = "other-backends"))]
 mod box2d_backend;

--- a/src_testbed/objects/node.rs
+++ b/src_testbed/objects/node.rs
@@ -104,6 +104,10 @@ impl EntityWithGraphics {
         }
     }
 
+    pub fn despawn(&mut self, commands: &mut Commands) {
+        //FIXME: Should this be despawn_recursive?
+        commands.entity(self.entity).despawn();
+    }
     pub fn select(&mut self, materials: &mut Assets<StandardMaterial>) {
         // NOTE: we don't just call `self.set_color` because that would
         //       overwrite self.base_color too.

--- a/src_testbed/objects/node.rs
+++ b/src_testbed/objects/node.rs
@@ -17,6 +17,7 @@ use {
     rapier::geometry::{Ball, Cuboid},
 };
 
+#[derive(Clone, Debug)]
 pub struct EntityWithGraphics {
     pub entity: Entity,
     pub color: Point3<f32>,

--- a/src_testbed/objects/node.rs
+++ b/src_testbed/objects/node.rs
@@ -23,7 +23,7 @@ pub struct EntityWithGraphics {
     pub entity: Entity,
     pub color: Point3<f32>,
     pub base_color: Point3<f32>,
-    pub collider: ColliderHandle,
+    pub collider: Option<ColliderHandle>,
     pub delta: Isometry<f32>,
     pub opacity: f32,
     material: Handle<StandardMaterial>,
@@ -36,7 +36,7 @@ impl EntityWithGraphics {
         materials: &mut Assets<StandardMaterial>,
         prefab_meshs: &HashMap<ShapeType, Handle<Mesh>>,
         shape: &dyn Shape,
-        collider: ColliderHandle,
+        collider: Option<ColliderHandle>,
         collider_pos: Isometry<f32>,
         delta: Isometry<f32>,
         color: Point3<f32>,
@@ -136,7 +136,7 @@ impl EntityWithGraphics {
     }
 
     pub fn update(&mut self, colliders: &ColliderSet, components: &mut Query<(&mut Transform,)>) {
-        if let Some(co) = colliders.get(self.collider) {
+        if let Some(Some(co)) = self.collider.map(|c| colliders.get(c)) {
             if let Ok(mut pos) = components.get_component_mut::<Transform>(self.entity) {
                 let co_pos = co.position() * self.delta;
                 pos.translation.x = co_pos.translation.vector.x;
@@ -159,7 +159,7 @@ impl EntityWithGraphics {
         }
     }
 
-    pub fn object(&self) -> ColliderHandle {
+    pub fn object(&self) -> Option<ColliderHandle> {
         self.collider
     }
 

--- a/src_testbed/plugin.rs
+++ b/src_testbed/plugin.rs
@@ -2,6 +2,7 @@ use crate::harness::Harness;
 use crate::physics::PhysicsState;
 use crate::GraphicsManager;
 use bevy::prelude::{Assets, Commands, Mesh, Query, StandardMaterial, Transform};
+use bevy_egui::EguiContext;
 use na::Point3;
 
 pub trait TestbedPlugin {
@@ -13,7 +14,6 @@ pub trait TestbedPlugin {
         materials: &mut Assets<StandardMaterial>,
         components: &mut Query<(&mut Transform,)>,
         harness: &mut Harness,
-
         gen_color: &mut dyn FnMut() -> Point3<f32>,
     );
     fn clear_graphics(&mut self, graphics: &mut GraphicsManager, commands: &mut Commands);
@@ -27,6 +27,16 @@ pub trait TestbedPlugin {
         materials: &mut Assets<StandardMaterial>,
         components: &mut Query<(&mut Transform,)>,
         harness: &mut Harness,
+    );
+    fn update_ui(
+        &mut self,
+        ui_context: &EguiContext,
+        harness: &mut Harness,
+        graphics: &mut GraphicsManager,
+        commands: &mut Commands,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<StandardMaterial>,
+        components: &mut Query<(&mut Transform,)>,
     );
     fn profiling_string(&self) -> String;
 }

--- a/src_testbed/plugin.rs
+++ b/src_testbed/plugin.rs
@@ -1,12 +1,32 @@
-use crate::harness::RunState;
+use crate::harness::Harness;
 use crate::physics::PhysicsState;
+use crate::GraphicsManager;
+use bevy::prelude::{Assets, Commands, Mesh, Query, StandardMaterial, Transform};
 use na::Point3;
 
 pub trait TestbedPlugin {
-    fn init_graphics(&mut self, gen_color: &mut dyn FnMut() -> Point3<f32>);
-    fn clear_graphics(&mut self);
-    fn run_callbacks(&mut self, physics: &mut PhysicsState, run_state: &RunState);
+    fn init_graphics(
+        &mut self,
+        graphics: &mut GraphicsManager,
+        commands: &mut Commands,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<StandardMaterial>,
+        components: &mut Query<(&mut Transform,)>,
+        harness: &mut Harness,
+
+        gen_color: &mut dyn FnMut() -> Point3<f32>,
+    );
+    fn clear_graphics(&mut self, graphics: &mut GraphicsManager, commands: &mut Commands);
+    fn run_callbacks(&mut self, harness: &mut Harness);
     fn step(&mut self, physics: &mut PhysicsState);
-    fn draw(&mut self);
+    fn draw(
+        &mut self,
+        graphics: &mut GraphicsManager,
+        commands: &mut Commands,
+        meshes: &mut Assets<Mesh>,
+        materials: &mut Assets<StandardMaterial>,
+        components: &mut Query<(&mut Transform,)>,
+        harness: &mut Harness,
+    );
     fn profiling_string(&self) -> String;
 }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -875,6 +875,18 @@ fn update_testbed(
     {
         let harness = &mut *harness;
         ui::update_ui(&ui_context, &mut state, harness);
+
+        for plugin in &mut plugins.0 {
+            plugin.update_ui(
+                &ui_context,
+                harness,
+                &mut graphics,
+                &mut commands,
+                &mut *meshes,
+                &mut *materials,
+                &mut gfx_components,
+            );
+        }
     }
 
     // Handle UI actions.


### PR DESCRIPTION
This is the changes required to upgrade salva to rapier 0.9.

Graphics are not being rendered, this is just so that salva's FluidTestbedPlugin has access to the data it will need.