### PR TITLE
Fix rigid bodies falling asleep when linear/angular threshold is negative

### DIFF
--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -352,8 +352,8 @@ impl IslandManager {
 }
 
 fn update_energy(activation: &mut RigidBodyActivation, sq_linvel: Real, sq_angvel: Real, dt: Real) {
-    if sq_linvel < activation.linear_threshold * activation.linear_threshold
-        && sq_angvel < activation.angular_threshold * activation.angular_threshold
+    if sq_linvel < activation.linear_threshold * activation.linear_threshold.abs()
+        && sq_angvel < activation.angular_threshold * activation.angular_threshold.abs()
     {
         activation.time_since_can_sleep += dt;
     } else {


### PR DESCRIPTION
When a rigid body is created with `.can_sleep(false)`, the builder sets its activation thresholds to -1. However when the actual check is being made in island manager, the value of thresholds gets squared and sign is lost, allowing body to fall asleep.
