### PR TITLE
Derive Debug for IntegrationParameters

### DIFF
--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -1,7 +1,7 @@
 use crate::math::Real;
 
 /// Parameters for a time-step of the physics engine.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct IntegrationParameters {
     /// The timestep length (default: `1.0 / 60.0`)


### PR DESCRIPTION
Derive `Debug` for `IntegrationParameters` as per [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits).

I wanted to print out the value of the `IntegrationParameters` struct that `bevy_rapier2d` begins with, but it didn't implement `Debug`.