### PR TITLE
Clarify coordinate space of TOI query results

### DIFF
--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -658,8 +658,9 @@ impl QueryPipeline {
 
     /// Casts a shape at a constant linear velocity and retrieve the first collider it hits.
     ///
-    /// This is similar to ray-casting except that we are casting a whole shape instead of
-    /// just a point (the ray origin).
+    /// This is similar to ray-casting except that we are casting a whole shape instead of just a
+    /// point (the ray origin). In the resulting `TOI`, witness and normal 1 refer to the world
+    /// collider, and are in world space.
     ///
     /// # Parameters
     /// * `colliders` - The set of colliders taking part in this pipeline.
@@ -701,6 +702,9 @@ impl QueryPipeline {
     }
 
     /// Casts a shape with an arbitrary continuous motion and retrieve the first collider it hits.
+    ///
+    /// In the resulting `TOI`, witness and normal 1 refer to the world collider, and are in world
+    /// space.
     ///
     /// # Parameters
     /// * `colliders` - The set of colliders taking part in this pipeline.


### PR DESCRIPTION
These are confusing because the documentation of the `TOI` struct specifies local space, which doesn't seem to be the case here in practice, perhaps because the "local space" in question is considered to be the entire collision world acting as a single shape.