### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.10.0
+### Added
+- Implement `Clone` for `IslandManager`.
+
+### Modified
+- `JointSet::insert` no longer takes the rigid-body set in its arguments.
+- Modify the testbed's plugin system to let plugins interact with the rendering.
+- Implement `PartialEq` for most collider and rigid-body components.
+
 ## v0.9.2
 ### Added
 - Make the method JointSet::remove_joints_attached_to_rigid_body public so that it can can be called externally for

--- a/benchmarks2d/joint_ball2.rs
+++ b/benchmarks2d/joint_ball2.rs
@@ -42,7 +42,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = BallJoint::new(Point::origin(), point![0.0, shift]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             // Horizontal joint.
@@ -50,7 +50,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - numi;
                 let parent_handle = body_handles[parent_index];
                 let joint = BallJoint::new(Point::origin(), point![-shift, 0.0]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             body_handles.push(child_handle);

--- a/benchmarks2d/joint_fixed2.rs
+++ b/benchmarks2d/joint_fixed2.rs
@@ -50,7 +50,7 @@ pub fn init_world(testbed: &mut Testbed) {
                             Isometry::identity(),
                             Isometry::translation(0.0, shift),
                         );
-                        joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                        joints.insert(parent_handle, child_handle, joint);
                     }
 
                     // Horizontal joint.
@@ -61,7 +61,7 @@ pub fn init_world(testbed: &mut Testbed) {
                             Isometry::identity(),
                             Isometry::translation(-shift, 0.0),
                         );
-                        joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                        joints.insert(parent_handle, child_handle, joint);
                     }
 
                     body_handles.push(child_handle);

--- a/benchmarks2d/joint_prismatic2.rs
+++ b/benchmarks2d/joint_prismatic2.rs
@@ -51,7 +51,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 prism.limits_enabled = true;
                 prism.limits[0] = -1.5;
                 prism.limits[1] = 1.5;
-                joints.insert(&mut bodies, curr_parent, curr_child, prism);
+                joints.insert(curr_parent, curr_child, prism);
 
                 curr_parent = curr_child;
             }

--- a/benchmarks3d/joint_ball3.rs
+++ b/benchmarks3d/joint_ball3.rs
@@ -37,7 +37,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = BallJoint::new(Point::origin(), point![0.0, 0.0, -shift]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             // Horizontal joint.
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - num;
                 let parent_handle = body_handles[parent_index];
                 let joint = BallJoint::new(Point::origin(), point![-shift, 0.0, 0.0]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             body_handles.push(child_handle);

--- a/benchmarks3d/joint_fixed3.rs
+++ b/benchmarks3d/joint_fixed3.rs
@@ -53,7 +53,7 @@ pub fn init_world(testbed: &mut Testbed) {
                                 Isometry::identity(),
                                 Isometry::translation(0.0, 0.0, -shift),
                             );
-                            joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                            joints.insert(parent_handle, child_handle, joint);
                         }
 
                         // Horizontal joint.
@@ -64,7 +64,7 @@ pub fn init_world(testbed: &mut Testbed) {
                                 Isometry::identity(),
                                 Isometry::translation(-shift, 0.0, 0.0),
                             );
-                            joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                            joints.insert(parent_handle, child_handle, joint);
                         }
 
                         body_handles.push(child_handle);

--- a/benchmarks3d/joint_prismatic3.rs
+++ b/benchmarks3d/joint_prismatic3.rs
@@ -59,7 +59,7 @@ pub fn init_world(testbed: &mut Testbed) {
                     prism.limits_enabled = true;
                     prism.limits[0] = -2.0;
                     prism.limits[1] = 2.0;
-                    joints.insert(&mut bodies, curr_parent, curr_child, prism);
+                    joints.insert(curr_parent, curr_child, prism);
 
                     curr_parent = curr_child;
                 }

--- a/benchmarks3d/joint_revolute3.rs
+++ b/benchmarks3d/joint_revolute3.rs
@@ -61,10 +61,10 @@ pub fn init_world(testbed: &mut Testbed) {
                     RevoluteJoint::new(o, x, point![shift, 0.0, 0.0], x),
                 ];
 
