### PR TITLE
Fix issue with non rigidbody colliders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ The Rust source code of the Rapier physics engines is available  on our `rapier`
    - Run the tests `cargo test`
    - Run the 2D examples and see if they behave as expected: `cargo run --release --bin all_examples2`
    - Run the 3D examples and see if they behave as expected: `cargo run --release --bin all_examples3`
-   - Run the 2D examples with the `parallel` and `simd-stable` features enabled: `cd all_examples2; cargo run --release --features parallel,simd-stable`
-   - Run the 3D examples with the `parallel` and `simd-stable` features enabled: `cd all_examples3; cargo run --release --features parallel,simd-stable`
+   - Run the 2D examples with the `parallel` and `simd-stable` features enabled: `cargo run --release --bin all_examples2 --features parallel,simd-stable`
+   - Run the 3D examples with the `parallel` and `simd-stable` features enabled: `cargo run --release --bin all_examples3 --features parallel,simd-stable`
 4. Once you are satisfied with your changes, submit them by [opening a Pull Request](https://github.com/dimforge/rapier/pulls) on GitHub.
 5. If that Pull Request does something you need urgently, or if you think it has been forgotten, don't hesitate
    to ask **@sebcrozet** directly [on Discord][discord] for a review.

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -571,8 +571,12 @@ impl NarrowPhase {
             let co_parent2: Option<&ColliderParent> = colliders.get(pair.collider2.0);
 
             if co_parent1.map(|p| p.handle) == co_parent2.map(|p| p.handle) {
-                // Same parents. Ignore collisions.
-                return;
+                if co_parent1.is_some() {
+                    // Same parents. Ignore collisions.
+                    return;
+                }
+
+                // These colliders have no parents - continue.
             }
 
             let (gid1, gid2) = self.graph_indices.ensure_pair_exists(

--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -204,3 +204,109 @@ impl CollisionPipeline {
         removed_colliders.clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    #[cfg(feature = "dim3")]
+    pub fn test_no_rigid_bodies() {
+        use crate::prelude::*;
+        let mut rigid_body_set = RigidBodySet::new();
+        let mut collider_set = ColliderSet::new();
+
+        /* Create the ground. */
+        let collider_a = ColliderBuilder::cuboid(1.0, 1.0, 1.0)
+            .active_collision_types(ActiveCollisionTypes::all())
+            .sensor(true)
+            .active_events(ActiveEvents::CONTACT_EVENTS | ActiveEvents::INTERSECTION_EVENTS)
+            .build();
+
+        let a_handle = collider_set.insert(collider_a);
+
+        let collider_b = ColliderBuilder::cuboid(1.0, 1.0, 1.0)
+            .active_collision_types(ActiveCollisionTypes::all())
+            .sensor(true)
+            .active_events(ActiveEvents::CONTACT_EVENTS | ActiveEvents::INTERSECTION_EVENTS)
+            .build();
+
+        let _ = collider_set.insert(collider_b);
+
+        let integration_parameters = IntegrationParameters::default();
+        let mut broad_phase = BroadPhase::new();
+        let mut narrow_phase = NarrowPhase::new();
+        let mut collision_pipeline = CollisionPipeline::new();
+        let physics_hooks = ();
+
+        collision_pipeline.step(
+            integration_parameters.prediction_distance,
+            &mut broad_phase,
+            &mut narrow_phase,
+            &mut rigid_body_set,
+            &mut collider_set,
+            &physics_hooks,
+            &(),
+        );
+
+        let mut hit = false;
+
+        for (_, _, intersecting) in narrow_phase.intersections_with(a_handle) {
+            if intersecting {
+                hit = true;
+            }
+        }
+
+        assert!(hit, "No hit found");
+    }
+
+    #[test]
+    #[cfg(feature = "dim2")]
+    pub fn test_no_rigid_bodies() {
+        use crate::prelude::*;
+        let mut rigid_body_set = RigidBodySet::new();
+        let mut collider_set = ColliderSet::new();
+
+        /* Create the ground. */
+        let collider_a = ColliderBuilder::cuboid(1.0, 1.0)
+            .active_collision_types(ActiveCollisionTypes::all())
+            .sensor(true)
+            .active_events(ActiveEvents::CONTACT_EVENTS | ActiveEvents::INTERSECTION_EVENTS)
+            .build();
+
+        let a_handle = collider_set.insert(collider_a);
+
+        let collider_b = ColliderBuilder::cuboid(1.0, 1.0)
+            .active_collision_types(ActiveCollisionTypes::all())
+            .sensor(true)
+            .active_events(ActiveEvents::CONTACT_EVENTS | ActiveEvents::INTERSECTION_EVENTS)
+            .build();
+
+        let _ = collider_set.insert(collider_b);
+
+        let integration_parameters = IntegrationParameters::default();
+        let mut broad_phase = BroadPhase::new();
+        let mut narrow_phase = NarrowPhase::new();
+        let mut collision_pipeline = CollisionPipeline::new();
+        let physics_hooks = ();
+
+        collision_pipeline.step(
+            integration_parameters.prediction_distance,
+            &mut broad_phase,
+            &mut narrow_phase,
+            &mut rigid_body_set,
+            &mut collider_set,
+            &physics_hooks,
+            &(),
+        );
+
+        let mut hit = false;
+
+        for (_, _, intersecting) in narrow_phase.intersections_with(a_handle) {
+            if intersecting {
+                hit = true;
+            }
+        }
+
+        assert!(hit, "No hit found");
+    }
+}


### PR DESCRIPTION
- When `NarrowPhase` adds a collision pair, it checks to make sure that they don't have the same parent
- In the case where the colliders have no parents (eg. they are not attached to a `RigidBody`) this yields a false positive.
- The fix is to ensure that colliders have a parent before ignoring the pair.
- Added a unit test in `collision_pipeline` to check for this
- Fixed a minor typo in CONTRIBUTING.md