### PR TITLE
Release 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.11.0
+Check out the user-guide for the JS/Typescript bindings for rapier. It has been fully rewritten and is now exhaustive!
+Check it out on [rapier.rs](https://www.rapier.rs/docs/user_guides/javascript/getting_started_js)
+
+### Added
+- Joint limits are now implemented for all joints that can support them (prismatic, revolute, and ball joints).
+
+### Modified
+- Switch to  `nalgebra 0.29`.
+
+### Fixed
+- Fix the build of Rapier when targeting emscripten.
+
 ## v0.10.1
 ### Added
 - Add `Collider::set_translation_wrt_parent` to change the translation of a collider wrt. its parent rigid-body.

--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,9 +47,9 @@ required-features = [ "dim2", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.28"
-parry2d-f64 = "0.6"
-simba = "0.5"
+nalgebra = "0.29"
+parry2d-f64 = "0.7"
+simba = "0.6"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,9 +47,9 @@ required-features = [ "dim2", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.28"
-parry2d = "0.6"
-simba = "0.5"
+nalgebra = "0.29"
+parry2d = "0.7"
+simba = "0.6"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,9 +47,9 @@ required-features = [ "dim3", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.28"
-parry3d-f64 = "0.6"
-simba = "0.5"
+nalgebra = "0.29"
+parry3d-f64 = "0.7"
+simba = "0.6"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.10.1"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,9 +47,9 @@ required-features = [ "dim3", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.28"
-parry3d = "0.6"
-simba = "0.5"
+nalgebra = "0.29"
+parry3d = "0.7"
+simba = "0.6"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/build/rapier_testbed2d/Cargo.toml
+++ b/build/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.10.0"
+version = "0.11.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -22,20 +22,20 @@ required-features = [ "dim2" ]
 default = [ "dim2" ]
 dim2 = [ ]
 parallel = [ "rapier2d/parallel", "num_cpus" ]
-other-backends = [ "wrapped2d", "nphysics2d" ]
+other-backends = [ "wrapped2d", "nphysics2d", "ncollide2d" ]
 
 
 [dependencies]
-nalgebra   = { version = "0.28", features = [ "rand" ] }
+nalgebra   = { version = "0.29", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 num_cpus   = { version = "1", optional = true }
 wrapped2d  = { version = "0.4", optional = true }
-parry2d = "0.6"
-ncollide2d = "0.31"
-nphysics2d = { version = "0.23", optional = true }
+parry2d = "0.7"
+ncollide2d = { version = "0.32", optional = true }
+nphysics2d = { version = "0.24", optional = true }
 crossbeam = "0.8"
 bincode = "1"
 Inflector  = "0.11"
@@ -54,5 +54,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier2d]
 path = "../rapier2d"
-version = "0.10"
+version = "0.11"
 features = [ "serde-serialize" ]

--- a/build/rapier_testbed3d/Cargo.toml
+++ b/build/rapier_testbed3d/Cargo.toml
@@ -22,19 +22,19 @@ required-features = [ "dim3" ]
 default = [ "dim3" ]
 dim3 = [ ]
 parallel = [ "rapier3d/parallel", "num_cpus" ]
-other-backends = [ "physx", "physx-sys", "glam", "nphysics3d" ]
+other-backends = [ "physx", "physx-sys", "glam", "nphysics3d", "ncollide3d" ]
 
 [dependencies]
-nalgebra   = { version = "0.28", features = [ "rand" ] }
+nalgebra   = { version = "0.29", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 glam       = { version = "0.12", optional = true }
 num_cpus   = { version = "1", optional = true }
-parry3d = "0.6"
-ncollide3d = "0.31"
-nphysics3d = { version = "0.23", optional = true }
+parry3d    = "0.7"
+ncollide3d = { version = "0.32", optional = true }
+nphysics3d = { version = "0.24", optional = true }
 physx      = { version = "0.11", optional = true }
 physx-sys = { version = "0.4", optional = true }
 crossbeam = "0.8"
@@ -56,5 +56,5 @@ bevy_webgl2 = "0.5"
 
 [dependencies.rapier3d]
 path = "../rapier3d"
-version = "0.10"
+version = "0.11"
 features = [ "serde-serialize" ]

--- a/src/dynamics/solver/delta_vel.rs
+++ b/src/dynamics/solver/delta_vel.rs
@@ -9,7 +9,7 @@ pub(crate) struct DeltaVel<N: Scalar + Copy> {
     pub angular: AngVector<N>,
 }
 
-impl<N: SimdRealField> DeltaVel<N> {
+impl<N: SimdRealField + Copy> DeltaVel<N> {
     pub fn zero() -> Self {
         Self {
             linear: na::zero(),
@@ -18,7 +18,7 @@ impl<N: SimdRealField> DeltaVel<N> {
     }
 }
 
-impl<N: SimdRealField> AddAssign for DeltaVel<N> {
+impl<N: SimdRealField + Copy> AddAssign for DeltaVel<N> {
     fn add_assign(&mut self, rhs: Self) {
         self.linear += rhs.linear;
         self.angular += rhs.angular;

--- a/src/dynamics/solver/parallel_island_solver.rs
+++ b/src/dynamics/solver/parallel_island_solver.rs
@@ -1,4 +1,7 @@
-use super::{DeltaVel, ParallelInteractionGroups, ParallelVelocitySolver};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rayon::Scope;
+
 use crate::data::{BundleSet, ComponentSet, ComponentSetMut};
 use crate::dynamics::solver::{
     AnyJointPositionConstraint, AnyJointVelocityConstraint, AnyPositionConstraint,
@@ -12,8 +15,8 @@ use crate::dynamics::{
 use crate::geometry::{ContactManifold, ContactManifoldIndex};
 use crate::math::{Isometry, Real};
 use crate::utils::WAngularInertia;
-use rayon::Scope;
-use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::{DeltaVel, ParallelInteractionGroups, ParallelVelocitySolver};
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -373,8 +373,8 @@ pub(crate) fn compute_tangent_contact_directions<N>(
     linvel2: &Vector<N>,
 ) -> ([Vector<N>; DIM - 1], na::UnitComplex<N>)
 where
-    N: na::SimdRealField,
-    N::Element: na::RealField,
+    N: na::SimdRealField + Copy,
+    N::Element: na::RealField + Copy,
     Vector<N>: WBasis,
 {
     use na::SimdValue;

--- a/src/dynamics/solver/velocity_constraint_element.rs
+++ b/src/dynamics/solver/velocity_constraint_element.rs
@@ -4,7 +4,7 @@ use crate::utils::{WBasis, WDot};
 use na::SimdRealField;
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityConstraintTangentPart<N: SimdRealField> {
+pub(crate) struct VelocityConstraintTangentPart<N: SimdRealField + Copy> {
     pub gcross1: [AngVector<N>; DIM - 1],
     pub gcross2: [AngVector<N>; DIM - 1],
     pub rhs: [N; DIM - 1],
@@ -15,7 +15,7 @@ pub(crate) struct VelocityConstraintTangentPart<N: SimdRealField> {
     pub r: [N; DIM - 1],
 }
 
-impl<N: SimdRealField> VelocityConstraintTangentPart<N> {
+impl<N: SimdRealField + Copy> VelocityConstraintTangentPart<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
@@ -40,7 +40,7 @@ impl<N: SimdRealField> VelocityConstraintTangentPart<N> {
         mj_lambda2: &mut DeltaVel<N>,
     ) where
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         for j in 0..DIM - 1 {
             mj_lambda1.linear += tangents1[j] * (im1 * self.impulse[j]);
@@ -62,7 +62,7 @@ impl<N: SimdRealField> VelocityConstraintTangentPart<N> {
         mj_lambda2: &mut DeltaVel<N>,
     ) where
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         #[cfg(feature = "dim2")]
         {
@@ -121,7 +121,7 @@ impl<N: SimdRealField> VelocityConstraintTangentPart<N> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityConstraintNormalPart<N: SimdRealField> {
+pub(crate) struct VelocityConstraintNormalPart<N: SimdRealField + Copy> {
     pub gcross1: AngVector<N>,
     pub gcross2: AngVector<N>,
     pub rhs: N,
@@ -129,7 +129,7 @@ pub(crate) struct VelocityConstraintNormalPart<N: SimdRealField> {
     pub r: N,
 }
 
-impl<N: SimdRealField> VelocityConstraintNormalPart<N> {
+impl<N: SimdRealField + Copy> VelocityConstraintNormalPart<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
@@ -187,12 +187,12 @@ impl<N: SimdRealField> VelocityConstraintNormalPart<N> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityConstraintElement<N: SimdRealField> {
+pub(crate) struct VelocityConstraintElement<N: SimdRealField + Copy> {
     pub normal_part: VelocityConstraintNormalPart<N>,
     pub tangent_part: VelocityConstraintTangentPart<N>,
 }
 
-impl<N: SimdRealField> VelocityConstraintElement<N> {
+impl<N: SimdRealField + Copy> VelocityConstraintElement<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     pub fn zero() -> Self {
         Self {
@@ -213,7 +213,7 @@ impl<N: SimdRealField> VelocityConstraintElement<N> {
     ) where
         Vector<N>: WBasis,
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         #[cfg(feature = "dim3")]
         let tangents1 = [tangent1, &dir1.cross(&tangent1)];
@@ -243,7 +243,7 @@ impl<N: SimdRealField> VelocityConstraintElement<N> {
     ) where
         Vector<N>: WBasis,
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         // Solve friction.
         #[cfg(feature = "dim3")]

--- a/src/dynamics/solver/velocity_ground_constraint_element.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_element.rs
@@ -4,7 +4,7 @@ use crate::utils::{WBasis, WDot};
 use na::SimdRealField;
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityGroundConstraintTangentPart<N: SimdRealField> {
+pub(crate) struct VelocityGroundConstraintTangentPart<N: SimdRealField + Copy> {
     pub gcross2: [AngVector<N>; DIM - 1],
     pub rhs: [N; DIM - 1],
     #[cfg(feature = "dim2")]
@@ -14,7 +14,7 @@ pub(crate) struct VelocityGroundConstraintTangentPart<N: SimdRealField> {
     pub r: [N; DIM - 1],
 }
 
-impl<N: SimdRealField> VelocityGroundConstraintTangentPart<N> {
+impl<N: SimdRealField + Copy> VelocityGroundConstraintTangentPart<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
@@ -50,7 +50,7 @@ impl<N: SimdRealField> VelocityGroundConstraintTangentPart<N> {
         mj_lambda2: &mut DeltaVel<N>,
     ) where
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         #[cfg(feature = "dim2")]
         {
@@ -96,14 +96,14 @@ impl<N: SimdRealField> VelocityGroundConstraintTangentPart<N> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityGroundConstraintNormalPart<N: SimdRealField> {
+pub(crate) struct VelocityGroundConstraintNormalPart<N: SimdRealField + Copy> {
     pub gcross2: AngVector<N>,
     pub rhs: N,
     pub impulse: N,
     pub r: N,
 }
 
-impl<N: SimdRealField> VelocityGroundConstraintNormalPart<N> {
+impl<N: SimdRealField + Copy> VelocityGroundConstraintNormalPart<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
@@ -137,12 +137,12 @@ impl<N: SimdRealField> VelocityGroundConstraintNormalPart<N> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct VelocityGroundConstraintElement<N: SimdRealField> {
+pub(crate) struct VelocityGroundConstraintElement<N: SimdRealField + Copy> {
     pub normal_part: VelocityGroundConstraintNormalPart<N>,
     pub tangent_part: VelocityGroundConstraintTangentPart<N>,
 }
 
-impl<N: SimdRealField> VelocityGroundConstraintElement<N> {
+impl<N: SimdRealField + Copy> VelocityGroundConstraintElement<N> {
     #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     pub fn zero() -> Self {
         Self {
@@ -161,7 +161,7 @@ impl<N: SimdRealField> VelocityGroundConstraintElement<N> {
     ) where
         Vector<N>: WBasis,
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         #[cfg(feature = "dim3")]
         let tangents1 = [tangent1, &dir1.cross(&tangent1)];
@@ -185,7 +185,7 @@ impl<N: SimdRealField> VelocityGroundConstraintElement<N> {
     ) where
         Vector<N>: WBasis,
         AngVector<N>: WDot<AngVector<N>, Result = N>,
-        N::Element: SimdRealField,
+        N::Element: SimdRealField + Copy,
     {
         // Solve friction.
         #[cfg(feature = "dim3")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,7 @@ pub trait WBasis: Sized {
     fn orthonormal_vector(self) -> Self;
 }
 
-impl<N: SimdRealField> WBasis for Vector2<N> {
+impl<N: SimdRealField + Copy> WBasis for Vector2<N> {
     type Basis = [Vector2<N>; 1];
     fn orthonormal_basis(self) -> [Vector2<N>; 1] {
         [Vector2::new(-self.y, self.x)]
@@ -122,7 +122,7 @@ impl<N: SimdRealField> WBasis for Vector2<N> {
     }
 }
 
-impl<N: SimdRealField + WSign<N>> WBasis for Vector3<N> {
+impl<N: SimdRealField + Copy + WSign<N>> WBasis for Vector3<N> {
     type Basis = [Vector3<N>; 2];
     // Robust and branchless implementation from Pixar:
     // https://graphics.pixar.com/library/OrthonormalB/paper.pdf

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
-#[cfg(feature = "dim2")]
+#[cfg(all(feature = "dim2", feature = "other-backends"))]
 extern crate ncollide2d as ncollide;
-#[cfg(feature = "dim3")]
+#[cfg(all(feature = "dim3", feature = "other-backends"))]
 extern crate ncollide3d as ncollide;
 #[cfg(all(feature = "dim2", feature = "other-backends"))]
 extern crate nphysics2d as nphysics;


### PR DESCRIPTION
## v0.11.0
Check out the user-guide for the JS/Typescript bindings for rapier. It has been fully rewritten and is now exhaustive!
Check it out on [rapier.rs](https://www.rapier.rs/docs/user_guides/javascript/getting_started_js)

### Added
- Joint limits are now implemented for all joints that can support them (prismatic, revolute, and ball joints).

### Modified
- Switch to  `nalgebra 0.29`.

### Fixed
- Fix the build of Rapier when targeting emscripten.
