### PR TITLE
Fix invalid sample count

### DIFF
--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -365,7 +365,7 @@ impl TestbedApp {
                 ..Default::default()
             })
             .insert_resource(ClearColor(Color::rgb(0.85, 0.85, 0.85)))
-            .insert_resource(Msaa { samples: 2 })
+            .insert_resource(Msaa { samples: 4 })
             .insert_resource(WgpuOptions {
                 features: WgpuFeatures {
                     // The Wireframe requires NonFillPolygonMode feature


### PR DESCRIPTION
Fix #261 

Valid sample counts are 1 and 4 in [WebGPU specification - 6.1.1 Texture Creation](https://www.w3.org/TR/webgpu/#texture-creation).

Sample counts are checked by wgpu (both 0.7.1 and 0.12.0) here: https://github.com/gfx-rs/wgpu/blob/v0.12/wgpu-core/src/command/render.rs#L865