### PR TITLE
Fix some solver issues

### DIFF
--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -21,7 +21,7 @@ required-features = [ "dim2" ]
 [features]
 default = [ "dim2" ]
 dim2 = [ ]
-parallel = [ "rapier2d/parallel", "num_cpus" ]
+parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "wrapped2d" ]
 
 
@@ -33,7 +33,6 @@ instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 num_cpus   = { version = "1", optional = true }
 wrapped2d  = { version = "0.4", optional = true }
-parry2d = "0.8"
 crossbeam = "0.8"
 bincode = "1"
 Inflector  = "0.11"
@@ -51,7 +50,8 @@ bevy = {version = "0.6", default-features = false, features = ["bevy_winit", "re
 bevy = {version = "0.6", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
-[dependencies.rapier2d]
+[dependencies.rapier]
+package = "rapier2d"
 path = "../rapier2d"
 version = "0.12.0-alpha.0"
 features = [ "serde-serialize" ]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -21,7 +21,7 @@ required-features = [ "dim3" ]
 [features]
 default = [ "dim3" ]
 dim3 = [ ]
-parallel = [ "rapier3d/parallel", "num_cpus" ]
+parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "physx", "physx-sys", "glam" ]
 
 [dependencies]
@@ -32,7 +32,6 @@ instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 glam       = { version = "0.12", optional = true }
 num_cpus   = { version = "1", optional = true }
-parry3d    = "0.8"
 physx      = { version = "0.11", optional = true }
 physx-sys = { version = "0.4", optional = true }
 crossbeam = "0.8"
@@ -53,7 +52,8 @@ bevy = {version = "0.6", default-features = false, features = ["bevy_winit", "re
 bevy = {version = "0.6", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
-[dependencies.rapier3d]
+[dependencies.rapier]
+package = "rapier3d"
 path = "../rapier3d"
 version = "0.12.0-alpha.0"
 features = [ "serde-serialize" ]

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -14,6 +14,7 @@ mod collision_groups2;
 mod convex_polygons2;
 mod damping2;
 mod debug_box_ball2;
+mod drum2;
 mod heightfield2;
 mod joints2;
 mod locked_rotations2;
@@ -63,6 +64,7 @@ pub fn main() {
         ("Collision groups", collision_groups2::init_world),
         ("Convex polygons", convex_polygons2::init_world),
         ("Damping", damping2::init_world),
+        ("Drum", drum2::init_world),
         ("Heightfield", heightfield2::init_world),
         ("Joints", joints2::init_world),
         ("Locked rotations", locked_rotations2::init_world),

--- a/examples2d/drum2.rs
+++ b/examples2d/drum2.rs
@@ -1,0 +1,81 @@
+use rapier2d::prelude::*;
+use rapier_testbed2d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
+
+    /*
+     * Create the boxes
+     */
+    let num = 30;
+    let rad = 0.2;
+
+    let shift = rad * 2.0;
+    let centerx = shift * num as f32 / 2.0;
+    let centery = shift * num as f32 / 2.0;
+
+    for i in 0usize..num {
+        for j in 0usize..num {
+            let x = i as f32 * shift - centerx;
+            let y = j as f32 * shift - centery;
+
+            // Build the rigid body.
+            let rigid_body = RigidBodyBuilder::new_dynamic()
+                .translation(vector![x, y])
+                .build();
+            let handle = bodies.insert(rigid_body);
+            let collider = ColliderBuilder::cuboid(rad, rad).build();
+            colliders.insert_with_parent(collider, handle, &mut bodies);
+        }
+    }
+
+    /*
+     * Setup a velocity-based kinematic rigid body.
+     */
+    let platform_body = RigidBodyBuilder::new_kinematic_velocity_based().build();
+    let velocity_based_platform_handle = bodies.insert(platform_body);
+
+    let sides = [
+        (10.0, 0.25, vector![0.0, 10.0]),
+        (10.0, 0.25, vector![0.0, -10.0]),
+        (0.25, 10.0, vector![10.0, 0.0]),
+        (0.25, 10.0, vector![-10.0, 0.0]),
+    ];
+    let balls = [
+        (1.25, vector![6.0, 6.0]),
+        (1.25, vector![-6.0, 6.0]),
+        (1.25, vector![6.0, -6.0]),
+        (1.25, vector![-6.0, -6.0]),
+    ];
+
+    for (hx, hy, pos) in sides {
+        let collider = ColliderBuilder::cuboid(hx, hy).translation(pos).build();
+        colliders.insert_with_parent(collider, velocity_based_platform_handle, &mut bodies);
+    }
+    for (r, pos) in balls {
+        let collider = ColliderBuilder::ball(r).translation(pos).build();
+        colliders.insert_with_parent(collider, velocity_based_platform_handle, &mut bodies);
+    }
+
+    /*
+     * Setup a callback to control the platform.
+     */
+    testbed.add_callback(move |_, physics, _, _| {
+        // Update the velocity-based kinematic body by setting its velocity.
+        if let Some(platform) = physics.bodies.get_mut(velocity_based_platform_handle) {
+            platform.set_angvel(-0.15, true);
+        }
+    });
+
+    /*
+     * Run the simulation.
+     */
+    testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
+    testbed.look_at(point![0.0, 1.0], 40.0);
+}

--- a/examples3d/debug_articulations3.rs
+++ b/examples3d/debug_articulations3.rs
@@ -66,17 +66,15 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut impulse_joints = ImpulseJointSet::new();
     let mut multibody_joints = MultibodyJointSet::new();
 
-    let rigid_body = RigidBodyBuilder::new_dynamic().build();
-    let collider = ColliderBuilder::cuboid(30.0, 0.01, 30.0) // Vector::y_axis())
-        .translation(vector![0.0, -3.0, 0.0])
+    let collider = ColliderBuilder::cuboid(30.0, 0.01, 30.0)
+        .translation(vector![0.0, -3.02, 0.0])
         .rotation(vector![0.1, 0.0, 0.1])
         .build();
-    let handle = bodies.insert(rigid_body);
-    colliders.insert_with_parent(collider, handle, &mut bodies);
+    colliders.insert(collider);
 
-    let rigid_body = RigidBodyBuilder::new_static().build();
-    let collider = ColliderBuilder::cuboid(30.0, 0.01, 30.0) // Vector::y_axis())
-        .translation(vector![0.0, -3.02, 0.0])
+    let rigid_body = RigidBodyBuilder::new_dynamic().build();
+    let collider = ColliderBuilder::cuboid(30.0, 0.01, 30.0)
+        .translation(vector![0.0, -3.0, 0.0])
         .rotation(vector![0.1, 0.0, 0.1])
         .build();
     let handle = bodies.insert(rigid_body);

--- a/src/data/arena.rs
+++ b/src/data/arena.rs
@@ -70,11 +70,8 @@ impl Index {
     ///
     /// Providing arbitrary values will lead to malformed indices and ultimately
     /// panics.
-    pub fn from_raw_parts(a: u32, b: u32) -> Index {
-        Index {
-            index: a,
-            generation: b,
-        }
+    pub fn from_raw_parts(index: u32, generation: u32) -> Index {
+        Index { index, generation }
     }
 
     /// Convert this `Index` into its raw parts.

--- a/src/data/coarena.rs
+++ b/src/data/coarena.rs
@@ -29,6 +29,10 @@ impl<T> Coarena<T> {
         self.data.get(index as usize).map(|(_, t)| t)
     }
 
+    pub(crate) fn get_gen(&self, index: u32) -> Option<u32> {
+        self.data.get(index as usize).map(|(gen, _)| *gen)
+    }
+
     /// Deletes an element for the coarena and returns its value.
     ///
     /// This method will reset the value to the given `removed_value`.

--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -30,6 +30,13 @@ pub struct IntegrationParameters {
     /// (default `0.0`).
     pub erp: Real,
 
+    /// 0-1: multiplier applied to each accumulated impulse during  constraints resolution.
+    /// This is similar to the concept of CFN (Constraint Force Mixing) except that it is
+    /// a multiplicative factor instead of an additive factor.
+    /// Larger values lead to stiffer constraints (1.0 being completely stiff).
+    /// Smaller values lead to more compliant constraints.
+    pub delassus_inv_factor: Real,
+
     /// Amount of penetration the engine wont attempt to correct (default: `0.001m`).
     pub allowed_linear_error: Real,
     /// The maximal distance separating two objects that will generate predictive contacts (default: `0.002`).
@@ -96,6 +103,7 @@ impl Default for IntegrationParameters {
             min_ccd_dt: 1.0 / 60.0 / 100.0,
             velocity_solve_fraction: 1.0,
             erp: 0.8,
+            delassus_inv_factor: 0.75,
             allowed_linear_error: 0.001, // 0.005
             prediction_distance: 0.002,
             max_velocity_iterations: 4,

--- a/src/dynamics/joint/impulse_joint/impulse_joint_set.rs
+++ b/src/dynamics/joint/impulse_joint/impulse_joint_set.rs
@@ -100,7 +100,7 @@ impl ImpulseJointSet {
 
     /// Gets the joint with the given handle without a known generation.
     ///
-    /// This is useful when you know you want the joint at position `i` but
+    /// This is useful when you know you want the joint at index `i` but
     /// don't know what is its current generation number. Generation numbers are
     /// used to protect from the ABA problem because the joint position `i`
     /// are recycled between two insertion and a removal.

--- a/src/dynamics/joint/joint_data.rs
+++ b/src/dynamics/joint/joint_data.rs
@@ -218,12 +218,14 @@ impl JointData {
     }
 
     /// Set the spring-like model used by the motor to reach the desired target velocity and position.
+    #[must_use]
     pub fn motor_model(mut self, axis: JointAxis, model: MotorModel) -> Self {
         self.motors[axis as usize].model = model;
         self
     }
 
     /// Sets the target velocity this motor needs to reach.
+    #[must_use]
     pub fn motor_velocity(self, axis: JointAxis, target_vel: Real, factor: Real) -> Self {
         self.motor_axis(
             axis,
@@ -235,6 +237,7 @@ impl JointData {
     }
 
     /// Sets the target angle this motor needs to reach.
+    #[must_use]
     pub fn motor_position(
         self,
         axis: JointAxis,
@@ -246,6 +249,7 @@ impl JointData {
     }
 
     /// Configure both the target angle and target velocity of the motor.
+    #[must_use]
     pub fn motor_axis(
         mut self,
         axis: JointAxis,
@@ -263,6 +267,7 @@ impl JointData {
         self
     }
 
+    #[must_use]
     pub fn motor_max_impulse(mut self, axis: JointAxis, max_impulse: Real) -> Self {
         self.motors[axis as usize].max_impulse = max_impulse;
         self

--- a/src/dynamics/joint/multibody_joint/multibody.rs
+++ b/src/dynamics/joint/multibody_joint/multibody.rs
@@ -62,7 +62,10 @@ fn concat_rb_mass_matrix(
 }
 
 /// An articulated body simulated using the reduced-coordinates approach.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone)]
 pub struct Multibody {
+    // TODO: serialization: skip the workspace fields.
     links: MultibodyLinkVec,
     pub(crate) velocities: DVector<Real>,
     pub(crate) damping: DVector<Real>,

--- a/src/dynamics/joint/multibody_joint/multibody_joint.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint.rs
@@ -11,6 +11,7 @@ use na::{DVector, DVectorSliceMut};
 #[cfg(feature = "dim3")]
 use na::{UnitQuaternion, Vector3};
 
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct MultibodyJoint {
     pub data: JointData,

--- a/src/dynamics/joint/multibody_joint/multibody_link.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_link.rs
@@ -5,6 +5,8 @@ use crate::math::{Isometry, Real, Vector};
 use crate::prelude::RigidBodyVelocity;
 
 /// One link of a multibody.
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone)]
 pub struct MultibodyLink {
     // FIXME: make all those private.
     pub(crate) internal_id: usize,
@@ -96,6 +98,8 @@ impl MultibodyLink {
 }
 
 // FIXME: keep this even if we already have the Index2 traits?
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[derive(Clone)]
 pub(crate) struct MultibodyLinkVec(pub Vec<MultibodyLink>);
 
 impl MultibodyLinkVec {

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1089,7 +1089,8 @@ impl RigidBodyBuilder {
         }
 
         if !self.can_sleep {
-            rb.rb_activation.threshold = -1.0;
+            rb.rb_activation.linear_threshold = -1.0;
+            rb.rb_activation.angular_threshold = -1.0;
         }
 
         rb

--- a/src/dynamics/solver/delta_vel.rs
+++ b/src/dynamics/solver/delta_vel.rs
@@ -1,7 +1,7 @@
 use crate::math::{AngVector, Vector, SPATIAL_DIM};
 use na::{DVectorSlice, DVectorSliceMut};
 use na::{Scalar, SimdRealField};
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Sub};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
@@ -42,5 +42,16 @@ impl<N: SimdRealField + Copy> AddAssign for DeltaVel<N> {
     fn add_assign(&mut self, rhs: Self) {
         self.linear += rhs.linear;
         self.angular += rhs.angular;
+    }
+}
+
+impl<N: SimdRealField + Copy> Sub for DeltaVel<N> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        DeltaVel {
+            linear: self.linear - rhs.linear,
+            angular: self.angular - rhs.angular,
+        }
     }
 }

--- a/src/dynamics/solver/generic_velocity_ground_constraint.rs
+++ b/src/dynamics/solver/generic_velocity_ground_constraint.rs
@@ -1,0 +1,242 @@
+use crate::data::{BundleSet, ComponentSet};
+use crate::dynamics::solver::VelocityGroundConstraint;
+use crate::dynamics::{
+    IntegrationParameters, MultibodyJointSet, RigidBodyIds, RigidBodyMassProps, RigidBodyType,
+    RigidBodyVelocity,
+};
+use crate::geometry::{ContactManifold, ContactManifoldIndex};
+use crate::math::{Point, Real, DIM, MAX_MANIFOLD_POINTS};
+use crate::utils::WCross;
+
+use super::{VelocityGroundConstraintElement, VelocityGroundConstraintNormalPart};
+use crate::dynamics::solver::AnyGenericVelocityConstraint;
+#[cfg(feature = "dim2")]
+use crate::utils::WBasis;
+use na::DVector;
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct GenericVelocityGroundConstraint {
+    // We just build the generic constraint on top of the velocity constraint,
+    // adding some information we can use in the generic case.
+    pub velocity_constraint: VelocityGroundConstraint,
+    pub j_id: usize,
+    pub ndofs2: usize,
+}
+
+impl GenericVelocityGroundConstraint {
+    pub fn generate<Bodies>(
+        params: &IntegrationParameters,
+        manifold_id: ContactManifoldIndex,
+        manifold: &ContactManifold,
+        bodies: &Bodies,
+        multibodies: &MultibodyJointSet,
+        out_constraints: &mut Vec<AnyGenericVelocityConstraint>,
+        jacobians: &mut DVector<Real>,
+        jacobian_id: &mut usize,
+        push: bool,
+    ) where
+        Bodies: ComponentSet<RigidBodyIds>
+            + ComponentSet<RigidBodyVelocity>
+            + ComponentSet<RigidBodyMassProps>
+            + ComponentSet<RigidBodyType>,
+    {
+        let inv_dt = params.inv_dt();
+        let erp_inv_dt = params.erp_inv_dt();
+
+        let mut handle1 = manifold.data.rigid_body1;
+        let mut handle2 = manifold.data.rigid_body2;
+        let flipped = manifold.data.relative_dominance < 0;
+
+        let (force_dir1, flipped_multiplier) = if flipped {
+            std::mem::swap(&mut handle1, &mut handle2);
+            (manifold.data.normal, -1.0)
+        } else {
+            (-manifold.data.normal, 1.0)
+        };
+
+        let (rb_vels1, world_com1) = if let Some(handle1) = handle1 {
+            let (vels1, mprops1): (&RigidBodyVelocity, &RigidBodyMassProps) =
+                bodies.index_bundle(handle1.0);
+            (*vels1, mprops1.world_com)
+        } else {
+            (RigidBodyVelocity::zero(), Point::origin())
+        };
+
+        let (rb_vels2, rb_mprops2): (&RigidBodyVelocity, &RigidBodyMassProps) =
+            bodies.index_bundle(handle2.unwrap().0);
+
+        let (mb2, link_id2) = handle2
+            .and_then(|h| multibodies.rigid_body_link(h))
+            .map(|m| (&multibodies[m.multibody], m.id))
+            .unwrap();
+        let mj_lambda2 = mb2.solver_id;
+
+        #[cfg(feature = "dim2")]
+        let tangents1 = force_dir1.orthonormal_basis();
+        #[cfg(feature = "dim3")]
+        let tangents1 = super::compute_tangent_contact_directions(
+            &force_dir1,
+            &rb_vels1.linvel,
+            &rb_vels2.linvel,
+        );
+
+        let multibodies_ndof = mb2.ndofs();
+        // For each solver contact we generate DIM constraints, and each constraints appends
+        // the multibodies jacobian and weighted jacobians
+        let required_jacobian_len =
+            *jacobian_id + manifold.data.solver_contacts.len() * multibodies_ndof * 2 * DIM;
+
+        if jacobians.nrows() < required_jacobian_len {
+            jacobians.resize_vertically_mut(required_jacobian_len, 0.0);
+        }
+
+        for (_l, manifold_points) in manifold
+            .data
+            .solver_contacts
+            .chunks(MAX_MANIFOLD_POINTS)
+            .enumerate()
+        {
+            let chunk_j_id = *jacobian_id;
+            let mut constraint = VelocityGroundConstraint {
+                dir1: force_dir1,
+                #[cfg(feature = "dim3")]
+                tangent1: tangents1[0],
+                elements: [VelocityGroundConstraintElement::zero(); MAX_MANIFOLD_POINTS],
+                im2: rb_mprops2.effective_inv_mass,
+                limit: 0.0,
+                mj_lambda2,
+                manifold_id,
+                manifold_contact_id: [0; MAX_MANIFOLD_POINTS],
+                num_contacts: manifold_points.len() as u8,
+            };
+
+            for k in 0..manifold_points.len() {
+                let manifold_point = &manifold_points[k];
+                let dp1 = manifold_point.point - world_com1;
+                let dp2 = manifold_point.point - rb_mprops2.world_com;
+
+                let vel1 = rb_vels1.linvel + rb_vels1.angvel.gcross(dp1);
+                let vel2 = rb_vels2.linvel + rb_vels2.angvel.gcross(dp2);
+
+                constraint.limit = manifold_point.friction;
+                constraint.manifold_contact_id[k] = manifold_point.contact_id;
+
+                // Normal part.
+                {
+                    let torque_dir2 = dp2.gcross(-force_dir1);
+                    let inv_r2 = mb2
+                        .fill_jacobians(
+                            link_id2,
+                            -force_dir1,
+                            #[cfg(feature = "dim2")]
+                            na::vector!(torque_dir2),
+                            #[cfg(feature = "dim3")]
+                            torque_dir2,
+                            jacobian_id,
+                            jacobians,
+                        )
+                        .0;
+
+                    let r = crate::utils::inv(inv_r2);
+
+                    let is_bouncy = manifold_point.is_bouncy() as u32 as Real;
+                    let is_resting = 1.0 - is_bouncy;
+
+                    let mut rhs_wo_bias = (1.0 + is_bouncy * manifold_point.restitution)
+                        * (vel1 - vel2).dot(&force_dir1);
+                    rhs_wo_bias += manifold_point.dist.max(0.0) * inv_dt;
+                    rhs_wo_bias *= is_bouncy + is_resting * params.velocity_solve_fraction;
+                    let rhs_bias =
+                        /* is_resting * */ erp_inv_dt * manifold_point.dist.min(0.0);
+
+                    constraint.elements[k].normal_part = VelocityGroundConstraintNormalPart {
+                        gcross2: na::zero(), // Unused for generic constraints.
+                        rhs: rhs_wo_bias + rhs_bias,
+                        rhs_wo_bias,
+                        impulse: na::zero(),
+                        r,
+                    };
+                }
+
+                // Tangent parts.
+                {
+                    constraint.elements[k].tangent_part.impulse = na::zero();
+
+                    for j in 0..DIM - 1 {
+                        let torque_dir2 = dp2.gcross(-tangents1[j]);
+                        let inv_r2 = mb2
+                            .fill_jacobians(
+                                link_id2,
+                                -tangents1[j],
+                                #[cfg(feature = "dim2")]
+                                na::vector![torque_dir2],
+                                #[cfg(feature = "dim3")]
+                                torque_dir2,
+                                jacobian_id,
+                                jacobians,
+                            )
+                            .0;
+
+                        let r = crate::utils::inv(inv_r2);
+
+                        let rhs = (vel1 - vel2
+                            + flipped_multiplier * manifold_point.tangent_velocity)
+                            .dot(&tangents1[j]);
+
+                        constraint.elements[k].tangent_part.rhs[j] = rhs;
+
+                        // FIXME: in 3D, we should take into account gcross[0].dot(gcross[1])
+                        // in lhs. See the corresponding code on the `velocity_constraint.rs`
+                        // file.
+                        constraint.elements[k].tangent_part.r[j] = r;
+                    }
+                }
+            }
+
+            let constraint = GenericVelocityGroundConstraint {
+                velocity_constraint: constraint,
+                j_id: chunk_j_id,
+                ndofs2: mb2.ndofs(),
+            };
+
+            if push {
+                out_constraints.push(AnyGenericVelocityConstraint::NongroupedGround(constraint));
+            } else {
+                out_constraints[manifold.data.constraint_index + _l] =
+                    AnyGenericVelocityConstraint::NongroupedGround(constraint);
+            }
+        }
+    }
+
+    pub fn solve(
+        &mut self,
+        jacobians: &DVector<Real>,
+        generic_mj_lambdas: &mut DVector<Real>,
+        solve_restitution: bool,
+        solve_friction: bool,
+    ) {
+        let mj_lambda2 = self.velocity_constraint.mj_lambda2 as usize;
+
+        let elements = &mut self.velocity_constraint.elements
+            [..self.velocity_constraint.num_contacts as usize];
+        VelocityGroundConstraintElement::generic_solve_group(
+            elements,
+            jacobians,
+            self.velocity_constraint.limit,
+            self.ndofs2,
+            self.j_id,
+            mj_lambda2,
+            generic_mj_lambdas,
+            solve_restitution,
+            solve_friction,
+        );
+    }
+
+    pub fn writeback_impulses(&self, manifolds_all: &mut [&mut ContactManifold]) {
+        self.velocity_constraint.writeback_impulses(manifolds_all);
+    }
+
+    pub fn remove_bias_from_rhs(&mut self) {
+        self.velocity_constraint.remove_bias_from_rhs();
+    }
+}

--- a/src/dynamics/solver/generic_velocity_ground_constraint_element.rs
+++ b/src/dynamics/solver/generic_velocity_ground_constraint_element.rs
@@ -1,0 +1,141 @@
+use crate::dynamics::solver::{
+    VelocityGroundConstraintElement, VelocityGroundConstraintNormalPart,
+    VelocityGroundConstraintTangentPart,
+};
+use crate::math::{Real, DIM};
+use na::DVector;
+#[cfg(feature = "dim2")]
+use na::SimdPartialOrd;
+
+impl VelocityGroundConstraintTangentPart<Real> {
+    #[inline]
+    pub fn generic_solve(
+        &mut self,
+        j_id2: usize,
+        jacobians: &DVector<Real>,
+        ndofs2: usize,
+        limit: Real,
+        mj_lambda2: usize,
+        mj_lambdas: &mut DVector<Real>,
+    ) {
+        #[cfg(feature = "dim2")]
+        {
+            let dvel_0 = jacobians
+                .rows(j_id2, ndofs2)
+                .dot(&mj_lambdas.rows(mj_lambda2, ndofs2))
+                + self.rhs[0];
+
+            let new_impulse = (self.impulse[0] - self.r[0] * dvel_0).simd_clamp(-limit, limit);
+            let dlambda = new_impulse - self.impulse[0];
+            self.impulse[0] = new_impulse;
+
+            mj_lambdas.rows_mut(mj_lambda2, ndofs2).axpy(
+                dlambda,
+                &jacobians.rows(j_id2 + ndofs2, ndofs2),
+                1.0,
+            );
+        }
+
+        #[cfg(feature = "dim3")]
+        {
+            let j_step = ndofs2 * 2;
+            let dvel_0 = jacobians
+                .rows(j_id2, ndofs2)
+                .dot(&mj_lambdas.rows(mj_lambda2, ndofs2))
+                + self.rhs[0];
+            let dvel_1 = jacobians
+                .rows(j_id2 + j_step, ndofs2)
+                .dot(&mj_lambdas.rows(mj_lambda2, ndofs2))
+                + self.rhs[1];
+
+            let new_impulse = na::Vector2::new(
+                self.impulse[0] - self.r[0] * dvel_0,
+                self.impulse[1] - self.r[1] * dvel_1,
+            );
+            let new_impulse = new_impulse.cap_magnitude(limit);
+
+            let dlambda = new_impulse - self.impulse;
+            self.impulse = new_impulse;
+
+            mj_lambdas.rows_mut(mj_lambda2, ndofs2).axpy(
+                dlambda[0],
+                &jacobians.rows(j_id2 + ndofs2, ndofs2),
+                1.0,
+            );
+            mj_lambdas.rows_mut(mj_lambda2, ndofs2).axpy(
+                dlambda[1],
+                &jacobians.rows(j_id2 + j_step + ndofs2, ndofs2),
+                1.0,
+            );
+        }
+    }
+}
+
+impl VelocityGroundConstraintNormalPart<Real> {
+    #[inline]
+    pub fn generic_solve(
+        &mut self,
+        j_id2: usize,
+        jacobians: &DVector<Real>,
+        ndofs2: usize,
+        mj_lambda2: usize,
+        mj_lambdas: &mut DVector<Real>,
+    ) {
+        let dvel = jacobians
+            .rows(j_id2, ndofs2)
+            .dot(&mj_lambdas.rows(mj_lambda2, ndofs2))
+            + self.rhs;
+
+        let new_impulse = (self.impulse - self.r * dvel).max(0.0);
+        let dlambda = new_impulse - self.impulse;
+        self.impulse = new_impulse;
+
+        mj_lambdas.rows_mut(mj_lambda2, ndofs2).axpy(
+            dlambda,
+            &jacobians.rows(j_id2 + ndofs2, ndofs2),
+            1.0,
+        );
+    }
+}
+
+impl VelocityGroundConstraintElement<Real> {
+    #[inline]
+    pub fn generic_solve_group(
+        elements: &mut [Self],
+        jacobians: &DVector<Real>,
+        limit: Real,
+        ndofs2: usize,
+        // Jacobian index of the first constraint.
+        j_id: usize,
+        mj_lambda2: usize,
+        mj_lambdas: &mut DVector<Real>,
+        solve_restitution: bool,
+        solve_friction: bool,
+    ) {
+        let j_step = ndofs2 * 2 * DIM;
+
+        // Solve penetration.
+        if solve_restitution {
+            let mut nrm_j_id = j_id;
+
+            for element in elements.iter_mut() {
+                element
+                    .normal_part
+                    .generic_solve(nrm_j_id, jacobians, ndofs2, mj_lambda2, mj_lambdas);
+                nrm_j_id += j_step;
+            }
+        }
+
+        // Solve friction.
+        if solve_friction {
+            let mut tng_j_id = j_id + ndofs2 * 2;
+
+            for element in elements.iter_mut() {
+                let limit = limit * element.normal_part.impulse;
+                let part = &mut element.tangent_part;
+                part.generic_solve(tng_j_id, jacobians, ndofs2, limit, mj_lambda2, mj_lambdas);
+                tng_j_id += j_step;
+            }
+        }
+    }
+}

--- a/src/dynamics/solver/island_solver.rs
+++ b/src/dynamics/solver/island_solver.rs
@@ -2,7 +2,8 @@ use super::VelocitySolver;
 use crate::counters::Counters;
 use crate::data::{BundleSet, ComponentSet, ComponentSetMut};
 use crate::dynamics::solver::{
-    AnyJointVelocityConstraint, AnyVelocityConstraint, GenericVelocityConstraint, SolverConstraints,
+    AnyGenericVelocityConstraint, AnyJointVelocityConstraint, AnyVelocityConstraint,
+    SolverConstraints,
 };
 use crate::dynamics::{
     IntegrationParameters, JointGraphEdge, JointIndex, RigidBodyDamping, RigidBodyForces,
@@ -13,7 +14,7 @@ use crate::geometry::{ContactManifold, ContactManifoldIndex};
 use crate::prelude::{MultibodyJointSet, RigidBodyActivation};
 
 pub struct IslandSolver {
-    contact_constraints: SolverConstraints<AnyVelocityConstraint, GenericVelocityConstraint>,
+    contact_constraints: SolverConstraints<AnyVelocityConstraint, AnyGenericVelocityConstraint>,
     joint_constraints: SolverConstraints<AnyJointVelocityConstraint, ()>,
     velocity_solver: VelocitySolver,
 }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -13,6 +13,7 @@ pub(self) use self::velocity_solver::VelocitySolver;
 pub(self) use delta_vel::DeltaVel;
 pub(self) use generic_velocity_constraint::*;
 pub(self) use generic_velocity_constraint_element::*;
+pub(self) use generic_velocity_ground_constraint::*;
 pub(self) use interaction_groups::*;
 pub(crate) use joint_constraint::MotorParameters;
 pub use joint_constraint::*;
@@ -29,6 +30,8 @@ mod categorization;
 mod delta_vel;
 mod generic_velocity_constraint;
 mod generic_velocity_constraint_element;
+mod generic_velocity_ground_constraint;
+mod generic_velocity_ground_constraint_element;
 mod interaction_groups;
 #[cfg(not(feature = "parallel"))]
 mod island_solver;

--- a/src/dynamics/solver/velocity_constraint.rs
+++ b/src/dynamics/solver/velocity_constraint.rs
@@ -236,7 +236,7 @@ impl VelocityConstraint {
                         .transform_vector(dp2.gcross(-force_dir1));
 
                     let imsum = mprops1.effective_inv_mass + mprops2.effective_inv_mass;
-                    let r = 1.0
+                    let r = params.delassus_inv_factor
                         / (force_dir1.dot(&imsum.component_mul(&force_dir1))
                             + gcross1.gdot(gcross1)
                             + gcross2.gdot(gcross2));
@@ -246,8 +246,7 @@ impl VelocityConstraint {
 
                     let mut rhs_wo_bias = (1.0 + is_bouncy * manifold_point.restitution)
                         * (vel1 - vel2).dot(&force_dir1);
-                    rhs_wo_bias +=
-                        (manifold_point.dist + params.allowed_linear_error).max(0.0) * inv_dt;
+                    rhs_wo_bias += manifold_point.dist.max(0.0) * inv_dt;
                     rhs_wo_bias *= is_bouncy + is_resting * params.velocity_solve_fraction;
                     let rhs_bias = /* is_resting
                         * */  erp_inv_dt
@@ -275,17 +274,26 @@ impl VelocityConstraint {
                             .effective_world_inv_inertia_sqrt
                             .transform_vector(dp2.gcross(-tangents1[j]));
                         let imsum = mprops1.effective_inv_mass + mprops2.effective_inv_mass;
-                        let r = 1.0
-                            / (tangents1[j].dot(&imsum.component_mul(&tangents1[j]))
-                                + gcross1.gdot(gcross1)
-                                + gcross2.gdot(gcross2));
+                        let r = tangents1[j].dot(&imsum.component_mul(&tangents1[j]))
+                            + gcross1.gdot(gcross1)
+                            + gcross2.gdot(gcross2);
                         let rhs =
                             (vel1 - vel2 + manifold_point.tangent_velocity).dot(&tangents1[j]);
 
                         constraint.elements[k].tangent_part.gcross1[j] = gcross1;
                         constraint.elements[k].tangent_part.gcross2[j] = gcross2;
                         constraint.elements[k].tangent_part.rhs[j] = rhs;
-                        constraint.elements[k].tangent_part.r[j] = r;
+                        constraint.elements[k].tangent_part.r[j] =
+                            if cfg!(feature = "dim2") { 1.0 / r } else { r };
+                    }
+
+                    #[cfg(feature = "dim3")]
+                    {
+                        constraint.elements[k].tangent_part.r[2] = 2.0
+                            * (constraint.elements[k].tangent_part.gcross1[0]
+                                .gdot(constraint.elements[k].tangent_part.gcross1[1])
+                                + constraint.elements[k].tangent_part.gcross2[0]
+                                    .gdot(constraint.elements[k].tangent_part.gcross2[1]));
                     }
                 }
             }

--- a/src/dynamics/solver/velocity_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_constraint_wide.rs
@@ -49,6 +49,7 @@ impl WVelocityConstraint {
         let inv_dt = SimdReal::splat(params.inv_dt());
         let velocity_solve_fraction = SimdReal::splat(params.velocity_solve_fraction);
         let erp_inv_dt = SimdReal::splat(params.erp_inv_dt());
+        let delassus_inv_factor = SimdReal::splat(params.delassus_inv_factor);
         let allowed_lin_err = SimdReal::splat(params.allowed_linear_error);
 
         let handles1 = gather![|ii| manifolds[ii].data.rigid_body1.unwrap()];
@@ -136,14 +137,14 @@ impl WVelocityConstraint {
                     let gcross2 = ii2.transform_vector(dp2.gcross(-force_dir1));
 
                     let imsum = im1 + im2;
-                    let r = SimdReal::splat(1.0)
+                    let r = delassus_inv_factor
                         / (force_dir1.dot(&imsum.component_mul(&force_dir1))
                             + gcross1.gdot(gcross1)
                             + gcross2.gdot(gcross2));
                     let projected_velocity = (vel1 - vel2).dot(&force_dir1);
                     let mut rhs_wo_bias =
                         (SimdReal::splat(1.0) + is_bouncy * restitution) * projected_velocity;
-                    rhs_wo_bias += (dist + allowed_lin_err).simd_max(SimdReal::zero()) * inv_dt;
+                    rhs_wo_bias += dist.simd_max(SimdReal::zero()) * inv_dt;
                     rhs_wo_bias *= is_bouncy + is_resting * velocity_solve_fraction;
                     let rhs_bias = (dist + allowed_lin_err).simd_min(SimdReal::zero())
                         * (erp_inv_dt/* * is_resting */);
@@ -165,16 +166,28 @@ impl WVelocityConstraint {
                     let gcross1 = ii1.transform_vector(dp1.gcross(tangents1[j]));
                     let gcross2 = ii2.transform_vector(dp2.gcross(-tangents1[j]));
                     let imsum = im1 + im2;
-                    let r = SimdReal::splat(1.0)
-                        / (tangents1[j].dot(&imsum.component_mul(&tangents1[j]))
-                            + gcross1.gdot(gcross1)
-                            + gcross2.gdot(gcross2));
+                    let r = tangents1[j].dot(&imsum.component_mul(&tangents1[j]))
+                        + gcross1.gdot(gcross1)
+                        + gcross2.gdot(gcross2);
                     let rhs = (vel1 - vel2 + tangent_velocity).dot(&tangents1[j]);
 
                     constraint.elements[k].tangent_part.gcross1[j] = gcross1;
                     constraint.elements[k].tangent_part.gcross2[j] = gcross2;
                     constraint.elements[k].tangent_part.rhs[j] = rhs;
-                    constraint.elements[k].tangent_part.r[j] = r;
+                    constraint.elements[k].tangent_part.r[j] = if cfg!(feature = "dim2") {
+                        SimdReal::splat(1.0) / r
+                    } else {
+                        r
+                    };
+                }
+
+                #[cfg(feature = "dim3")]
+                {
+                    constraint.elements[k].tangent_part.r[2] = SimdReal::splat(2.0)
+                        * (constraint.elements[k].tangent_part.gcross1[0]
+                            .gdot(constraint.elements[k].tangent_part.gcross1[1])
+                            + constraint.elements[k].tangent_part.gcross2[0]
+                                .gdot(constraint.elements[k].tangent_part.gcross2[1]));
                 }
             }
 

--- a/src/dynamics/solver/velocity_ground_constraint_element.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_element.rs
@@ -11,17 +11,22 @@ pub(crate) struct VelocityGroundConstraintTangentPart<N: SimdRealField + Copy> {
     pub impulse: na::Vector1<N>,
     #[cfg(feature = "dim3")]
     pub impulse: na::Vector2<N>,
-    pub r: [N; DIM - 1],
+    #[cfg(feature = "dim2")]
+    pub r: [N; 1],
+    #[cfg(feature = "dim3")]
+    pub r: [N; DIM],
 }
 
 impl<N: SimdRealField + Copy> VelocityGroundConstraintTangentPart<N> {
-    #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
             gcross2: [na::zero(); DIM - 1],
             rhs: [na::zero(); DIM - 1],
             impulse: na::zero(),
-            r: [na::zero(); DIM - 1],
+            #[cfg(feature = "dim2")]
+            r: [na::zero(); 1],
+            #[cfg(feature = "dim3")]
+            r: [na::zero(); DIM],
         }
     }
 
@@ -38,10 +43,10 @@ impl<N: SimdRealField + Copy> VelocityGroundConstraintTangentPart<N> {
     {
         #[cfg(feature = "dim2")]
         {
-            let dimpulse = -tangents1[0].dot(&mj_lambda2.linear)
+            let dvel = -tangents1[0].dot(&mj_lambda2.linear)
                 + self.gcross2[0].gdot(mj_lambda2.angular)
                 + self.rhs[0];
-            let new_impulse = (self.impulse[0] - self.r[0] * dimpulse).simd_clamp(-limit, limit);
+            let new_impulse = (self.impulse[0] - self.r[0] * dvel).simd_clamp(-limit, limit);
             let dlambda = new_impulse - self.impulse[0];
             self.impulse[0] = new_impulse;
 
@@ -51,17 +56,22 @@ impl<N: SimdRealField + Copy> VelocityGroundConstraintTangentPart<N> {
 
         #[cfg(feature = "dim3")]
         {
-            let dimpulse_0 = -tangents1[0].dot(&mj_lambda2.linear)
+            let dvel_0 = -tangents1[0].dot(&mj_lambda2.linear)
                 + self.gcross2[0].gdot(mj_lambda2.angular)
                 + self.rhs[0];
-            let dimpulse_1 = -tangents1[1].dot(&mj_lambda2.linear)
+            let dvel_1 = -tangents1[1].dot(&mj_lambda2.linear)
                 + self.gcross2[1].gdot(mj_lambda2.angular)
                 + self.rhs[1];
 
-            let new_impulse = na::Vector2::new(
-                self.impulse[0] - self.r[0] * dimpulse_0,
-                self.impulse[1] - self.r[1] * dimpulse_1,
-            );
+            let dvel_00 = dvel_0 * dvel_0;
+            let dvel_11 = dvel_1 * dvel_1;
+            let dvel_01 = dvel_0 * dvel_1;
+            let inv_lhs = (dvel_00 + dvel_11)
+                * crate::utils::simd_inv(
+                    dvel_00 * self.r[0] + dvel_11 * self.r[1] + dvel_01 * self.r[2],
+                );
+            let delta_impulse = na::vector![inv_lhs * dvel_0, inv_lhs * dvel_1];
+            let new_impulse = self.impulse - delta_impulse;
             let new_impulse = {
                 let _disable_fe_except =
                     crate::utils::DisableFloatingPointExceptionsFlags::
@@ -69,7 +79,6 @@ impl<N: SimdRealField + Copy> VelocityGroundConstraintTangentPart<N> {
                 new_impulse.simd_cap_magnitude(limit)
             };
             let dlambda = new_impulse - self.impulse;
-
             self.impulse = new_impulse;
 
             mj_lambda2.linear += tangents1[0].component_mul(im2) * -dlambda[0]
@@ -89,7 +98,6 @@ pub(crate) struct VelocityGroundConstraintNormalPart<N: SimdRealField + Copy> {
 }
 
 impl<N: SimdRealField + Copy> VelocityGroundConstraintNormalPart<N> {
-    #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     fn zero() -> Self {
         Self {
             gcross2: na::zero(),
@@ -105,9 +113,8 @@ impl<N: SimdRealField + Copy> VelocityGroundConstraintNormalPart<N> {
     where
         AngVector<N>: WDot<AngVector<N>, Result = N>,
     {
-        let dimpulse =
-            -dir1.dot(&mj_lambda2.linear) + self.gcross2.gdot(mj_lambda2.angular) + self.rhs;
-        let new_impulse = (self.impulse - self.r * dimpulse).simd_max(N::zero());
+        let dvel = -dir1.dot(&mj_lambda2.linear) + self.gcross2.gdot(mj_lambda2.angular) + self.rhs;
+        let new_impulse = (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 
@@ -123,7 +130,6 @@ pub(crate) struct VelocityGroundConstraintElement<N: SimdRealField + Copy> {
 }
 
 impl<N: SimdRealField + Copy> VelocityGroundConstraintElement<N> {
-    #[cfg(any(not(target_arch = "wasm32"), feature = "simd-is-enabled"))]
     pub fn zero() -> Self {
         Self {
             normal_part: VelocityGroundConstraintNormalPart::zero(),

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -1,6 +1,6 @@
 use super::AnyJointVelocityConstraint;
 use crate::data::{BundleSet, ComponentSet, ComponentSetMut};
-use crate::dynamics::solver::GenericVelocityConstraint;
+use crate::dynamics::solver::AnyGenericVelocityConstraint;
 use crate::dynamics::{
     solver::{AnyVelocityConstraint, DeltaVel},
     IntegrationParameters, JointGraphEdge, MultibodyJointSet, RigidBodyForces, RigidBodyType,
@@ -36,7 +36,7 @@ impl VelocitySolver {
         manifolds_all: &mut [&mut ContactManifold],
         joints_all: &mut [JointGraphEdge],
         contact_constraints: &mut [AnyVelocityConstraint],
-        generic_contact_constraints: &mut [GenericVelocityConstraint],
+        generic_contact_constraints: &mut [AnyGenericVelocityConstraint],
         generic_contact_jacobians: &DVector<Real>,
         joint_constraints: &mut [AnyJointVelocityConstraint],
         generic_joint_jacobians: &DVector<Real>,

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -179,6 +179,7 @@ impl PhysicsPipeline {
     {
         self.counters.stages.island_construction_time.resume();
         islands.update_active_set_with_contacts(
+            integration_parameters.dt,
             bodies,
             colliders,
             narrow_phase,

--- a/src_testbed/camera2d.rs
+++ b/src_testbed/camera2d.rs
@@ -39,10 +39,8 @@ impl OrbitCameraPlugin {
         mut query: Query<(&OrbitCamera, &mut Transform), (Changed<OrbitCamera>, With<Camera>)>,
     ) {
         for (camera, mut transform) in query.iter_mut() {
-            if camera.enabled {
-                transform.translation = camera.center;
-                transform.scale = Vec3::new(1.0 / camera.zoom, 1.0 / camera.zoom, 1.0);
-            }
+            transform.translation = camera.center;
+            transform.scale = Vec3::new(1.0 / camera.zoom, 1.0 / camera.zoom, 1.0);
         }
     }
 

--- a/src_testbed/camera3d.rs
+++ b/src_testbed/camera3d.rs
@@ -50,12 +50,10 @@ impl OrbitCameraPlugin {
         mut query: Query<(&OrbitCamera, &mut Transform), (Changed<OrbitCamera>, With<Camera>)>,
     ) {
         for (camera, mut transform) in query.iter_mut() {
-            if camera.enabled {
-                let rot = Quat::from_axis_angle(Vec3::Y, camera.x)
-                    * Quat::from_axis_angle(-Vec3::X, camera.y);
-                transform.translation = (rot * Vec3::Y) * camera.distance + camera.center;
-                transform.look_at(camera.center, Vec3::Y);
-            }
+            let rot = Quat::from_axis_angle(Vec3::Y, camera.x)
+                * Quat::from_axis_angle(-Vec3::X, camera.y);
+            transform.translation = (rot * Vec3::Y) * camera.distance + camera.center;
+            transform.look_at(camera.center, Vec3::Y);
         }
     }
 

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -2,10 +2,10 @@ use bevy::prelude::*;
 
 use na::{point, Point3};
 
-use crate::math::Isometry;
 use crate::objects::node::EntityWithGraphics;
 use rapier::dynamics::{RigidBodyHandle, RigidBodySet};
 use rapier::geometry::{ColliderHandle, ColliderSet, Shape, ShapeType};
+use rapier::math::{Isometry, Real};
 //use crate::objects::capsule::Capsule;
 //#[cfg(feature = "dim3")]
 //use crate::objects::mesh::Mesh;
@@ -301,8 +301,8 @@ impl GraphicsManager {
         handle: Option<ColliderHandle>,
         shape: &dyn Shape,
         sensor: bool,
-        pos: &Isometry<f32>,
-        delta: &Isometry<f32>,
+        pos: &Isometry<Real>,
+        delta: &Isometry<Real>,
         color: Point3<f32>,
         out: &mut Vec<EntityWithGraphics>,
     ) {
@@ -347,18 +347,24 @@ impl GraphicsManager {
         _bodies: &RigidBodySet,
         colliders: &ColliderSet,
         components: &mut Query<(&mut Transform,)>,
+        _materials: &mut Assets<BevyMaterial>,
     ) {
         for (_, ns) in self.b2sn.iter_mut() {
             for n in ns.iter_mut() {
-                // if let Some(co) = colliders.get(n.collider()) {
-                //     let bo = &_bodies[co.parent()];
-                //
-                //     if bo.is_dynamic() {
-                //         if bo.is_ccd_active() {
-                //             n.set_color(point![1.0, 0.0, 0.0]);
-                //         } else {
-                //             n.set_color(point![0.0, 1.0, 0.0]);
-                //         }
+                // if let Some(bo) = n
+                //     .collider
+                //     .and_then(|h| bodies.get(colliders.get(h)?.parent()?))
+                // {
+                //     if bo.activation().time_since_can_sleep
+                //         >= RigidBodyActivation::default_time_until_sleep()
+                //     {
+                //         n.set_color(materials, point![1.0, 0.0, 0.0]);
+                //     }
+                //     /* else if bo.activation().energy < bo.activation().threshold {
+                //         n.set_color(materials, point![0.0, 0.0, 1.0]);
+                //     } */
+                //     else {
+                //         n.set_color(materials, point![0.0, 1.0, 0.0]);
                 //     }
                 // }
 

--- a/src_testbed/harness/mod.rs
+++ b/src_testbed/harness/mod.rs
@@ -8,7 +8,7 @@ use rapier::dynamics::{
     RigidBodySet,
 };
 use rapier::geometry::{BroadPhase, ColliderSet, NarrowPhase};
-use rapier::math::Vector;
+use rapier::math::{Real, Vector};
 use rapier::pipeline::{ChannelEventCollector, PhysicsHooks, PhysicsPipeline, QueryPipeline};
 
 pub mod plugin;
@@ -131,7 +131,7 @@ impl Harness {
         colliders: ColliderSet,
         impulse_joints: ImpulseJointSet,
         multibody_joints: MultibodyJointSet,
-        gravity: Vector<f32>,
+        gravity: Vector<Real>,
         hooks: impl PhysicsHooks<RigidBodySet, ColliderSet> + 'static,
     ) {
         // println!("Num bodies: {}", bodies.len());
@@ -235,7 +235,7 @@ impl Harness {
 
         self.events.poll_all();
 
-        self.state.time += self.physics.integration_parameters.dt;
+        self.state.time += self.physics.integration_parameters.dt as f32;
         self.state.timestep_id += 1;
     }
 

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -1,12 +1,4 @@
 extern crate nalgebra as na;
-#[cfg(feature = "dim2")]
-extern crate parry2d as parry;
-#[cfg(feature = "dim3")]
-extern crate parry3d as parry;
-#[cfg(feature = "dim2")]
-extern crate rapier2d as rapier;
-#[cfg(feature = "dim3")]
-extern crate rapier3d as rapier;
 
 #[macro_use]
 extern crate bitflags;

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -4,7 +4,7 @@ use rapier::dynamics::{
     RigidBodySet,
 };
 use rapier::geometry::{BroadPhase, ColliderSet, ContactEvent, IntersectionEvent, NarrowPhase};
-use rapier::math::Vector;
+use rapier::math::{Real, Vector};
 use rapier::pipeline::{PhysicsHooks, PhysicsPipeline, QueryPipeline};
 
 pub struct PhysicsSnapshot {
@@ -82,7 +82,7 @@ pub struct PhysicsState {
     pub pipeline: PhysicsPipeline,
     pub query_pipeline: QueryPipeline,
     pub integration_parameters: IntegrationParameters,
-    pub gravity: Vector<f32>,
+    pub gravity: Vector<Real>,
     pub hooks: Box<dyn PhysicsHooks<RigidBodySet, ColliderSet>>,
 }
 

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -1,4 +1,5 @@
 use rapier::counters::Counters;
+use rapier::math::Real;
 
 use crate::harness::Harness;
 use crate::testbed::{
@@ -147,7 +148,7 @@ pub fn update_ui(ui_context: &EguiContext, state: &mut TestbedState, harness: &m
         );
         let mut frequency = integration_parameters.inv_dt().round() as u32;
         ui.add(Slider::new(&mut frequency, 0..=240).text("frequency (Hz)"));
-        integration_parameters.set_inv_dt(frequency as f32);
+        integration_parameters.set_inv_dt(frequency as Real);
 
         let mut sleep = state.flags.contains(TestbedStateFlags::SLEEP);
         // let mut contact_points = state.flags.contains(TestbedStateFlags::CONTACT_POINTS);


### PR DESCRIPTION
- Fix the wrong codepath taken  by the solver for contacts involving a collider without parent (fix https://github.com/dimforge/bevy_rapier/issues/110).
- Properly address the non-linear treatment of the friction direction.
- Simplify the sleeping strategy.
- Add an impulse resolution multiplier.