### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 
-## Unreleased
+## v0.12.0 (30 Apr. 2022)
 ### Fixed
 - Fix the simulation when the `parallel` feature is enabled.
 - Fix bug where damping would not be applied properly to some bodies.
 - Fix panics caused by various situations (contact or joints) involving rigid-bodies with locked translations/rotations.
-
+- Fix bug where collider modifications (like changes of collision groups, or shape) would not wake-up their attached
+  rigid-body, or would not have any effect on pre-existing contacts.
+- Fix the automatic update of a rigid-body’s mass properties after changing one of its attached colliders.
+- Fix the broad-phase becoming potentially invalid after a change of collision groups.
 
 ### Modified
+- Switch to `nalgebra` 0.31.
+- Switch to `parry` 0.9.
 - Rename `JointHandle` to `ImpulseJointHandle`.
 - Rename `RigidBodyMassPropsFlags` to `LockedAxes`.
 - Rename `RigidBody::apply_force`, `::apply_torque`, `::apply_force_at_point` to `::add_force`,
@@ -24,10 +29,13 @@
   which are more stable.  
 - Calling the `.build()` function from builders (`RigidBodyBuilder`, `ColliderBuilder`, etc.) is no longer necessary
   whan adding them to sets. It is automatically called thanks to `Into<_>` implementations.  
+- The `ComponentSet` abstractions (and related `_generic` methods like `PhysicsPipeline::step_generic`) have been
+  removed. Custom storage for colliders and rigid-bodies are no longer possible: use the built-in `RigidBodySet` and
+  `ColliderSet` instead.
 
 ### Semantic modifications
 These are changes in the behavior of the physics engine that are not necessarily
