### PR TITLE
fix the parameter used for local center of mass

### DIFF
--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -462,7 +462,7 @@ impl PhysicsPipeline {
                         &rb_pos.position,
                         // NOTE: we don't use the `world_com` here because it is not
                         //       really updated for kinematic bodies.
-                        &(rb_pos.position * rb_mprops.local_mprops.local_com),
+                        &rb_mprops.local_mprops.local_com,
                     );
                     bodies.set_internal(handle.0, RigidBodyPosition::from(new_pos));
                 }

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -460,8 +460,6 @@ impl PhysicsPipeline {
                     let new_pos = rb_vel.integrate(
                         integration_parameters.dt,
                         &rb_pos.position,
-                        // NOTE: we don't use the `world_com` here because it is not
-                        //       really updated for kinematic bodies.
                         &rb_mprops.local_mprops.local_com,
                     );
                     bodies.set_internal(handle.0, RigidBodyPosition::from(new_pos));


### PR DESCRIPTION
In `rapier2d::pipeline::physics_pipeline::PhysicsPipeline::interpolate_kinematic_velocities()`:
The code that handles `RigidBodyType::KinematicVelocityBased`: `rb_vel.integrate()` expects a local center of mass which is already in `rb_mprops.local_mprops.local_com`.