### PR TITLE
Add a pointer from `docs.rs` docs to rapier docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! - The ability to snapshot the state of the physics engine, and restore it later.
 //! - The ability to run a perfectly deterministic simulation on different machine, as long as they
 //! are compliant with the IEEE 754-2008 floating point standard.
+//!
+//! User documentation for Rapier is on [the official Rapier site](https://rapier.rs/docs/).
 
 #![deny(bare_trait_objects)]
 #![warn(missing_docs)]


### PR DESCRIPTION
Added a pointer from the module-level cargo docs to the actual docs on `rapier.rs` so other people won't be lost like I was.

(Searches for documentation often end up on `docs.rs`, which is not where most of Rapier's docs live. The README has a pointer to the docs, but it isn't as visible once you're on `docs.rs`.)

This is the same change as pr89 for `bevy_rapier`. This one is less important since it's harder to overlook `rapier.rs` from here, but I think it doesn't hurt.

Ideally you'd be able to just include the `README.md` into the lib documentation, but I think that's still a nightly-only feature in cargo doc.