### PR TITLE
Make BroadPhasePairEvent and ColliderPair public.

### DIFF
--- a/src/geometry/broad_phase_multi_sap/broad_phase_pair_event.rs
+++ b/src/geometry/broad_phase_multi_sap/broad_phase_pair_event.rs
@@ -2,12 +2,16 @@ use crate::geometry::ColliderHandle;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+/// A pair of collider handles.
 pub struct ColliderPair {
+    /// The handle of the first collider involved in this pair.
     pub collider1: ColliderHandle,
+    /// The handle of the second ocllider involved in this pair.
     pub collider2: ColliderHandle,
 }
 
 impl ColliderPair {
+    /// Creates a new pair of collider handles.
     pub fn new(collider1: ColliderHandle, collider2: ColliderHandle) -> Self {
         ColliderPair {
             collider1,
@@ -15,10 +19,12 @@ impl ColliderPair {
         }
     }
 
+    /// Swaps the two collider handles in `self`.
     pub fn swap(self) -> Self {
         Self::new(self.collider2, self.collider1)
     }
 
+    /// Constructs a pair of artificial handles that are not guaranteed to be valid..
     pub fn zero() -> Self {
         Self {
             collider1: ColliderHandle::from_raw_parts(0, 0),
@@ -27,7 +33,10 @@ impl ColliderPair {
     }
 }
 
+/// An event emitted by the broad-phase.
 pub enum BroadPhasePairEvent {
+    /// A potential new collision pair has been detected by the broad-phase.
     AddPair(ColliderPair),
+    /// The two colliders are guaranteed not to touch any more.
     DeletePair(ColliderPair),
 }

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,6 +1,6 @@
 //! Structures related to geometry: colliders, shapes, etc.
 
-pub use self::broad_phase_multi_sap::BroadPhase;
+pub use self::broad_phase_multi_sap::{BroadPhase, BroadPhasePairEvent, ColliderPair};
 pub use self::collider_components::*;
 pub use self::contact_pair::{ContactData, ContactManifoldData};
 pub use self::contact_pair::{ContactPair, SolverContact, SolverFlags};
@@ -88,7 +88,7 @@ impl IntersectionEvent {
     }
 }
 
-pub(crate) use self::broad_phase_multi_sap::{BroadPhasePairEvent, ColliderPair, SAPProxyIndex};
+pub(crate) use self::broad_phase_multi_sap::SAPProxyIndex;
 pub(crate) use self::narrow_phase::ContactManifoldIndex;
 pub(crate) use parry::partitioning::QBVH;
 pub use parry::shape::*;


### PR DESCRIPTION
Otherwise it is impossible to use BroadPhase::update properly from other crates. I am actually surprised the compiler didn’t output an error about this (private type in public interface).