### PR TITLE
Derive and impl more traits for components

### DIFF
--- a/src/dynamics/joint/ball_joint.rs
+++ b/src/dynamics/joint/ball_joint.rs
@@ -1,7 +1,7 @@
 use crate::dynamics::SpringModel;
 use crate::math::{Point, Real, Rotation, Vector};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A joint that removes all relative linear motion between a pair of points on two bodies.
 pub struct BallJoint {

--- a/src/dynamics/joint/fixed_joint.rs
+++ b/src/dynamics/joint/fixed_joint.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Real, SpacialVector};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A joint that prevents all relative movement between two bodies.
 ///

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -2,7 +2,7 @@ use crate::dynamics::{BallJoint, FixedJoint, PrismaticJoint, RevoluteJoint};
 use crate::math::{Isometry, Real, SpacialVector};
 use crate::na::{Rotation3, UnitQuaternion};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A joint that prevents all relative movement between two bodies.
 ///

--- a/src/dynamics/joint/joint.rs
+++ b/src/dynamics/joint/joint.rs
@@ -2,7 +2,7 @@
 use crate::dynamics::RevoluteJoint;
 use crate::dynamics::{BallJoint, FixedJoint, JointHandle, PrismaticJoint, RigidBodyHandle};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// An enum grouping all possible types of joints.
 pub enum JointParams {

--- a/src/dynamics/joint/prismatic_joint.rs
+++ b/src/dynamics/joint/prismatic_joint.rs
@@ -7,7 +7,7 @@ use na::Vector2;
 #[cfg(feature = "dim3")]
 use na::Vector5;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A joint that removes all relative motion between two bodies, except for the translations along one axis.
 pub struct PrismaticJoint {

--- a/src/dynamics/joint/revolute_joint.rs
+++ b/src/dynamics/joint/revolute_joint.rs
@@ -3,7 +3,7 @@ use crate::math::{Isometry, Point, Real, Vector};
 use crate::utils::WBasis;
 use na::{RealField, Unit, Vector5};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A joint that removes all relative motion between two bodies, except for the rotations along one axis.
 pub struct RevoluteJoint {

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -117,7 +117,7 @@ impl Default for RigidBodyChanges {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// The position of this rigid-body.
 pub struct RigidBodyPosition {
     /// The world-space position of the rigid-body.
@@ -199,9 +199,9 @@ bitflags::bitflags! {
         const TRANSLATION_LOCKED = 1 << 0;
         /// Flag indicating that the rigid-body cannot rotate along the `X` axis.
         const ROTATION_LOCKED_X = 1 << 1;
-        /// Flag indicating that the rigid-body cannot rotate along the `X` axis.
+        /// Flag indicating that the rigid-body cannot rotate along the `Y` axis.
         const ROTATION_LOCKED_Y = 1 << 2;
-        /// Flag indicating that the rigid-body cannot rotate along the `X` axis.
+        /// Flag indicating that the rigid-body cannot rotate along the `Z` axis.
         const ROTATION_LOCKED_Z = 1 << 3;
         /// Combination of flags indicating that the rigid-body cannot rotate along any axis.
         const ROTATION_LOCKED = Self::ROTATION_LOCKED_X.bits | Self::ROTATION_LOCKED_Y.bits | Self::ROTATION_LOCKED_Z.bits;
@@ -210,7 +210,7 @@ bitflags::bitflags! {
 
 // TODO: split this into "LocalMassProps" and `WorldMassProps"?
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// The mass properties of this rigid-bodies.
 pub struct RigidBodyMassProps {
     /// Flags for locking rotation and translation.
@@ -326,7 +326,7 @@ impl RigidBodyMassProps {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// The velocities of this rigid-body.
 pub struct RigidBodyVelocity {
     /// The linear velocity of the rigid-body.
@@ -466,7 +466,7 @@ impl RigidBodyVelocity {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// Damping factors to progressively slow down a rigid-body.
 pub struct RigidBodyDamping {
     /// Damping factor for gradually slowing down the translational motion of the rigid-body.
@@ -485,7 +485,7 @@ impl Default for RigidBodyDamping {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// The user-defined external forces applied to this rigid-body.
 pub struct RigidBodyForces {
     /// Accumulation of external forces (only for dynamic bodies).
@@ -545,7 +545,7 @@ impl RigidBodyForces {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq)]
 /// Information used for Continuous-Collision-Detection.
 pub struct RigidBodyCcd {
     /// The distance used by the CCD solver to decide if a movement would
@@ -617,7 +617,7 @@ impl RigidBodyCcd {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
 /// Internal identifiers used by the physics engine.
 pub struct RigidBodyIds {
     pub(crate) active_island_id: usize,
@@ -638,7 +638,7 @@ impl Default for RigidBodyIds {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// The set of colliders attached to this rigid-bodies.
 ///
 /// This should not be modified manually unless you really know what
@@ -735,7 +735,7 @@ impl RigidBodyColliders {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// The dominance groups of a rigid-body.
 pub struct RigidBodyDominance(pub i8);
 
@@ -746,7 +746,7 @@ impl Default for RigidBodyDominance {
 }
 
 impl RigidBodyDominance {
-    /// The actually dominance group of this rigid-body, after taking into account its type.
+    /// The actual dominance group of this rigid-body, after taking into account its type.
     pub fn effective_group(&self, status: &RigidBodyType) -> i16 {
         if status.is_dynamic() {
             self.0 as i16
@@ -760,7 +760,7 @@ impl RigidBodyDominance {
 ///
 /// This controls whether a body is sleeping or not.
 /// If the threshold is negative, the body never sleeps.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct RigidBodyActivation {
     /// The threshold pseudo-kinetic energy bellow which the body can fall asleep.

--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -3,7 +3,7 @@ use crate::geometry::{InteractionGroups, SAPProxyIndex, Shape, SharedShape};
 use crate::math::{Isometry, Real};
 use crate::parry::partitioning::IndexedData;
 use crate::pipeline::{ActiveEvents, ActiveHooks};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// The unique identifier of a collider added to a collider set.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -97,7 +97,7 @@ impl ColliderType {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// Data associated to a collider that takes part to a broad-phase algorithm.
 pub struct ColliderBroadPhaseData {
@@ -115,7 +115,7 @@ impl Default for ColliderBroadPhaseData {
 /// The shape of a collider.
 pub type ColliderShape = SharedShape;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// The mass-properties of a collider.
 pub enum ColliderMassProps {
@@ -155,7 +155,7 @@ impl ColliderMassProps {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// Information about the rigid-body this collider is attached to.
 pub struct ColliderParent {
@@ -165,7 +165,7 @@ pub struct ColliderParent {
     pub pos_wrt_parent: Isometry<Real>,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// The position of a collider.
 pub struct ColliderPosition(pub Isometry<Real>);
@@ -177,11 +177,23 @@ impl AsRef<Isometry<Real>> for ColliderPosition {
     }
 }
 
+impl AsMut<Isometry<Real>> for ColliderPosition {
+    fn as_mut(&mut self) -> &mut Isometry<Real> {
+        &mut self.0
+    }
+}
+
 impl Deref for ColliderPosition {
     type Target = Isometry<Real>;
     #[inline]
     fn deref(&self) -> &Isometry<Real> {
         &self.0
+    }
+}
+
+impl DerefMut for ColliderPosition {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -208,7 +220,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// The constraints solver-related properties of this collider (friction, restitution, etc.)
 pub struct ColliderMaterial {
@@ -329,7 +341,7 @@ impl Default for ActiveCollisionTypes {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A set of flags for controlling collision/intersection filtering, modification, and events.
 pub struct ColliderFlags {


### PR DESCRIPTION
I mostly need `PartialEq` on a few `RigidBody` components, but I looked at all of the other component types and tried to determine whether they could implement `Eq`, `PartialOrd`, `Ord`, and/or `Hash`. Most of the types containing `Real`s only make sense to implement `PartialEq`, but some of the other components seem to be able to implement more traits. Also added `AsMut + DerefMut` to `ColliderPosition` for convenience since the field is public anyway, and found a few more typos.

Let me know if there's anything I missed or anything I added that I shouldn't have.