### PR TITLE
Address issues with the genral-case for multibody joints

### DIFF
--- a/src/dynamics/joint/multibody_joint/multibody_joint.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint.rs
@@ -1,42 +1,21 @@
 use crate::dynamics::solver::AnyJointVelocityConstraint;
 use crate::dynamics::{
-    joint, FixedJoint, IntegrationParameters, JointAxesMask, JointData, Multibody, MultibodyLink,
+    joint, FixedJoint, IntegrationParameters, JointData, Multibody, MultibodyLink,
     RigidBodyVelocity,
 };
 use crate::math::{
-    Isometry, JacobianSliceMut, Matrix, Real, Rotation, SpacialVector, Translation, Vector,
-    ANG_DIM, DIM, SPATIAL_DIM,
+    Isometry, JacobianSliceMut, Real, Rotation, SpacialVector, Translation, Vector, ANG_DIM, DIM,
+    SPATIAL_DIM,
 };
-use crate::utils::WCross;
 use na::{DVector, DVectorSliceMut};
 #[cfg(feature = "dim3")]
-use {
-    crate::utils::WCrossMatrix,
-    na::{UnitQuaternion, Vector3, VectorSlice3},
-};
+use na::{UnitQuaternion, Vector3};
 
 #[derive(Copy, Clone, Debug)]
 pub struct MultibodyJoint {
     pub data: JointData,
     pub(crate) coords: SpacialVector<Real>,
     pub(crate) joint_rot: Rotation<Real>,
-    jacobian_v: Matrix<Real>,
-    jacobian_dot_v: Matrix<Real>,
-    jacobian_dot_veldiff_v: Matrix<Real>,
-}
-
-#[cfg(feature = "dim2")]
-fn revolute_locked_axes() -> JointAxesMask {
-    JointAxesMask::X | JointAxesMask::Y
-}
-
-#[cfg(feature = "dim3")]
-fn revolute_locked_axes() -> JointAxesMask {
-    JointAxesMask::X
-        | JointAxesMask::Y
-        | JointAxesMask::Z
-        | JointAxesMask::ANG_Y
-        | JointAxesMask::ANG_Z
 }
 
 impl MultibodyJoint {
@@ -45,9 +24,6 @@ impl MultibodyJoint {
             data,
             coords: na::zero(),
             joint_rot: Rotation::identity(),
-            jacobian_v: na::zero(),
-            jacobian_dot_v: na::zero(),
-            jacobian_dot_veldiff_v: na::zero(),
         }
     }
 
