### PR TITLE
Allow collider modifications to wake-up their parent rigid-body

### DIFF
--- a/examples3d/debug_shape_modification3.rs
+++ b/examples3d/debug_shape_modification3.rs
@@ -61,7 +61,7 @@ pub fn init_world(testbed: &mut Testbed) {
         }
 
         let ball_coll = physics.colliders.get_mut(ball_coll_handle).unwrap();
-        ball_coll.set_shape(SharedShape::ball(ball_rad * step as f32 * 2.0));
+        ball_coll.set_shape(SharedShape::ball(ball_rad * step as f32 * 2.0), true);
     });
 
     /*

--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -62,6 +62,8 @@ bitflags::bitflags! {
         /// This flags is automatically set by the `PhysicsPipeline` when the `RigidBodyChanges::DOMINANCE`
         /// or `RigidBodyChanges::TYPE` of the parent rigid-body of this collider is detected.
         const PARENT_EFFECTIVE_DOMINANCE = 1 << 6; // NF update.
+        /// Indicates that the parent rigid-body of this collider should be awaken.
+        const WAKE_UP_PARENT = 1 << 7;
     }
 }
 


### PR DESCRIPTION
Until now, modifying a collider will not result in its parent being woken up, unless the user does so explicitly. Therefore, modifying, e.g., the collision groups of a collider may not have an immediate impact on the existing contacts because these contacts would not be recomputed if the rigid-body isn’t awaken.

In order to reduce the risk of the user forgetting to manually wake-up the collider’s parent, this PR add to colliders the ability to wake-up their parent automatically (at the next timestep).