### PR TITLE
Update intersection graph regardless of active_events

### DIFF
--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -783,13 +783,13 @@ impl NarrowPhase {
                 if active_events.contains(ActiveEvents::INTERSECTION_EVENTS)
                     && intersection != edge.weight
                 {
-                    edge.weight = intersection;
                     events.handle_intersection_event(IntersectionEvent::new(
                         handle1,
                         handle2,
                         intersection,
                     ));
                 }
+                edge.weight = intersection;
             }
         });
     }


### PR DESCRIPTION
It looks like the contact graph updates unconditionally, whereas the intersection graph's edge labels only update if `ActiveEvents::INTERSECTION_EVENTS` is set. This is inconsistent and doesn't seem to be documented, so I'm guessing it wasn't intended.