@@ -84,76 +60,59 @@ impl MultibodyJoint {
 
     /// The position of the multibody link containing this multibody_joint relative to its parent.
     pub fn body_to_parent(&self) -> Isometry<Real> {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            self.data.local_frame1.translation
-                * self.joint_rot
-                * self.data.local_frame2.translation.inverse()
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let mut transform = self.joint_rot * self.data.local_frame2.inverse();
+        let locked_bits = self.data.locked_axes.bits();
+        let mut transform = self.joint_rot * self.data.local_frame2.inverse();
 
-            for i in 0..DIM {
-                if (locked_bits & (1 << i)) == 0 {
-                    transform = Translation::from(Vector::ith(i, self.coords[i])) * transform;
-                }
+        for i in 0..DIM {
+            if (locked_bits & (1 << i)) == 0 {
+                transform = Translation::from(Vector::ith(i, self.coords[i])) * transform;
             }
-
-            self.data.local_frame1 * transform
         }
+
+        self.data.local_frame1 * transform
     }
 
     /// Integrate the position of this multibody_joint.
     pub fn integrate(&mut self, dt: Real, vels: &[Real]) {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            #[cfg(feature = "dim3")]
-            let axis = self.data.local_frame1 * Vector::x_axis();
-            self.coords[DIM] += vels[0] * dt;
+        let locked_bits = self.data.locked_axes.bits();
+        let mut curr_free_dof = 0;
 
-            #[cfg(feature = "dim2")]
-            {
-                self.joint_rot = Rotation::from_angle(self.coords[DIM]);
+        for i in 0..DIM {
+            if (locked_bits & (1 << i)) == 0 {
+                self.coords[i] += vels[curr_free_dof] * dt;
+                curr_free_dof += 1;
             }
-            #[cfg(feature = "dim3")]
-            {
-                self.joint_rot = Rotation::from_axis_angle(&axis, self.coords[DIM]);
-            }
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let mut curr_free_dof = 0;
+        }
 
-            for i in 0..DIM {
-                if (locked_bits & (1 << i)) == 0 {
-                    self.coords[i] += vels[curr_free_dof] * dt;
-                    curr_free_dof += 1;
-                }
-            }
-
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
+        let locked_ang_bits = locked_bits >> DIM;
+        let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
+        match num_free_ang_dofs {
+            0 => { /* No free dofs. */ }
+            1 => {
+                let dof_id = (!locked_ang_bits).trailing_zeros() as usize;
+                self.coords[DIM + dof_id] += vels[curr_free_dof] * dt;
+                #[cfg(feature = "dim2")]
+                {
+                    self.joint_rot = Rotation::new(self.coords[DIM + dof_id]);
                 }
                 #[cfg(feature = "dim3")]
-                3 => {
-                    let angvel = Vector3::from_row_slice(&vels[curr_free_dof..curr_free_dof + 3]);
-                    let disp = UnitQuaternion::new_eps(angvel * dt, 0.0);
-                    self.joint_rot = disp * self.joint_rot;
+                {
+                    self.joint_rot = Rotation::from_axis_angle(
+                        &Vector::ith_axis(dof_id),
+                        self.coords[DIM + dof_id],
+                    );
                 }
-                _ => unreachable!(),
             }
+            2 => {
+                todo!()
+            }
+            #[cfg(feature = "dim3")]
+            3 => {
+                let angvel = Vector3::from_row_slice(&vels[curr_free_dof..curr_free_dof + 3]);
+                let disp = UnitQuaternion::new_eps(angvel * dt, 0.0);
+                self.joint_rot = disp * self.joint_rot;
+            }
+            _ => unreachable!(),
         }
     }
 
@@ -162,278 +121,91 @@ impl MultibodyJoint {
         self.integrate(1.0, disp);
     }
 
-    /// Update the jacobians of this multibody_joint.
-    pub fn update_jacobians(&mut self, vels: &[Real]) {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            #[cfg(feature = "dim2")]
-            let axis = 1.0;
-            #[cfg(feature = "dim3")]
-            let axis = self.data.local_frame1 * Vector::x_axis();
-            let body_shift = self.data.local_frame2.translation.vector;
-            let shift = self.joint_rot * -body_shift;
-            let shift_dot_veldiff = axis.gcross(shift);
-
-            #[cfg(feature = "dim2")]
-            {
-                self.jacobian_v.column_mut(0).copy_from(&axis.gcross(shift));
-            }
-            #[cfg(feature = "dim3")]
-            {
-                self.jacobian_v.column_mut(0).copy_from(&axis.gcross(shift));
-            }
-            self.jacobian_dot_veldiff_v
-                .column_mut(0)
-                .copy_from(&axis.gcross(shift_dot_veldiff));
-            self.jacobian_dot_v
-                .column_mut(0)
-                .copy_from(&(axis.gcross(shift_dot_veldiff) * vels[0]));
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let num_free_lin_dofs = self.num_free_lin_dofs();
-                    let inv_frame2 = self.data.local_frame2.inverse();
-                    let shift = self.joint_rot * inv_frame2.translation.vector;
-                    let angvel =
-                        VectorSlice3::from_slice(&vels[num_free_lin_dofs..num_free_lin_dofs + 3]);
-                    let inv_rotmat2 = inv_frame2.rotation.to_rotation_matrix().into_inner();
-
-                    self.jacobian_v = inv_rotmat2 * shift.gcross_matrix().transpose();
-                    self.jacobian_dot_v =
-                        inv_rotmat2 * angvel.cross(&shift).gcross_matrix().transpose();
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-
     /// Sets in `out` the non-zero entries of the multibody_joint jacobian transformed by `transform`.
-    pub fn jacobian(&self, transform: &Isometry<Real>, out: &mut JacobianSliceMut<Real>) {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            #[cfg(feature = "dim2")]
-            let axis = 1.0;
+    pub fn jacobian(&self, transform: &Rotation<Real>, out: &mut JacobianSliceMut<Real>) {
+        let locked_bits = self.data.locked_axes.bits();
+        let mut curr_free_dof = 0;
+
+        for i in 0..DIM {
+            if (locked_bits & (1 << i)) == 0 {
+                let transformed_axis = transform * Vector::ith(i, 1.0);
+                out.fixed_slice_mut::<DIM, 1>(0, curr_free_dof)
+                    .copy_from(&transformed_axis);
+                curr_free_dof += 1;
+            }
+        }
+
+        let locked_ang_bits = locked_bits >> DIM;
+        let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
+        match num_free_ang_dofs {
+            0 => { /* No free dofs. */ }
+            1 => {
+                #[cfg(feature = "dim2")]
+                {
+                    out[(DIM, curr_free_dof)] = 1.0;
+                }
+
+                #[cfg(feature = "dim3")]
+                {
+                    let dof_id = (!locked_ang_bits).trailing_zeros() as usize;
+                    let rotmat = transform.to_rotation_matrix().into_inner();
+                    out.fixed_slice_mut::<ANG_DIM, 1>(DIM, curr_free_dof)
+                        .copy_from(&rotmat.column(dof_id));
+                }
+            }
+            2 => {
+                todo!()
+            }
             #[cfg(feature = "dim3")]
-            let axis = self.data.local_frame1 * Vector::x();
-            let jacobian = RigidBodyVelocity::new(self.jacobian_v.column(0).into_owned(), axis);
-            out.copy_from(jacobian.transformed(transform).as_vector())
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let mut curr_free_dof = 0;
-
-            for i in 0..DIM {
-                if (locked_bits & (1 << i)) == 0 {
-                    let transformed_axis = transform * self.data.local_frame1 * Vector::ith(i, 1.0);
-                    out.fixed_slice_mut::<DIM, 1>(0, curr_free_dof)
-                        .copy_from(&transformed_axis);
-                    curr_free_dof += 1;
-                }
+            3 => {
+                let rotmat = transform.to_rotation_matrix();
+                out.fixed_slice_mut::<3, 3>(3, curr_free_dof)
+                    .copy_from(rotmat.matrix());
             }
-
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let rotmat = transform.rotation.to_rotation_matrix();
-                    out.fixed_slice_mut::<3, 3>(0, curr_free_dof)
-                        .copy_from(&(rotmat * self.jacobian_v));
-                    out.fixed_slice_mut::<3, 3>(3, curr_free_dof)
-                        .copy_from(rotmat.matrix());
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    /// Sets in `out` the non-zero entries of the time-derivative of the multibody_joint jacobian transformed by `transform`.
-    pub fn jacobian_dot(&self, transform: &Isometry<Real>, out: &mut JacobianSliceMut<Real>) {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            let jacobian = RigidBodyVelocity::from_vectors(
-                self.jacobian_dot_v.column(0).into_owned(),
-                na::zero(),
-            );
-            out.copy_from(jacobian.transformed(transform).as_vector())
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let num_free_lin_dofs = self.num_free_lin_dofs();
-                    let rotmat = transform.rotation.to_rotation_matrix();
-                    out.fixed_slice_mut::<3, 3>(0, num_free_lin_dofs)
-                        .copy_from(&(rotmat * self.jacobian_dot_v));
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    /// Sets in `out` the non-zero entries of the velocity-derivative of the time-derivative of the multibody_joint jacobian transformed by `transform`.
-    pub fn jacobian_dot_veldiff_mul_coordinates(
-        &self,
-        transform: &Isometry<Real>,
-        acc: &[Real],
-        out: &mut JacobianSliceMut<Real>,
-    ) {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            let jacobian = RigidBodyVelocity::from_vectors(
-                self.jacobian_dot_veldiff_v.column(0).into_owned(),
-                na::zero(),
-            );
-            out.copy_from((jacobian.transformed(transform) * acc[0]).as_vector())
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let num_free_lin_dofs = self.num_free_lin_dofs();
-                    let angvel =
-                        Vector3::from_row_slice(&acc[num_free_lin_dofs..num_free_lin_dofs + 3]);
-                    let rotmat = transform.rotation.to_rotation_matrix();
-                    let res = rotmat * angvel.gcross_matrix() * self.jacobian_v;
-                    out.fixed_slice_mut::<3, 3>(0, num_free_lin_dofs)
-                        .copy_from(&res);
-                }
-                _ => unreachable!(),
-            }
+            _ => unreachable!(),
         }
     }
 
     /// Multiply the multibody_joint jacobian by generalized velocities to obtain the
     /// relative velocity of the multibody link containing this multibody_joint.
     pub fn jacobian_mul_coordinates(&self, acc: &[Real]) -> RigidBodyVelocity {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            #[cfg(feature = "dim2")]
-            let axis = 1.0;
+        let locked_bits = self.data.locked_axes.bits();
+        let mut result = RigidBodyVelocity::zero();
+        let mut curr_free_dof = 0;
+
+        for i in 0..DIM {
+            if (locked_bits & (1 << i)) == 0 {
+                result.linvel += Vector::ith(i, acc[curr_free_dof]);
+                curr_free_dof += 1;
+            }
+        }
+
+        let locked_ang_bits = locked_bits >> DIM;
+        let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
+        match num_free_ang_dofs {
+            0 => { /* No free dofs. */ }
+            1 => {
+                #[cfg(feature = "dim2")]
+                {
+                    result.angvel += acc[curr_free_dof];
+                }
+                #[cfg(feature = "dim3")]
+                {
+                    let dof_id = (!locked_ang_bits).trailing_zeros() as usize;
+                    result.angvel[dof_id] += acc[curr_free_dof];
+                }
+            }
+            2 => {
+                todo!()
+            }
             #[cfg(feature = "dim3")]
-            let axis = self.data.local_frame1 * Vector::x();
-            RigidBodyVelocity::new(self.jacobian_v.column(0).into_owned(), axis) * acc[0]
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-            let mut result = RigidBodyVelocity::zero();
-            let mut curr_free_dof = 0;
-
-            for i in 0..DIM {
-                if (locked_bits & (1 << i)) == 0 {
-                    result.linvel += self.data.local_frame1 * Vector::ith(i, acc[curr_free_dof]);
-                    curr_free_dof += 1;
-                }
+            3 => {
+                let angvel = Vector3::from_row_slice(&acc[curr_free_dof..curr_free_dof + 3]);
+                result.angvel += angvel;
             }
-
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => { /* No free dofs. */ }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let angvel = Vector3::from_row_slice(&acc[curr_free_dof..curr_free_dof + 3]);
-                    let linvel = self.jacobian_v * angvel;
-                    result += RigidBodyVelocity::new(linvel, angvel);
-                }
-                _ => unreachable!(),
-            }
-            result
+            _ => unreachable!(),
         }
-    }
-
-    /// Multiply the multibody_joint jacobian by generalized accelerations to obtain the
-    /// relative acceleration of the multibody link containing this multibody_joint.
-    pub fn jacobian_dot_mul_coordinates(&self, acc: &[Real]) -> RigidBodyVelocity {
-        if self.data.locked_axes == revolute_locked_axes() {
-            // FIXME: this is a special case for the revolute joint.
-            // We have the mathematical formulation ready that works in the general case, but its
-            // implementation will take some time. So let’s make a special case for the alpha
-            // release and fix is soon after.
-            RigidBodyVelocity::from_vectors(self.jacobian_dot_v.column(0).into_owned(), na::zero())
-                * acc[0]
-        } else {
-            let locked_bits = self.data.locked_axes.bits();
-
-            let locked_ang_bits = locked_bits >> DIM;
-            let num_free_ang_dofs = ANG_DIM - locked_ang_bits.count_ones() as usize;
-            match num_free_ang_dofs {
-                0 => {
-                    /* No free dofs. */
-                    RigidBodyVelocity::zero()
-                }
-                1 => {
-                    todo!()
-                }
-                2 => {
-                    todo!()
-                }
-                #[cfg(feature = "dim3")]
-                3 => {
-                    let num_free_lin_dofs = self.num_free_lin_dofs();
-                    let angvel =
-                        Vector3::from_row_slice(&acc[num_free_lin_dofs..num_free_lin_dofs + 3]);
-                    let linvel = self.jacobian_dot_v * angvel;
-                    RigidBodyVelocity::new(linvel, na::zero())
-                }
-                _ => unreachable!(),
-            }
-        }
+        result
     }
 
     /// Fill `out` with the non-zero entries of a damping that can be applied by default to ensure a good stability of the multibody_joint.
@@ -445,7 +217,7 @@ impl MultibodyJoint {
         for i in DIM..SPATIAL_DIM {
             if locked_bits & (1 << i) == 0 {
                 // This is a free angular DOF.
-                out[curr_free_dof] = 0.2;
+                out[curr_free_dof] = 0.1;
                 curr_free_dof += 1;
             }
         }

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -389,19 +389,6 @@ impl RigidBodyVelocity {
         }
     }
 
-    #[cfg(feature = "dim2")]
-    pub(crate) fn from_vectors(linvel: Vector<Real>, angvel: na::Vector1<Real>) -> Self {
-        Self {
-            linvel,
-            angvel: angvel.x,
-        }
-    }
-
-    #[cfg(feature = "dim3")]
-    pub(crate) fn from_vectors(linvel: Vector<Real>, angvel: Vector<Real>) -> Self {
-        Self { linvel, angvel }
-    }
-
     /// Velocities set to zero.
     #[must_use]
     pub fn zero() -> Self {
@@ -463,21 +450,9 @@ impl RigidBodyVelocity {
         unsafe { std::mem::transmute(self) }
     }
 
-    /// Return `self` transformed by `transform`.
-    #[must_use]
-    pub fn transformed(self, transform: &Isometry<Real>) -> Self {
-        Self {
-            linvel: transform * self.linvel,
-            #[cfg(feature = "dim2")]
-            angvel: self.angvel,
-            #[cfg(feature = "dim3")]
-            angvel: transform * self.angvel,
-        }
-    }
-
     /// Return `self` rotated by `rotation`.
     #[must_use]
-    pub fn rotated(self, rotation: &Rotation<Real>) -> Self {
+    pub fn transformed(self, rotation: &Rotation<Real>) -> Self {
         Self {
             linvel: rotation * self.linvel,
             #[cfg(feature = "dim2")]

--- a/src/dynamics/solver/island_solver.rs
+++ b/src/dynamics/solver/island_solver.rs
@@ -132,8 +132,8 @@ impl IslandSolver {
                     if link.id == 0 || link.id == 1 && !multibody.root_is_dynamic {
                         let accels = &multibody.accelerations;
                         multibody.velocities.axpy(params.dt, accels, 1.0);
-                        multibody.integrate_next(params.dt);
-                        multibody.forward_kinematics_next(bodies, false);
+                        multibody.integrate(params.dt);
+                        multibody.forward_kinematics(bodies, false);
                     }
                 } else {
                     // Since we didn't run the velocity solver we need to integrate the accelerations here

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -145,8 +145,8 @@ impl VelocitySolver {
                         .rows(multibody.solver_id, multibody.ndofs());
                     let prev_vels = multibody.velocities.clone(); // FIXME: avoid allocations.
                     multibody.velocities += mj_lambdas;
-                    multibody.integrate_next(params.dt);
-                    multibody.forward_kinematics_next(bodies, false);
+                    multibody.integrate(params.dt);
+                    multibody.forward_kinematics(bodies, false);
 
                     if params.max_stabilization_iterations > 0 {
                         multibody.velocities = prev_vels;

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -542,7 +542,7 @@ impl PhysicsPipeline {
             multibody.1.update_root_type(bodies);
             // FIXME: what should we do here? We should not
             //        rely on the next state here.
-            multibody.1.forward_kinematics_next(bodies, true);
+            multibody.1.forward_kinematics(bodies, true);
         }
 
         self.detect_collisions(


### PR DESCRIPTION
This addresses most of the remaining issues with the use of multibody joints in their most general form (manually configured 6-dof joints). This does not address the issues with the angular motors that should be able to act on coupled coordinates instead of each axis individually.