-                joints.insert(&mut bodies, curr_parent, handles[0], revs[0]);
-                joints.insert(&mut bodies, handles[0], handles[1], revs[1]);
-                joints.insert(&mut bodies, handles[1], handles[2], revs[2]);
-                joints.insert(&mut bodies, handles[2], handles[3], revs[3]);
+                joints.insert(curr_parent, handles[0], revs[0]);
+                joints.insert(handles[0], handles[1], revs[1]);
+                joints.insert(handles[1], handles[2], revs[2]);
+                joints.insert(handles[2], handles[3], revs[3]);
 
                 curr_parent = handles[3];
             }

--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.9.2"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,8 +47,8 @@ required-features = [ "dim2", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.27"
-parry2d-f64 = "0.5"
+nalgebra = "0.28"
+parry2d-f64 = "0.6"
 simba = "0.5"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.9.2"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,8 +47,8 @@ required-features = [ "dim2", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.27"
-parry2d = "0.5"
+nalgebra = "0.28"
+parry2d = "0.6"
 simba = "0.5"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.9.2"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,8 +47,8 @@ required-features = [ "dim3", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.27"
-parry3d-f64 = "0.5"
+nalgebra = "0.28"
+parry3d-f64 = "0.6"
 simba = "0.5"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.9.2"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,8 +47,8 @@ required-features = [ "dim3", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.27"
-parry3d = "0.5"
+nalgebra = "0.28"
+parry3d = "0.6"
 simba = "0.5"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/build/rapier_testbed2d/Cargo.toml
+++ b/build/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.9.0"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -26,16 +26,16 @@ other-backends = [ "wrapped2d", "nphysics2d" ]
 
 
 [dependencies]
-nalgebra   = { version = "0.27", features = [ "rand" ] }
+nalgebra   = { version = "0.28", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 num_cpus   = { version = "1", optional = true }
 wrapped2d  = { version = "0.4", optional = true }
-parry2d = "0.5"
-ncollide2d = "0.30"
-nphysics2d = { version = "0.22", optional = true }
+parry2d = "0.6"
+ncollide2d = "0.31"
+nphysics2d = { version = "0.23", optional = true }
 crossbeam = "0.8"
 bincode = "1"
 Inflector  = "0.11"
@@ -54,5 +54,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier2d]
 path = "../rapier2d"
-version = "0.9"
+version = "0.10"
 features = [ "serde-serialize" ]

--- a/build/rapier_testbed3d/Cargo.toml
+++ b/build/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.9.0"
+version = "0.10.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -25,16 +25,16 @@ parallel = [ "rapier3d/parallel", "num_cpus" ]
 other-backends = [ "physx", "physx-sys", "glam", "nphysics3d" ]
 
 [dependencies]
-nalgebra   = { version = "0.27", features = [ "rand" ] }
+nalgebra   = { version = "0.28", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 glam       = { version = "0.12", optional = true }
 num_cpus   = { version = "1", optional = true }
-parry3d = "0.5"
-ncollide3d = "0.30"
-nphysics3d = { version = "0.22", optional = true }
+parry3d = "0.6"
+ncollide3d = "0.31"
+nphysics3d = { version = "0.23", optional = true }
 physx      = { version = "0.11", optional = true }
 physx-sys = { version = "0.4", optional = true }
 crossbeam = "0.8"
@@ -56,5 +56,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier3d]
 path = "../rapier3d"
-version = "0.9"
+version = "0.10"
 features = [ "serde-serialize" ]

