### PR TITLE
Rename STATIC -> FIXED and joints_with -> attached_joints

### DIFF
--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -256,7 +256,7 @@ impl IslandManager {
             // in contact or joined with this collider.
             push_contacting_bodies(&rb.colliders, colliders, narrow_phase, &mut self.stack);
 
-            for inter in impulse_joints.joints_with(handle) {
+            for inter in impulse_joints.attached_joints(handle) {
                 let other = crate::utils::select_other((inter.0, inter.1), handle);
                 self.stack.push(other);
             }

--- a/src/dynamics/joint/impulse_joint/impulse_joint_set.rs
+++ b/src/dynamics/joint/impulse_joint/impulse_joint_set.rs
@@ -69,15 +69,23 @@ impl ImpulseJointSet {
         &self.joint_graph
     }
 
-    /// Iterates through all the impulse_joints attached to the given rigid-body.
-    pub fn joints_with<'a>(
+    /// Iterates through all the impulse joints attached to the given rigid-body.
+    pub fn attached_joints<'a>(
         &'a self,
         body: RigidBodyHandle,
-    ) -> impl Iterator<Item = (RigidBodyHandle, RigidBodyHandle, &'a ImpulseJoint)> {
+    ) -> impl Iterator<
+        Item = (
+            RigidBodyHandle,
+            RigidBodyHandle,
+            ImpulseJointHandle,
+            &'a ImpulseJoint,
+        ),
+    > {
         self.rb_graph_ids
             .get(body.0)
             .into_iter()
             .flat_map(move |id| self.joint_graph.interactions_with(*id))
+            .map(|inter| (inter.0, inter.1, inter.2.handle, inter.2))
     }
 
     /// Is the given joint handle valid?

--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -286,19 +286,19 @@ bitflags::bitflags! {
         const DYNAMIC_KINEMATIC = 0b0000_0000_0000_1100;
         /// Enable collision-detection between a collider attached to a dynamic body
         /// and another collider attached to a fixed body (or not attached to any body).
-        const DYNAMIC_STATIC  = 0b0000_0000_0000_0010;
+        const DYNAMIC_FIXED  = 0b0000_0000_0000_0010;
         /// Enable collision-detection between a collider attached to a kinematic body
         /// and another collider attached to a kinematic body.
         const KINEMATIC_KINEMATIC = 0b1100_1100_0000_0000;
 
         /// Enable collision-detection between a collider attached to a kinematic body
         /// and another collider attached to a fixed body (or not attached to any body).
-        const KINEMATIC_STATIC = 0b0010_0010_0000_0000;
+        const KINEMATIC_FIXED = 0b0010_0010_0000_0000;
 
         /// Enable collision-detection between a collider attached to a fixed body (or
         /// not attached to any body) and another collider attached to a fixed body (or
         /// not attached to any body).
-        const STATIC_STATIC = 0b0000_0000_0010_0000;
+        const FIXED_FIXED = 0b0000_0000_0010_0000;
     }
 }
 
@@ -308,20 +308,20 @@ impl ActiveCollisionTypes {
         // NOTE: This test is quite complicated so here is an explanation.
         //       First, we associate the following bit masks:
         //           - DYNAMIC = 0001
-        //           - STATIC = 0010
+        //           - FIXED = 0010
         //           - KINEMATIC = 1100
         //       These are equal to the bits indexed by `RigidBodyType as u32`.
         //       The bit masks defined by ActiveCollisionTypes are defined is such a way
         //       that the first part of the variant name (e.g. DYNAMIC_*) indicates which
         //       groups of four bits should be considered:
         //           - DYNAMIC_* = the first group of four bits.
-        //           - STATIC_* = the second group of four bits.
+        //           - FIXED_* = the second group of four bits.
         //           - KINEMATIC_* = the third and fourth groups of four bits.
         //       The second part of the variant name (e.g. *_DYNAMIC) indicates the value
         //       of the aforementioned groups of four bits.
-        //       For example, DYNAMIC_STATIC means that the first group of four bits (because
-        //       of DYNAMIC_*) must have the value 0010 (because of *_STATIC). That gives
-        //       us 0b0000_0000_0000_0010 for the DYNAMIC_STATIC_VARIANT.
+        //       For example, DYNAMIC_FIXED means that the first group of four bits (because
+        //       of DYNAMIC_*) must have the value 0010 (because of *_FIXED). That gives
+        //       us 0b0000_0000_0000_0010 for the DYNAMIC_FIXED_VARIANT.
         //
         //       The KINEMATIC_* is special because it occupies two groups of four bits. This is
         //       because it combines both KinematicPositionBased and KinematicVelocityBased.
@@ -347,7 +347,7 @@ impl Default for ActiveCollisionTypes {
     fn default() -> Self {
         ActiveCollisionTypes::DYNAMIC_DYNAMIC
             | ActiveCollisionTypes::DYNAMIC_KINEMATIC
-            | ActiveCollisionTypes::DYNAMIC_STATIC
+            | ActiveCollisionTypes::DYNAMIC_FIXED
     }
 }
 


### PR DESCRIPTION
- Rename STATIC to FIXED in the `ActiveCollisionTypes` flags.
- Rename `ImpulseJointSet::joints_with` to `::attached_joints`. Add the joint’s handle to the closure arguments.
- Add `MultibodyJointSet::attached_joints` to return all the multibody joints attached to a rigid-body.