### PR TITLE
Add bevy-components feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ resolver = "2"
 #ncollide3d = { git = "https://github.com/dimforge/ncollide" }
 #nphysics2d = { git = "https://github.com/dimforge/nphysics" }
 #nphysics3d = { git = "https://github.com/dimforge/nphysics" }
+bevy = { path="../bevy" }
 
 [profile.release]
 #debug = true

--- a/build/rapier2d-f64/Cargo.toml
+++ b/build/rapier2d-f64/Cargo.toml
@@ -29,6 +29,7 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d-f64/enhanced-determinism", "indexmap" ]
+bevy-components = ["bevy", "parry2d-f64/bevy-components"]
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = [ ]
@@ -61,6 +62,7 @@ indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"
+bevy = { version = "0.5", default-features=false, optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/build/rapier2d/Cargo.toml
+++ b/build/rapier2d/Cargo.toml
@@ -29,6 +29,7 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry2d/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry2d/enhanced-determinism", "indexmap" ]
+bevy-components = ["bevy", "parry2d/bevy-components"]
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = [ ]
@@ -61,6 +62,7 @@ indexmap = { version = "1", features = [ "serde-1" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"
+bevy = { version = "0.5", default-features=false, optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/build/rapier3d-f64/Cargo.toml
+++ b/build/rapier3d-f64/Cargo.toml
@@ -29,6 +29,7 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d-f64/enhanced-determinism" ]
+bevy-components = ["bevy", "parry3d-f64/bevy-components"]
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = [ ]
@@ -60,6 +61,7 @@ serde = { version = "1", features = [ "derive" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"
+bevy = { version = "0.5", default-features=false, optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/build/rapier3d/Cargo.toml
+++ b/build/rapier3d/Cargo.toml
@@ -29,6 +29,7 @@ simd-is-enabled = [ "vec_map" ]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 serde-serialize = [ "nalgebra/serde-serialize", "parry3d/serde-serialize", "serde", "bit-vec/serde" ]
 enhanced-determinism = [ "simba/libm_force", "parry3d/enhanced-determinism" ]
+bevy-components = ["bevy", "parry3d/bevy-components"]
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = [ ]
@@ -60,6 +61,8 @@ serde = { version = "1", features = [ "derive" ], optional = true }
 downcast-rs = "1.2"
 num-derive = "0.3"
 bitflags = "1"
+bevy = { version = "0.5", default-features=false, optional = true }
+
 
 [dev-dependencies]
 bincode = "1"

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -9,9 +9,13 @@ use crate::parry::partitioning::IndexedData;
 use crate::utils::{WCross, WDot};
 use num::Zero;
 
+#[cfg(feature = "bevy-components")]
+use bevy::prelude::Component;
+
 /// The unique handle of a rigid body added to a `RigidBodySet`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[repr(transparent)]
 pub struct RigidBodyHandle(pub crate::data::arena::Index);
 
@@ -51,6 +55,7 @@ pub type BodyStatus = RigidBodyType;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// The status of a body, governing the way it is affected by external forces.
 pub enum RigidBodyType {
     /// A `RigidBodyType::Dynamic` body can be affected by all external forces.
@@ -95,6 +100,7 @@ impl RigidBodyType {
 
 bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "bevy-components", derive(Component))]
     /// Flags describing how the rigid-body has been modified by the user.
     pub struct RigidBodyChanges: u32 {
         /// Flag indicating that any component of this rigid-body has been modified.
@@ -117,6 +123,7 @@ impl Default for RigidBodyChanges {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// The position of this rigid-body.
 pub struct RigidBodyPosition {
@@ -214,6 +221,7 @@ bitflags::bitflags! {
 
 // TODO: split this into "LocalMassProps" and `WorldMassProps"?
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// The mass properties of this rigid-bodies.
 pub struct RigidBodyMassProps {
@@ -330,6 +338,7 @@ impl RigidBodyMassProps {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// The velocities of this rigid-body.
 pub struct RigidBodyVelocity {
@@ -470,6 +479,7 @@ impl RigidBodyVelocity {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// Damping factors to progressively slow down a rigid-body.
 pub struct RigidBodyDamping {
@@ -489,6 +499,7 @@ impl Default for RigidBodyDamping {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// The user-defined external forces applied to this rigid-body.
 pub struct RigidBodyForces {
@@ -549,6 +560,7 @@ impl RigidBodyForces {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq)]
 /// Information used for Continuous-Collision-Detection.
 pub struct RigidBodyCcd {
@@ -621,6 +633,7 @@ impl RigidBodyCcd {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
 /// Internal identifiers used by the physics engine.
 pub struct RigidBodyIds {
@@ -642,6 +655,7 @@ impl Default for RigidBodyIds {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// The set of colliders attached to this rigid-bodies.
 ///
@@ -739,6 +753,7 @@ impl RigidBodyColliders {
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// The dominance groups of a rigid-body.
 pub struct RigidBodyDominance(pub i8);
@@ -766,6 +781,7 @@ impl RigidBodyDominance {
 /// If the threshold is negative, the body never sleeps.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 pub struct RigidBodyActivation {
     /// The threshold pseudo-kinetic energy bellow which the body can fall asleep.
     pub threshold: Real,

--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -4,10 +4,13 @@ use crate::math::{Isometry, Real};
 use crate::parry::partitioning::IndexedData;
 use crate::pipeline::{ActiveEvents, ActiveHooks};
 use std::ops::{Deref, DerefMut};
+#[cfg(feature = "bevy-components")]
+use bevy::prelude::Component;
 
 /// The unique identifier of a collider added to a collider set.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 #[repr(transparent)]
 pub struct ColliderHandle(pub crate::data::arena::Index);
 
@@ -43,6 +46,7 @@ impl IndexedData for ColliderHandle {
 
 bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "bevy-components", derive(Component))]
     /// Flags describing how the collider has been modified by the user.
     pub struct ColliderChanges: u32 {
         /// Flag indicating that any component of the collider has been modified.
@@ -82,6 +86,7 @@ impl ColliderChanges {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// The type of collider.
 pub enum ColliderType {
     /// A collider that can generate contacts and contact events.
@@ -99,6 +104,7 @@ impl ColliderType {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// Data associated to a collider that takes part to a broad-phase algorithm.
 pub struct ColliderBroadPhaseData {
     pub(crate) proxy_index: SAPProxyIndex,
@@ -117,6 +123,7 @@ pub type ColliderShape = SharedShape;
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// The mass-properties of a collider.
 pub enum ColliderMassProps {
     /// The collider is given a density.
@@ -157,6 +164,7 @@ impl ColliderMassProps {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// Information about the rigid-body this collider is attached to.
 pub struct ColliderParent {
     /// Handle of the rigid-body this collider is attached to.
@@ -167,6 +175,7 @@ pub struct ColliderParent {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// The position of a collider.
 pub struct ColliderPosition(pub Isometry<Real>);
 
@@ -222,6 +231,7 @@ where
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// The constraints solver-related properties of this collider (friction, restitution, etc.)
 pub struct ColliderMaterial {
     /// The friction coefficient of this collider.
@@ -343,6 +353,7 @@ impl Default for ActiveCollisionTypes {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy-components", derive(Component))]
 /// A set of flags for controlling collision/intersection filtering, modification, and events.
 pub struct ColliderFlags {
     /// Controls whether collision-detection happens between two colliders depending on


### PR DESCRIPTION
Due to changes made in https://github.com/bevyengine/bevy/pull/2254 this add the `Component` annotation to all data structures that are used as components in `bevy_rapier`.

It's dependent on the branch of `parry` in this PR: https://github.com/dimforge/parry/pull/57 since `SharedShape` is re-exported by `rapier`.