-reflected by an API change:
+reflected by an API change. See [#304](https://github.com/dimforge/rapier/pull/304) for extensive details.
 - `RigidBody::set_linvel` and `RigidBody::set_angvel` no longer modify the velocity of static bodies.
 - `RigidBody::set_body_type` will reset the velocity of a rigid-body to zero if it is static.
 - Don’t automatically clear forces at the end of a timestep.
@@ -43,7 +51,9 @@ reflected by an API change:
 - Adds a `bool` argument to `RigidBodySet::remove`. If set to `false`, the colliders attached to the rigid-body
   won’t be automatically deleted (they will only be detached from the deleted rigid-body instead).
 - Add `RigidBody::reset_forces` and `RigidBody::reset_torques` to reset all the forces and torques added to the
-  rigid-bodiy by the user.
+  rigid-body by the user.
+- Add the `debug-render` cargo feature that enables the `DebugRenderPipeline`: a line-based backend-agnostic
+  renderer to debug the state of the physics engine.
 
 ## v0.12.0-alpha.0 (2 Jan. 2022)
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ resolver = "2"
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 [profile.release]
 #debug = true

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,8 +47,8 @@ required-features = [ "dim2", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.30"
-parry2d-f64 = "0.8"
+nalgebra = "0.31"
+parry2d-f64 = "0.9"
 simba = "0.7"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"
@@ -47,8 +47,8 @@ required-features = [ "dim2", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.30"
-parry2d = "0.8"
+nalgebra = "0.31"
+parry2d = "0.9"
 simba = "0.7"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,8 +47,8 @@ required-features = [ "dim3", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.30"
-parry3d-f64 = "0.8"
+nalgebra = "0.31"
+parry3d-f64 = "0.9"
 simba = "0.7"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"
@@ -47,8 +47,8 @@ required-features = [ "dim3", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ]}
 num-traits = "0.2"
-nalgebra = "0.30"
-parry3d = "0.8"
+nalgebra = "0.31"
+parry3d = "0.9"
 simba = "0.7"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -26,7 +26,7 @@ other-backends = [ "wrapped2d" ]
 
 
 [dependencies]
-nalgebra   = { version = "0.30", features = [ "rand" ] }
+nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 features = [ "serde-serialize", "debug-render" ]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -26,7 +26,7 @@ other-backends = [ "wrapped2d" ]
 
 
 [dependencies]
-nalgebra   = { version = "0.30", features = [ "rand" ] }
+nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 features = [ "serde-serialize", "debug-render" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -24,7 +24,7 @@ dim3 = [ ]
 parallel = [ "rapier/parallel", "num_cpus" ]
 
 [dependencies]
-nalgebra   = { version = "0.30", features = [ "rand" ] }
+nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -52,5 +52,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 features = [ "serde-serialize", "debug-render" ]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -25,7 +25,7 @@ parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "physx", "physx-sys", "glam" ]
 
 [dependencies]
-nalgebra   = { version = "0.30", features = [ "rand" ] }
+nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -56,5 +56,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.12.0-alpha.1"
+version = "0.12.0"
 features = [ "serde-serialize", "debug-render" ]


### PR DESCRIPTION
## v0.12.0 (30 Apr. 2022)
### Fixed
- Fix the simulation when the `parallel` feature is enabled.
- Fix bug where damping would not be applied properly to some bodies.
- Fix panics caused by various situations (contact or joints) involving rigid-bodies with locked translations/rotations.
- Fix bug where collider modifications (like changes of collision groups, or shape) would not wake-up their attached
  rigid-body, or would not have any effect on pre-existing contacts.
- Fix the automatic update of a rigid-body’s mass properties after changing one of its attached colliders.
- Fix the broad-phase becoming potentially invalid after a change of collision groups.

### Modified
- Switch to `nalgebra` 0.31.
- Switch to `parry` 0.9.
- Rename `JointHandle` to `ImpulseJointHandle`.
- Rename `RigidBodyMassPropsFlags` to `LockedAxes`.
- Rename `RigidBody::apply_force`, `::apply_torque`, `::apply_force_at_point` to `::add_force`,
  `::add_torque`, and `::add_force_at_point` to better reflect the fact that they are not cleared at the end
  of the timestep.
- Rename `RigidBodyType::Static` to `RigidBodyType::Fixed` to avoid confusion with the `static` keyword.
- All method referring to `static` rigid-bodies now use `fixed` instead of `static`.
- Rename `RigidBodyBuilder::new_static, new_kinematic_velocity_based, new_kinematic_velocity_based` to
  `RigidBodyBuilder::fixed, kinematic_velocity_based, kinematic_velocity_based`.
- The `ContactEvent` and `IntersectionEvent` have been replaced by a single enum `CollisionEvent` in order
  to simplify the user’s event handling.
- The `ActiveEvents::CONTACT_EVENTS` and `ActiveEvents::INTERSECTION_EVENTS` flags have been replaced by a single
  flag `ActiveEvents::COLLISION_EVENTS`.
- Joint motors no longer have a `VelocityBased` model. The new choices are `AccelerationBased` and `ForceBased`
  which are more stable.  
- Calling the `.build()` function from builders (`RigidBodyBuilder`, `ColliderBuilder`, etc.) is no longer necessary
  whan adding them to sets. It is automatically called thanks to `Into<_>` implementations.  
- The `ComponentSet` abstractions (and related `_generic` methods like `PhysicsPipeline::step_generic`) have been
  removed. Custom storage for colliders and rigid-bodies are no longer possible: use the built-in `RigidBodySet` and
  `ColliderSet` instead.

### Semantic modifications
These are changes in the behavior of the physics engine that are not necessarily
reflected by an API change. See [#304](https://github.com/dimforge/rapier/pull/304) for extensive details.
- `RigidBody::set_linvel` and `RigidBody::set_angvel` no longer modify the velocity of static bodies.
- `RigidBody::set_body_type` will reset the velocity of a rigid-body to zero if it is static.
- Don’t automatically clear forces at the end of a timestep.
- Don’t reset the velocity of kinematic bodies to zero at the end of the timestep.
- Events `CollisionEvent::Stopped` are now generated after a collider is removed. 

### Added
- Significantly improve the API of joints by adding:
  * Builders based on the builder pattern.
  * Getters and setters for all joints.
  * Method to convert a `GenericJoint` to one of the more specific joint type.
- Improve stability of joint motors.
- Adds a `bool` argument to `RigidBodySet::remove`. If set to `false`, the colliders attached to the rigid-body
  won’t be automatically deleted (they will only be detached from the deleted rigid-body instead).
- Add `RigidBody::reset_forces` and `RigidBody::reset_torques` to reset all the forces and torques added to the
  rigid-body by the user.
- Add the `debug-render` cargo feature that enables the `DebugRenderPipeline`: a line-based backend-agnostic
  renderer to debug the state of the physics engine.