### PR TITLE
Fix mass-properties update after collider change

### DIFF
--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -76,6 +76,12 @@ bitflags::bitflags! {
     }
 }
 
+impl Default for JointAxesMask {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 /// Identifiers of degrees of freedoms of a joint.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -230,7 +236,8 @@ impl GenericJoint {
         self.limit_axes.is_empty() && self.motor_axes.is_empty()
     }
 
-    fn complete_ang_frame(axis: UnitVector<Real>) -> Rotation<Real> {
+    #[doc(hidden)]
+    pub fn complete_ang_frame(axis: UnitVector<Real>) -> Rotation<Real> {
         let basis = axis.orthonormal_basis();
 
         #[cfg(feature = "dim2")]

--- a/src/dynamics/solver/interaction_groups.rs
+++ b/src/dynamics/solver/interaction_groups.rs
@@ -431,14 +431,14 @@ impl InteractionGroups {
                     let data: (_, &RigidBodyIds) = bodies.index_bundle(rb1.0);
                     (*data.0, data.1.active_set_offset)
                 } else {
-                    (RigidBodyType::Fixed, 0)
+                    (RigidBodyType::Fixed, usize::MAX)
                 };
                 let (status2, active_set_offset2) = if let Some(rb2) = interaction.data.rigid_body2
                 {
                     let data: (_, &RigidBodyIds) = bodies.index_bundle(rb2.0);
                     (*data.0, data.1.active_set_offset)
                 } else {
-                    (RigidBodyType::Fixed, 0)
+                    (RigidBodyType::Fixed, usize::MAX)
                 };
 
                 let is_fixed1 = !status1.is_dynamic();
@@ -451,7 +451,9 @@ impl InteractionGroups {
 
                 let i1 = active_set_offset1;
                 let i2 = active_set_offset2;
-                let conflicts = self.body_masks[i1] | self.body_masks[i2];
+                let mask1 = if !is_fixed1 { self.body_masks[i1] } else { 0 };
+                let mask2 = if !is_fixed2 { self.body_masks[i2] } else { 0 };
+                let conflicts = mask1 | mask2;
                 let conflictfree_targets = !(conflicts & occupied_mask); // The & is because we consider empty buckets as free of conflicts.
                 let conflictfree_occupied_targets = conflictfree_targets & occupied_mask;
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -411,21 +411,18 @@ impl ColliderBuilder {
 
     /// Initialize a new collider builder with a capsule shape aligned with the `x` axis.
     pub fn capsule_x(half_height: Real, radius: Real) -> Self {
-        let p = Point::from(Vector::x() * half_height);
-        Self::new(SharedShape::capsule(-p, p, radius))
+        Self::new(SharedShape::capsule_x(half_height, radius))
     }
 
     /// Initialize a new collider builder with a capsule shape aligned with the `y` axis.
     pub fn capsule_y(half_height: Real, radius: Real) -> Self {
-        let p = Point::from(Vector::y() * half_height);
-        Self::new(SharedShape::capsule(-p, p, radius))
+        Self::new(SharedShape::capsule_y(half_height, radius))
     }
 
     /// Initialize a new collider builder with a capsule shape aligned with the `z` axis.
     #[cfg(feature = "dim3")]
     pub fn capsule_z(half_height: Real, radius: Real) -> Self {
-        let p = Point::from(Vector::z() * half_height);
-        Self::new(SharedShape::capsule(-p, p, radius))
+        Self::new(SharedShape::capsule_z(half_height, radius))
     }
 
     /// Initialize a new collider builder with a cuboid shape defined by its half-extents.

--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -3,12 +3,12 @@
 use crate::data::{ComponentSet, ComponentSetMut, ComponentSetOption};
 use crate::dynamics::{
     RigidBodyActivation, RigidBodyChanges, RigidBodyColliders, RigidBodyDominance, RigidBodyHandle,
-    RigidBodyIds, RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
+    RigidBodyIds, RigidBodyMassProps, RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
 };
 use crate::geometry::{
     BroadPhase, BroadPhasePairEvent, ColliderBroadPhaseData, ColliderChanges, ColliderFlags,
-    ColliderHandle, ColliderMaterial, ColliderPair, ColliderParent, ColliderPosition,
-    ColliderShape, ColliderType, NarrowPhase,
+    ColliderHandle, ColliderMassProps, ColliderMaterial, ColliderPair, ColliderParent,
+    ColliderPosition, ColliderShape, ColliderType, NarrowPhase,
 };
 use crate::math::Real;
 use crate::pipeline::{EventHandler, PhysicsHooks};
@@ -169,6 +169,7 @@ impl CollisionPipeline {
             + ComponentSetMut<RigidBodyIds>
             + ComponentSetMut<RigidBodyActivation>
             + ComponentSetMut<RigidBodyChanges>
+            + ComponentSetMut<RigidBodyMassProps>
             + ComponentSet<RigidBodyColliders>
             + ComponentSet<RigidBodyDominance>
             + ComponentSet<RigidBodyType>,
@@ -179,7 +180,8 @@ impl CollisionPipeline {
             + ComponentSetOption<ColliderParent>
             + ComponentSet<ColliderType>
             + ComponentSet<ColliderMaterial>
-            + ComponentSet<ColliderFlags>,
+            + ComponentSet<ColliderFlags>
+            + ComponentSet<ColliderMassProps>,
     {
         super::user_changes::handle_user_changes_to_colliders(
             bodies,

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -15,7 +15,7 @@ use crate::dynamics::{JointGraphEdge, ParallelIslandSolver as IslandSolver};
 use crate::geometry::{
     BroadPhase, BroadPhasePairEvent, ColliderBroadPhaseData, ColliderChanges, ColliderFlags,
     ColliderHandle, ColliderMaterial, ColliderPair, ColliderParent, ColliderPosition,
-    ColliderShape, ColliderType, ContactManifoldIndex, NarrowPhase,
+    ColliderShape, ColliderType, ContactManifoldIndex, NarrowPhase, ColliderMassProps
 };
 use crate::math::{Real, Vector};
 use crate::pipeline::{EventHandler, PhysicsHooks};
@@ -504,7 +504,8 @@ impl PhysicsPipeline {
             + ComponentSetOption<ColliderParent>
             + ComponentSet<ColliderType>
             + ComponentSet<ColliderMaterial>
-            + ComponentSet<ColliderFlags>,
+            + ComponentSet<ColliderFlags>
+            + ComponentSet<ColliderMassProps>,
     {
         self.counters.reset();
         self.counters.step_started();


### PR DESCRIPTION
This PR ensures that the mass-properties of a rigid-body are recomputed after modifying one of its attached colliders.
These mass-properties are recomputed from the colliders, as well as the newly stored additional mass-properties given to the rigid-body during its creation with the `RigidBodyBuilder`.