--- a/examples2d/joints2.rs
+++ b/examples2d/joints2.rs
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = BallJoint::new(Point::origin(), point![0.0, shift]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             // Horizontal joint.
@@ -53,7 +53,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - numi;
                 let parent_handle = body_handles[parent_index];
                 let joint = BallJoint::new(Point::origin(), point![-shift, 0.0]);
-                joints.insert(&mut bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             body_handles.push(child_handle);

--- a/examples3d/debug_prismatic3.rs
+++ b/examples3d/debug_prismatic3.rs
@@ -51,7 +51,7 @@ fn prismatic_repro(
         let (stiffness, damping) = (0.05, 0.2);
         prismatic.configure_motor_position(0.0, stiffness, damping);
 
-        joints.insert(bodies, box_rb, wheel_rb, prismatic);
+        joints.insert(box_rb, wheel_rb, prismatic);
     }
 
     // put a small box under one of the wheels

--- a/examples3d/joints3.rs
+++ b/examples3d/joints3.rs
@@ -46,7 +46,7 @@ fn create_prismatic_joints(
         prism.limits[0] = -2.0;
         prism.limits[1] = 2.0;
 
-        joints.insert(bodies, curr_parent, curr_child, prism);
+        joints.insert(curr_parent, curr_child, prism);
 
         curr_parent = curr_child;
     }
@@ -113,7 +113,7 @@ fn create_actuated_prismatic_joints(
             prism.limits[1] = 5.0;
         }
 
-        joints.insert(bodies, curr_parent, curr_child, prism);
+        joints.insert(curr_parent, curr_child, prism);
 
         curr_parent = curr_child;
     }
@@ -168,10 +168,10 @@ fn create_revolute_joints(
             RevoluteJoint::new(o, x, point![shift, 0.0, 0.0], x),
         ];
 
-        joints.insert(bodies, curr_parent, handles[0], revs[0]);
-        joints.insert(bodies, handles[0], handles[1], revs[1]);
-        joints.insert(bodies, handles[1], handles[2], revs[2]);
-        joints.insert(bodies, handles[2], handles[3], revs[3]);
+        joints.insert(curr_parent, handles[0], revs[0]);
+        joints.insert(handles[0], handles[1], revs[1]);
+        joints.insert(handles[1], handles[2], revs[2]);
+        joints.insert(handles[2], handles[3], revs[3]);
 
         curr_parent = handles[3];
     }
@@ -221,7 +221,7 @@ fn create_fixed_joints(
                     Isometry::identity(),
                     Isometry::translation(0.0, 0.0, -shift),
                 );
-                joints.insert(bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             // Horizontal joint.
@@ -232,7 +232,7 @@ fn create_fixed_joints(
                     Isometry::identity(),
                     Isometry::translation(-shift, 0.0, 0.0),
                 );
-                joints.insert(bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             body_handles.push(child_handle);
@@ -273,7 +273,7 @@ fn create_ball_joints(
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = BallJoint::new(Point::origin(), point![0.0, 0.0, -shift * 2.0]);
-                joints.insert(bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             // Horizontal joint.
@@ -281,7 +281,7 @@ fn create_ball_joints(
                 let parent_index = body_handles.len() - num;
                 let parent_handle = body_handles[parent_index];
                 let joint = BallJoint::new(Point::origin(), point![-shift, 0.0, 0.0]);
-                joints.insert(bodies, parent_handle, child_handle, joint);
+                joints.insert(parent_handle, child_handle, joint);
             }
 
             body_handles.push(child_handle);
@@ -348,7 +348,7 @@ fn create_actuated_revolute_joints(
                 joint.configure_motor_velocity(-2.0, 0.1);
             }
 
-            joints.insert(bodies, parent_handle, child_handle, joint);
+            joints.insert(parent_handle, child_handle, joint);
         }
 
         parent_handle = child_handle;
@@ -406,7 +406,7 @@ fn create_actuated_ball_joints(
                 );
             }
 
-            joints.insert(bodies, parent_handle, child_handle, joint);
+            joints.insert(parent_handle, child_handle, joint);
         }
 
         parent_handle = child_handle;

--- a/src/dynamics/joint/joint_set.rs
+++ b/src/dynamics/joint/joint_set.rs
@@ -172,7 +172,6 @@ impl JointSet {
     /// Inserts a new joint into this set and retrieve its handle.
     pub fn insert<J>(
         &mut self,
-        _bodies: &mut impl ComponentSetMut<RigidBodyIds>, // FIXME: remove this argument, this is no longer necessary.
         body1: RigidBodyHandle,
         body2: RigidBodyHandle,
         joint_params: J,


### PR DESCRIPTION
### Added
- Implement `Clone` for `IslandManager`.

### Modified
- `JointSet::insert` no longer takes the rigid-body set in its arguments.
- Modify the testbed's plugin system to let plugins interact with the rendering.
- Implement `PartialEq` for most collider and rigid-body components.