### PR TITLE
Some CCD and debug-render improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+### Modified
+- Add a `wake_up: bool` argument to the `ImpulseJointSet::insert` and `MultibodyJointSet::insert` to
+  automatically wake-up the rigid-bodies attached to the inserted joint.
+- The methods `ImpulseJointSet::remove/remove_joints_attached_to_rigid_body`,
+  `MultibodyJointSet::remove/remove_joints_attached_to_rigid_body` and
+  `MultibodyjointSet::remove_multibody_articulations` no longer require the `bodies`
+  and `islands` arguments.
 
 ## v0.12.0 (30 Apr. 2022)
 ### Fixed

--- a/benchmarks2d/joint_ball2.rs
+++ b/benchmarks2d/joint_ball2.rs
@@ -42,7 +42,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = RevoluteJointBuilder::new().local_anchor2(point![0.0, shift]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             // Horizontal joint.
@@ -50,7 +50,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - numi;
                 let parent_handle = body_handles[parent_index];
                 let joint = RevoluteJointBuilder::new().local_anchor2(point![-shift, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);

--- a/benchmarks2d/joint_fixed2.rs
+++ b/benchmarks2d/joint_fixed2.rs
@@ -48,7 +48,7 @@ pub fn init_world(testbed: &mut Testbed) {
                         let parent_handle = *body_handles.last().unwrap();
                         let joint = FixedJointBuilder::new()
                             .local_frame2(Isometry::translation(0.0, shift));
-                        impulse_joints.insert(parent_handle, child_handle, joint);
+                        impulse_joints.insert(parent_handle, child_handle, joint, true);
                     }
 
                     // Horizontal joint.
@@ -57,7 +57,7 @@ pub fn init_world(testbed: &mut Testbed) {
                         let parent_handle = body_handles[parent_index];
                         let joint = FixedJointBuilder::new()
                             .local_frame2(Isometry::translation(-shift, 0.0));
-                        impulse_joints.insert(parent_handle, child_handle, joint);
+                        impulse_joints.insert(parent_handle, child_handle, joint, true);
                     }
 
                     body_handles.push(child_handle);

--- a/benchmarks2d/joint_prismatic2.rs
+++ b/benchmarks2d/joint_prismatic2.rs
@@ -46,7 +46,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let prism = PrismaticJointBuilder::new(axis)
                     .local_anchor2(point![0.0, shift])
                     .limits([-1.5, 1.5]);
-                impulse_joints.insert(curr_parent, curr_child, prism);
+                impulse_joints.insert(curr_parent, curr_child, prism, true);
 
                 curr_parent = curr_child;
             }

--- a/benchmarks3d/joint_ball3.rs
+++ b/benchmarks3d/joint_ball3.rs
@@ -37,7 +37,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = SphericalJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             // Horizontal joint.
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - num;
                 let parent_handle = body_handles[parent_index];
                 let joint = SphericalJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);

--- a/benchmarks3d/joint_fixed3.rs
+++ b/benchmarks3d/joint_fixed3.rs
@@ -54,7 +54,7 @@ pub fn init_world(testbed: &mut Testbed) {
                             let parent_handle = *body_handles.last().unwrap();
                             let joint =
                                 FixedJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
-                            impulse_joints.insert(parent_handle, child_handle, joint);
+                            impulse_joints.insert(parent_handle, child_handle, joint, true);
                         }
 
                         // Horizontal joint.
@@ -63,7 +63,7 @@ pub fn init_world(testbed: &mut Testbed) {
                             let parent_handle = body_handles[parent_index];
                             let joint =
                                 FixedJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
-                            impulse_joints.insert(parent_handle, child_handle, joint);
+                            impulse_joints.insert(parent_handle, child_handle, joint, true);
                         }
 
                         body_handles.push(child_handle);

--- a/benchmarks3d/joint_prismatic3.rs
+++ b/benchmarks3d/joint_prismatic3.rs
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
                     let prism = PrismaticJointBuilder::new(axis)
                         .local_anchor2(point![0.0, 0.0, -shift])
                         .limits([-2.0, 0.0]);
-                    impulse_joints.insert(curr_parent, curr_child, prism);
+                    impulse_joints.insert(curr_parent, curr_child, prism, true);
 
                     curr_parent = curr_child;
                 }

--- a/benchmarks3d/joint_revolute3.rs
+++ b/benchmarks3d/joint_revolute3.rs
@@ -55,10 +55,10 @@ pub fn init_world(testbed: &mut Testbed) {
                     RevoluteJointBuilder::new(x).local_anchor2(point![shift, 0.0, 0.0]),
                 ];
 
-                impulse_joints.insert(curr_parent, handles[0], revs[0]);
-                impulse_joints.insert(handles[0], handles[1], revs[1]);
-                impulse_joints.insert(handles[1], handles[2], revs[2]);
-                impulse_joints.insert(handles[2], handles[3], revs[3]);
+                impulse_joints.insert(curr_parent, handles[0], revs[0], true);
+                impulse_joints.insert(handles[0], handles[1], revs[1], true);
+                impulse_joints.insert(handles[1], handles[2], revs[2], true);
+                impulse_joints.insert(handles[2], handles[3], revs[3], true);
 
                 curr_parent = handles[3];
             }

--- a/examples2d/joints2.rs
+++ b/examples2d/joints2.rs
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
             if i > 0 {
                 let parent_handle = *body_handles.last().unwrap();
                 let joint = RevoluteJointBuilder::new().local_anchor2(point![0.0, shift]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             // Horizontal joint.
@@ -53,7 +53,7 @@ pub fn init_world(testbed: &mut Testbed) {
                 let parent_index = body_handles.len() - numi;
                 let parent_handle = body_handles[parent_index];
                 let joint = RevoluteJointBuilder::new().local_anchor2(point![-shift, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);

--- a/examples3d/debug_articulations3.rs
+++ b/examples3d/debug_articulations3.rs
@@ -39,7 +39,7 @@ fn create_ball_articulations(
                 let parent_handle = *body_handles.last().unwrap();
                 let joint =
                     SphericalJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift * 2.0]);
-                multibody_joints.insert(parent_handle, child_handle, joint);
+                multibody_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             // Horizontal multibody_joint.
@@ -52,7 +52,7 @@ fn create_ball_articulations(
                 // let joint = FixedJoint::new().local_anchor2(point![-shift, 0.0, 0.0]);
                 // let joint =
                 //     RevoluteJoint::new(Vector::x_axis()).local_anchor2(point![-shift, 0.0, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);

--- a/examples3d/debug_excentric_boxes3.rs
+++ b/examples3d/debug_excentric_boxes3.rs
@@ -1,0 +1,44 @@
+use rapier3d::prelude::*;
+use rapier_testbed3d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
+
+    /*
+     * Ground
+     */
+    let ground_size = 100.1;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0]);
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
+    colliders.insert_with_parent(collider, handle, &mut bodies);
+
+    // Build the dynamic box rigid body.
+    let (mut vtx, idx) = Cuboid::new(vector![1.0, 1.0, 1.0]).to_trimesh();
+    vtx.iter_mut()
+        .for_each(|pt| *pt += vector![100.0, 100.0, 100.0]);
+    let shape = SharedShape::convex_mesh(vtx, &idx).unwrap();
+
+    for _ in 0..2 {
+        let rigid_body = RigidBodyBuilder::dynamic()
+            .translation(vector![-100.0, -100.0 + 10.0, -100.0])
+            .can_sleep(false);
+        let handle = bodies.insert(rigid_body);
+        let collider = ColliderBuilder::new(shape.clone());
+        colliders.insert_with_parent(collider, handle, &mut bodies);
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
+    testbed.look_at(point![10.0, 10.0, 10.0], Point::origin());
+}

--- a/examples3d/debug_prismatic3.rs
+++ b/examples3d/debug_prismatic3.rs
@@ -36,7 +36,7 @@ fn prismatic_repro(
         let prismatic = PrismaticJointBuilder::new(Vector::y_axis())
             .local_anchor1(point![pos.x, pos.y, pos.z])
             .motor_position(0.0, stiffness, damping);
-        impulse_joints.insert(box_rb, wheel_rb, prismatic);
+        impulse_joints.insert(box_rb, wheel_rb, prismatic, true);
     }
 
     // put a small box under one of the wheels

--- a/examples3d/joints3.rs
+++ b/examples3d/joints3.rs
@@ -24,9 +24,9 @@ fn create_coupled_joints(
         .coupled_axes(JointAxesMask::Y | JointAxesMask::Z);
 
     if use_articulations {
-        multibody_joints.insert(ground, body1, joint1);
+        multibody_joints.insert(ground, body1, joint1, true);
     } else {
-        impulse_joints.insert(ground, body1, joint1);
+        impulse_joints.insert(ground, body1, joint1, true);
     }
 }
 
@@ -66,9 +66,9 @@ fn create_prismatic_joints(
             .limits([-2.0, 2.0]);
 
         if use_articulations {
-            multibody_joints.insert(curr_parent, curr_child, prism);
+            multibody_joints.insert(curr_parent, curr_child, prism, true);
         } else {
-            impulse_joints.insert(curr_parent, curr_child, prism);
+            impulse_joints.insert(curr_parent, curr_child, prism, true);
         }
         curr_parent = curr_child;
     }
@@ -130,9 +130,9 @@ fn create_actuated_prismatic_joints(
         }
 
         if use_articulations {
-            multibody_joints.insert(curr_parent, curr_child, prism);
+            multibody_joints.insert(curr_parent, curr_child, prism, true);
         } else {
-            impulse_joints.insert(curr_parent, curr_child, prism);
+            impulse_joints.insert(curr_parent, curr_child, prism, true);
         }
 
         curr_parent = curr_child;
@@ -185,15 +185,15 @@ fn create_revolute_joints(
         ];
 
         if use_articulations {
-            multibody_joints.insert(curr_parent, handles[0], revs[0]);
-            multibody_joints.insert(handles[0], handles[1], revs[1]);
-            multibody_joints.insert(handles[1], handles[2], revs[2]);
-            multibody_joints.insert(handles[2], handles[3], revs[3]);
+            multibody_joints.insert(curr_parent, handles[0], revs[0], true);
+            multibody_joints.insert(handles[0], handles[1], revs[1], true);
+            multibody_joints.insert(handles[1], handles[2], revs[2], true);
+            multibody_joints.insert(handles[2], handles[3], revs[3], true);
         } else {
-            impulse_joints.insert(curr_parent, handles[0], revs[0]);
-            impulse_joints.insert(handles[0], handles[1], revs[1]);
-            impulse_joints.insert(handles[1], handles[2], revs[2]);
-            impulse_joints.insert(handles[2], handles[3], revs[3]);
+            impulse_joints.insert(curr_parent, handles[0], revs[0], true);
+            impulse_joints.insert(handles[0], handles[1], revs[1], true);
+            impulse_joints.insert(handles[1], handles[2], revs[2], true);
+            impulse_joints.insert(handles[2], handles[3], revs[3], true);
         }
 
         curr_parent = handles[3];
@@ -228,9 +228,9 @@ fn create_revolute_joints_with_limits(
     //     .coupled_axes(JointAxesMask::ANG_Y | JointAxesMask::ANG_Z);
 
     if use_articulations {
-        multibody_joints.insert(ground, platform1, joint1);
+        multibody_joints.insert(ground, platform1, joint1, true);
     } else {
-        impulse_joints.insert(ground, platform1, joint1);
+        impulse_joints.insert(ground, platform1, joint1, true);
     }
 
     let joint2 = RevoluteJointBuilder::new(z)
@@ -247,9 +247,9 @@ fn create_revolute_joints_with_limits(
     //     .coupled_axes(JointAxesMask::ANG_Y | JointAxesMask::ANG_Z);
 
     if use_articulations {
-        multibody_joints.insert(platform1, platform2, joint2);
+        multibody_joints.insert(platform1, platform2, joint2, true);
     } else {
-        impulse_joints.insert(platform1, platform2, joint2);
+        impulse_joints.insert(platform1, platform2, joint2, true);
     }
 
     // Let’s add a couple of cuboids that will fall on the platforms, triggering the joint limits.
@@ -315,9 +315,9 @@ fn create_fixed_joints(
                 let joint = FixedJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
 
                 if use_articulations {
-                    multibody_joints.insert(parent_handle, child_handle, joint);
+                    multibody_joints.insert(parent_handle, child_handle, joint, true);
                 } else {
-                    impulse_joints.insert(parent_handle, child_handle, joint);
+                    impulse_joints.insert(parent_handle, child_handle, joint, true);
                 }
             }
 
@@ -326,7 +326,7 @@ fn create_fixed_joints(
                 let parent_index = body_handles.len() - 1;
                 let parent_handle = body_handles[parent_index];
                 let joint = FixedJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);
@@ -374,9 +374,9 @@ fn create_spherical_joints(
                     SphericalJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift * 2.0]);
 
                 if use_articulations {
-                    multibody_joints.insert(parent_handle, child_handle, joint);
+                    multibody_joints.insert(parent_handle, child_handle, joint, true);
                 } else {
-                    impulse_joints.insert(parent_handle, child_handle, joint);
+                    impulse_joints.insert(parent_handle, child_handle, joint, true);
                 }
             }
 
@@ -385,7 +385,7 @@ fn create_spherical_joints(
                 let parent_index = body_handles.len() - num;
                 let parent_handle = body_handles[parent_index];
                 let joint = SphericalJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
 
             body_handles.push(child_handle);
@@ -426,11 +426,11 @@ fn create_spherical_joints_with_limits(
         .limits(JointAxis::Y, [-0.3, 0.3]);
 
     if use_articulations {
-        multibody_joints.insert(ground, ball1, joint1);
-        multibody_joints.insert(ball1, ball2, joint2);
+        multibody_joints.insert(ground, ball1, joint1, true);
+        multibody_joints.insert(ball1, ball2, joint2, true);
     } else {
-        impulse_joints.insert(ground, ball1, joint1);
-        impulse_joints.insert(ball1, ball2, joint2);
+        impulse_joints.insert(ground, ball1, joint1, true);
+        impulse_joints.insert(ball1, ball2, joint2, true);
     }
 }
 
@@ -493,9 +493,9 @@ fn create_actuated_revolute_joints(
             }
 
             if use_articulations {
-                multibody_joints.insert(parent_handle, child_handle, joint);
+                multibody_joints.insert(parent_handle, child_handle, joint, true);
             } else {
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
         }
 
@@ -559,9 +559,9 @@ fn create_actuated_spherical_joints(
             }
 
             if use_articulations {
-                multibody_joints.insert(parent_handle, child_handle, joint);
+                multibody_joints.insert(parent_handle, child_handle, joint, true);
             } else {
-                impulse_joints.insert(parent_handle, child_handle, joint);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
             }
         }
 

--- a/src/dynamics/ccd/toi_entry.rs
+++ b/src/dynamics/ccd/toi_entry.rs
@@ -56,14 +56,14 @@ impl TOIEntry {
             return None;
         }
 
-        let linvel1 =
-            frozen1.is_none() as u32 as Real * rb1.map(|b| b.vels.linvel).unwrap_or(na::zero());
-        let linvel2 =
-            frozen2.is_none() as u32 as Real * rb2.map(|b| b.vels.linvel).unwrap_or(na::zero());
-        let angvel1 =
-            frozen1.is_none() as u32 as Real * rb1.map(|b| b.vels.angvel).unwrap_or(na::zero());
-        let angvel2 =
-            frozen2.is_none() as u32 as Real * rb2.map(|b| b.vels.angvel).unwrap_or(na::zero());
+        let linvel1 = frozen1.is_none() as u32 as Real
+            * rb1.map(|b| b.integrated_vels.linvel).unwrap_or(na::zero());
+        let linvel2 = frozen2.is_none() as u32 as Real
+            * rb2.map(|b| b.integrated_vels.linvel).unwrap_or(na::zero());
+        let angvel1 = frozen1.is_none() as u32 as Real
+            * rb1.map(|b| b.integrated_vels.angvel).unwrap_or(na::zero());
+        let angvel2 = frozen2.is_none() as u32 as Real
+            * rb2.map(|b| b.integrated_vels.angvel).unwrap_or(na::zero());
 
         #[cfg(feature = "dim2")]
         let vel12 = (linvel2 - linvel1).norm()
@@ -114,6 +114,20 @@ impl TOIEntry {
         // because the colliders may be in a separating trajectory.
         let stop_at_penetration = is_pseudo_intersection_test;
 
+        // let pos12 = motion_c1
+        //     .position_at_time(start_time)
+        //     .inv_mul(&motion_c2.position_at_time(start_time));
+        // let vel12 = linvel2 - linvel1;
+        // let res_toi = query_dispatcher
+        //     .time_of_impact(
+        //         &pos12,
+        //         &vel12,
+        //         co1.shape.as_ref(),
+        //         co2.shape.as_ref(),
+        //         end_time - start_time,
+        //     )
+        //     .ok();
+
         let res_toi = query_dispatcher
             .nonlinear_time_of_impact(
                 &motion_c1,
@@ -144,8 +158,8 @@ impl TOIEntry {
             NonlinearRigidMotion::new(
                 rb.pos.position,
                 rb.mprops.local_mprops.local_com,
-                rb.vels.linvel,
-                rb.vels.angvel,
+                rb.integrated_vels.linvel,
+                rb.integrated_vels.angvel,
             )
         } else {
             NonlinearRigidMotion::constant_position(rb.pos.next_position)

--- a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
@@ -1,11 +1,8 @@
 use crate::data::{Arena, Coarena, Index};
 use crate::dynamics::joint::MultibodyLink;
-use crate::dynamics::{
-    GenericJoint, IslandManager, Multibody, MultibodyJoint, RigidBodyHandle, RigidBodySet,
-};
+use crate::dynamics::{GenericJoint, Multibody, MultibodyJoint, RigidBodyHandle};
 use crate::geometry::{InteractionGraph, RigidBodyGraphIndex};
 use crate::parry::partitioning::IndexedData;
-use crate::prelude::RigidBody;
 
 /// The unique handle of an multibody_joint added to a `MultibodyJointSet`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -19,6 +19,10 @@ use num::Zero;
 pub struct RigidBody {
     pub(crate) pos: RigidBodyPosition,
     pub(crate) mprops: RigidBodyMassProps,
+    // NOTE: we need this so that the CCD can use the actual velocities obtained
+    //       by the velocity solver with bias. If we switch to intepolation, we
+    //       should remove this field.
+    pub(crate) integrated_vels: RigidBodyVelocity,
     pub(crate) vels: RigidBodyVelocity,
     pub(crate) damping: RigidBodyDamping,
     pub(crate) forces: RigidBodyForces,
@@ -47,6 +51,7 @@ impl RigidBody {
         Self {
             pos: RigidBodyPosition::default(),
             mprops: RigidBodyMassProps::default(),
+            integrated_vels: RigidBodyVelocity::default(),
             vels: RigidBodyVelocity::default(),
             damping: RigidBodyDamping::default(),
             forces: RigidBodyForces::default(),

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -752,7 +752,7 @@ pub struct RigidBodyCcd {
 impl Default for RigidBodyCcd {
     fn default() -> Self {
         Self {
-            ccd_thickness: 0.0,
+            ccd_thickness: Real::MAX,
             ccd_max_dist: 0.0,
             ccd_active: false,
             ccd_enabled: false,

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -109,8 +109,8 @@ impl RigidBodySet {
         /*
          * Remove impulse_joints attached to this rigid-body.
          */
-        impulse_joints.remove_joints_attached_to_rigid_body(handle, islands, self);
-        multibody_joints.remove_joints_attached_to_rigid_body(handle, islands, self);
+        impulse_joints.remove_joints_attached_to_rigid_body(handle);
+        multibody_joints.remove_joints_attached_to_rigid_body(handle);
 
         Some(rb)
     }

--- a/src/dynamics/solver/parallel_velocity_solver.rs
+++ b/src/dynamics/solver/parallel_velocity_solver.rs
@@ -45,7 +45,6 @@ impl ParallelVelocitySolver {
         let joint_descs = &joint_constraints.constraint_descs[..];
         let mut target_num_desc = 0;
         let mut shift = 0;
-        let cfm_factor = params.cfm_factor();
 
         // Each thread will concurrently grab thread.batch_size constraint desc to
         // solve. If the batch size is large enough to cross the boundary of
@@ -122,7 +121,6 @@ impl ParallelVelocitySolver {
                 // Solve rigid-body contacts.
                 solve!(
                     contact_constraints,
-                    cfm_factor,
                     &contact_constraints.generic_jacobians,
                     &mut self.mj_lambdas,
                     &mut self.generic_mj_lambdas,
@@ -135,7 +133,6 @@ impl ParallelVelocitySolver {
                 // Solve generic rigid-body contacts.
                 solve!(
                     contact_constraints,
-                    cfm_factor,
                     &contact_constraints.generic_jacobians,
                     &mut self.mj_lambdas,
                     &mut self.generic_mj_lambdas,
@@ -148,7 +145,6 @@ impl ParallelVelocitySolver {
                 if solve_friction {
                     solve!(
                         contact_constraints,
-                        cfm_factor,
                         &contact_constraints.generic_jacobians,
                         &mut self.mj_lambdas,
                         &mut self.generic_mj_lambdas,
@@ -173,7 +169,6 @@ impl ParallelVelocitySolver {
             for _ in 0..remaining_friction_iterations {
                 solve!(
                     contact_constraints,
-                    cfm_factor,
                     &contact_constraints.generic_jacobians,
                     &mut self.mj_lambdas,
                     &mut self.generic_mj_lambdas,
@@ -265,7 +260,6 @@ impl ParallelVelocitySolver {
 
                 solve!(
                     contact_constraints,
-                    cfm_factor,
                     &contact_constraints.generic_jacobians,
                     &mut self.mj_lambdas,
                     &mut self.generic_mj_lambdas,
@@ -277,7 +271,6 @@ impl ParallelVelocitySolver {
 
                 solve!(
                     contact_constraints,
-                    cfm_factor,
                     &contact_constraints.generic_jacobians,
                     &mut self.mj_lambdas,
                     &mut self.generic_mj_lambdas,

--- a/src/dynamics/solver/velocity_constraint_element.rs
+++ b/src/dynamics/solver/velocity_constraint_element.rs
@@ -112,7 +112,6 @@ pub(crate) struct VelocityConstraintNormalPart<N: WReal> {
     pub rhs_wo_bias: N,
     pub impulse: N,
     pub r: N,
-    pub cfm: N,
 }
 
 impl<N: WReal> VelocityConstraintNormalPart<N> {
@@ -124,7 +123,6 @@ impl<N: WReal> VelocityConstraintNormalPart<N> {
             rhs_wo_bias: na::zero(),
             impulse: na::zero(),
             r: na::zero(),
-            cfm: na::one(),
         }
     }
 
@@ -144,7 +142,7 @@ impl<N: WReal> VelocityConstraintNormalPart<N> {
             - dir1.dot(&mj_lambda2.linear)
             + self.gcross2.gdot(mj_lambda2.angular)
             + self.rhs;
-        let new_impulse = self.cfm * (self.impulse - self.r * dvel).simd_max(N::zero());
+        let new_impulse = cfm_factor * (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 

--- a/src/dynamics/solver/velocity_constraint_element.rs
+++ b/src/dynamics/solver/velocity_constraint_element.rs
@@ -112,6 +112,7 @@ pub(crate) struct VelocityConstraintNormalPart<N: WReal> {
     pub rhs_wo_bias: N,
     pub impulse: N,
     pub r: N,
+    pub cfm: N,
 }
 
 impl<N: WReal> VelocityConstraintNormalPart<N> {
@@ -123,6 +124,7 @@ impl<N: WReal> VelocityConstraintNormalPart<N> {
             rhs_wo_bias: na::zero(),
             impulse: na::zero(),
             r: na::zero(),
+            cfm: na::one(),
         }
     }
 
@@ -142,7 +144,7 @@ impl<N: WReal> VelocityConstraintNormalPart<N> {
             - dir1.dot(&mj_lambda2.linear)
             + self.gcross2.gdot(mj_lambda2.angular)
             + self.rhs;
-        let new_impulse = cfm_factor * (self.impulse - self.r * dvel).simd_max(N::zero());
+        let new_impulse = self.cfm * (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 

--- a/src/dynamics/solver/velocity_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_constraint_wide.rs
@@ -12,6 +12,7 @@ use crate::math::{
 use crate::utils::WBasis;
 use crate::utils::{self, WAngularInertia, WCross, WDot};
 use num::Zero;
+use parry::math::SimdBool;
 use simba::simd::{SimdPartialOrd, SimdValue};
 
 #[derive(Copy, Clone, Debug)]
@@ -23,6 +24,7 @@ pub(crate) struct WVelocityConstraint {
     pub num_contacts: u8,
     pub im1: Vector<SimdReal>,
     pub im2: Vector<SimdReal>,
+    pub cfm_factor: SimdReal,
     pub limit: SimdReal,
     pub mj_lambda1: [usize; SIMD_WIDTH],
     pub mj_lambda2: [usize; SIMD_WIDTH],
@@ -97,6 +99,7 @@ impl WVelocityConstraint {
                 gather![|ii| &manifolds[ii].data.solver_contacts[l..num_active_contacts]];
             let num_points = manifold_points[0].len().min(MAX_MANIFOLD_POINTS);
 
+            let mut is_fast_contact = SimdBool::splat(false);
             let mut constraint = WVelocityConstraint {
                 dir1: force_dir1,
                 #[cfg(feature = "dim3")]
@@ -104,6 +107,7 @@ impl WVelocityConstraint {
                 elements: [VelocityConstraintElement::zero(); MAX_MANIFOLD_POINTS],
                 im1,
                 im2,
+                cfm_factor,
                 limit: SimdReal::splat(0.0),
                 mj_lambda1,
                 mj_lambda2,
@@ -154,8 +158,8 @@ impl WVelocityConstraint {
                         * (erp_inv_dt/* * is_resting */);
 
                     let rhs = rhs_wo_bias + rhs_bias;
-                    let is_fast_contact = (-rhs * dt).simd_gt(ccd_thickness * SimdReal::splat(0.5));
-                    let cfm = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+                    is_fast_contact =
+                        is_fast_contact | (-rhs * dt).simd_gt(ccd_thickness * SimdReal::splat(0.5));
 
                     constraint.elements[k].normal_part = VelocityConstraintNormalPart {
                         gcross1,
@@ -164,7 +168,6 @@ impl WVelocityConstraint {
                         rhs_wo_bias,
                         impulse: SimdReal::splat(0.0),
                         r: projected_mass,
-                        cfm,
                     };
                 }
 
@@ -200,6 +203,8 @@ impl WVelocityConstraint {
                 }
             }
 
+            constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+
             if let Some(at) = insert_at {
                 out_constraints[at + l / MAX_MANIFOLD_POINTS] =
                     AnyVelocityConstraint::Grouped(constraint);
@@ -211,7 +216,6 @@ impl WVelocityConstraint {
 
     pub fn solve(
         &mut self,
-        cfm_factor: Real,
         mj_lambdas: &mut [DeltaVel<Real>],
         solve_normal: bool,
         solve_friction: bool,
@@ -231,7 +235,7 @@ impl WVelocityConstraint {
         };
 
         VelocityConstraintElement::solve_group(
-            SimdReal::splat(cfm_factor),
+            self.cfm_factor,
             &mut self.elements[..self.num_contacts as usize],
             &self.dir1,
             #[cfg(feature = "dim3")]
@@ -281,7 +285,8 @@ impl WVelocityConstraint {
         }
     }
 
-    pub fn remove_bias_from_rhs(&mut self) {
+    pub fn remove_cfm_and_bias_from_rhs(&mut self) {
+        self.cfm_factor = SimdReal::splat(1.0);
         for elt in &mut self.elements {
             elt.normal_part.rhs = elt.normal_part.rhs_wo_bias;
         }

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -128,6 +128,7 @@ impl VelocityGroundConstraint {
                     constraint.tangent1 = tangents1[0];
                 }
                 constraint.im2 = mprops2.effective_inv_mass;
+                constraint.cfm_factor = cfm_factor;
                 constraint.limit = 0.0;
                 constraint.mj_lambda2 = mj_lambda2;
                 constraint.manifold_id = manifold_id;
@@ -171,7 +172,7 @@ impl VelocityGroundConstraint {
 
                     let rhs = rhs_wo_bias + rhs_bias;
                     is_fast_contact =
-                        is_fast_contact || -rhs * params.dt > rb2.ccd.ccd_thickness * 0.5;
+                        is_fast_contact || (-rhs * params.dt > rb2.ccd.ccd_thickness * 0.5);
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintNormalPart {
                         gcross2,
@@ -215,9 +216,7 @@ impl VelocityGroundConstraint {
                 }
             }
 
-            if is_fast_contact {
-                constraint.cfm_factor = 1.0;
-            }
+            constraint.cfm_factor = if is_fast_contact { 1.0 } else { cfm_factor };
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(at) = insert_at {

--- a/src/dynamics/solver/velocity_ground_constraint.rs
+++ b/src/dynamics/solver/velocity_ground_constraint.rs
@@ -34,6 +34,7 @@ impl VelocityGroundConstraint {
         out_constraints: &mut Vec<AnyVelocityConstraint>,
         insert_at: Option<usize>,
     ) {
+        let cfm_factor = params.cfm_factor();
         let inv_dt = params.inv_dt();
         let erp_inv_dt = params.erp_inv_dt();
 
@@ -156,20 +157,25 @@ impl VelocityGroundConstraint {
                     let is_bouncy = manifold_point.is_bouncy() as u32 as Real;
                     let is_resting = 1.0 - is_bouncy;
 
-                    let mut rhs_wo_bias = (1.0 + is_bouncy * manifold_point.restitution)
-                        * (vel1 - vel2).dot(&force_dir1);
+                    let dvel = (vel1 - vel2).dot(&force_dir1);
+                    let mut rhs_wo_bias = (1.0 + is_bouncy * manifold_point.restitution) * dvel;
                     rhs_wo_bias += manifold_point.dist.max(0.0) * inv_dt;
                     rhs_wo_bias *= is_bouncy + is_resting;
                     let rhs_bias = /* is_resting
                         * */ erp_inv_dt
                         * (manifold_point.dist + params.allowed_linear_error).clamp(-params.max_penetration_correction, 0.0);
 
+                    let rhs = rhs_wo_bias + rhs_bias;
+                    let is_fast_contact = -rhs * params.dt > rb2.ccd.ccd_thickness * 0.5;
+                    let cfm = if is_fast_contact { 1.0 } else { cfm_factor };
+
                     constraint.elements[k].normal_part = VelocityGroundConstraintNormalPart {
                         gcross2,
-                        rhs: rhs_wo_bias + rhs_bias,
+                        rhs,
                         rhs_wo_bias,
                         impulse: na::zero(),
                         r: projected_mass,
+                        cfm,
                     };
                 }
 

--- a/src/dynamics/solver/velocity_ground_constraint_element.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_element.rs
@@ -93,6 +93,7 @@ pub(crate) struct VelocityGroundConstraintNormalPart<N: WReal> {
     pub rhs_wo_bias: N,
     pub impulse: N,
     pub r: N,
+    pub cfm: N,
 }
 
 impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
@@ -103,6 +104,7 @@ impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
             rhs_wo_bias: na::zero(),
             impulse: na::zero(),
             r: na::zero(),
+            cfm: na::one(),
         }
     }
 
@@ -117,7 +119,7 @@ impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
         AngVector<N>: WDot<AngVector<N>, Result = N>,
     {
         let dvel = -dir1.dot(&mj_lambda2.linear) + self.gcross2.gdot(mj_lambda2.angular) + self.rhs;
-        let new_impulse = cfm_factor * (self.impulse - self.r * dvel).simd_max(N::zero());
+        let new_impulse = self.cfm * (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 

--- a/src/dynamics/solver/velocity_ground_constraint_element.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_element.rs
@@ -93,7 +93,6 @@ pub(crate) struct VelocityGroundConstraintNormalPart<N: WReal> {
     pub rhs_wo_bias: N,
     pub impulse: N,
     pub r: N,
-    pub cfm: N,
 }
 
 impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
@@ -104,7 +103,6 @@ impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
             rhs_wo_bias: na::zero(),
             impulse: na::zero(),
             r: na::zero(),
-            cfm: na::one(),
         }
     }
 
@@ -119,7 +117,7 @@ impl<N: WReal> VelocityGroundConstraintNormalPart<N> {
         AngVector<N>: WDot<AngVector<N>, Result = N>,
     {
         let dvel = -dir1.dot(&mj_lambda2.linear) + self.gcross2.gdot(mj_lambda2.angular) + self.rhs;
-        let new_impulse = self.cfm * (self.impulse - self.r * dvel).simd_max(N::zero());
+        let new_impulse = cfm_factor * (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 

--- a/src/dynamics/solver/velocity_ground_constraint_wide.rs
+++ b/src/dynamics/solver/velocity_ground_constraint_wide.rs
@@ -9,11 +9,11 @@ use crate::geometry::{ContactManifold, ContactManifoldIndex};
 use crate::math::{
     AngVector, AngularInertia, Point, Real, SimdReal, Vector, DIM, MAX_MANIFOLD_POINTS, SIMD_WIDTH,
 };
-use crate::prelude::RigidBody;
 #[cfg(feature = "dim2")]
 use crate::utils::WBasis;
 use crate::utils::{self, WAngularInertia, WCross, WDot};
 use num::Zero;
+use parry::math::SimdBool;
 use simba::simd::{SimdPartialOrd, SimdValue};
 
 #[derive(Copy, Clone, Debug)]
@@ -24,6 +24,7 @@ pub(crate) struct WVelocityGroundConstraint {
     pub elements: [VelocityGroundConstraintElement<SimdReal>; MAX_MANIFOLD_POINTS],
     pub num_contacts: u8,
     pub im2: Vector<SimdReal>,
+    pub cfm_factor: SimdReal,
     pub limit: SimdReal,
     pub mj_lambda2: [usize; SIMD_WIDTH],
     pub manifold_id: [ContactManifoldIndex; SIMD_WIDTH],
@@ -105,12 +106,14 @@ impl WVelocityGroundConstraint {
             let manifold_points = gather![|ii| &manifolds[ii].data.solver_contacts[l..]];
             let num_points = manifold_points[0].len().min(MAX_MANIFOLD_POINTS);
 
+            let mut is_fast_contact = SimdBool::splat(false);
             let mut constraint = WVelocityGroundConstraint {
                 dir1: force_dir1,
                 #[cfg(feature = "dim3")]
                 tangent1: tangents1[0],
                 elements: [VelocityGroundConstraintElement::zero(); MAX_MANIFOLD_POINTS],
                 im2,
+                cfm_factor,
                 limit: SimdReal::splat(0.0),
                 mj_lambda2,
                 manifold_id,
@@ -157,8 +160,8 @@ impl WVelocityGroundConstraint {
                         * (erp_inv_dt/* * is_resting */);
 
                     let rhs = rhs_wo_bias + rhs_bias;
-                    let is_fast_contact = (-rhs * dt).simd_gt(ccd_thickness * SimdReal::splat(0.5));
-                    let cfm = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+                    is_fast_contact =
+                        is_fast_contact | (-rhs * dt).simd_gt(ccd_thickness * SimdReal::splat(0.5));
 
                     constraint.elements[k].normal_part = VelocityGroundConstraintNormalPart {
                         gcross2,
@@ -166,7 +169,6 @@ impl WVelocityGroundConstraint {
                         rhs_wo_bias,
                         impulse: na::zero(),
                         r: projected_mass,
-                        cfm,
                     };
                 }
 
@@ -196,6 +198,8 @@ impl WVelocityGroundConstraint {
                 }
             }
 
+            constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+
             if let Some(at) = insert_at {
                 out_constraints[at + l / MAX_MANIFOLD_POINTS] =
                     AnyVelocityConstraint::GroupedGround(constraint);
@@ -207,7 +211,6 @@ impl WVelocityGroundConstraint {
 
     pub fn solve(
         &mut self,
-        cfm_factor: Real,
         mj_lambdas: &mut [DeltaVel<Real>],
         solve_normal: bool,
         solve_friction: bool,
@@ -220,7 +223,7 @@ impl WVelocityGroundConstraint {
         };
 
         VelocityGroundConstraintElement::solve_group(
-            SimdReal::splat(cfm_factor),
+            self.cfm_factor,
             &mut self.elements[..self.num_contacts as usize],
             &self.dir1,
             #[cfg(feature = "dim3")]
@@ -265,7 +268,8 @@ impl WVelocityGroundConstraint {
         }
     }
 
-    pub fn remove_bias_from_rhs(&mut self) {
+    pub fn remove_cfm_and_bias_from_rhs(&mut self) {
+        self.cfm_factor = SimdReal::splat(1.0);
         for elt in &mut self.elements {
             elt.normal_part.rhs = elt.normal_part.rhs_wo_bias;
         }

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -168,6 +168,7 @@ impl VelocitySolver {
                     &rb.pos.position,
                     &rb.mprops.local_mprops.local_com,
                 );
+                rb.integrated_vels = new_vels;
                 rb.pos = new_pos;
             }
         }

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -35,7 +35,6 @@ impl VelocitySolver {
         joint_constraints: &mut [AnyJointVelocityConstraint],
         generic_joint_jacobians: &DVector<Real>,
     ) {
-        let cfm_factor = params.cfm_factor();
         self.mj_lambdas.clear();
         self.mj_lambdas
             .resize(islands.active_island(island_id).len(), DeltaVel::zero());
@@ -86,7 +85,6 @@ impl VelocitySolver {
 
             for constraint in &mut *contact_constraints {
                 constraint.solve(
-                    cfm_factor,
                     generic_contact_jacobians,
                     &mut self.mj_lambdas[..],
                     &mut self.generic_mj_lambdas,
@@ -98,7 +96,6 @@ impl VelocitySolver {
             if solve_friction {
                 for constraint in &mut *contact_constraints {
                     constraint.solve(
-                        cfm_factor,
                         generic_contact_jacobians,
                         &mut self.mj_lambdas[..],
                         &mut self.generic_mj_lambdas,
@@ -121,7 +118,6 @@ impl VelocitySolver {
         for _ in 0..remaining_friction_iterations {
             for constraint in &mut *contact_constraints {
                 constraint.solve(
-                    cfm_factor,
                     generic_contact_jacobians,
                     &mut self.mj_lambdas[..],
                     &mut self.generic_mj_lambdas,
@@ -191,7 +187,6 @@ impl VelocitySolver {
 
             for constraint in &mut *contact_constraints {
                 constraint.solve(
-                    1.0,
                     generic_contact_jacobians,
                     &mut self.mj_lambdas[..],
                     &mut self.generic_mj_lambdas,
@@ -202,7 +197,6 @@ impl VelocitySolver {
 
             for constraint in &mut *contact_constraints {
                 constraint.solve(
-                    1.0,
                     generic_contact_jacobians,
                     &mut self.mj_lambdas[..],
                     &mut self.generic_mj_lambdas,

--- a/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
@@ -2,12 +2,10 @@ use super::{outlines, DebugRenderBackend};
 use crate::dynamics::{
     GenericJoint, ImpulseJointSet, MultibodyJointSet, RigidBodySet, RigidBodyType,
 };
-use crate::geometry::{
-    Ball, ColliderSet, Cuboid, NarrowPhase, OctantPattern, Shape, TypedShape, VoxelType, AABB,
-};
+use crate::geometry::{Ball, ColliderSet, Cuboid, NarrowPhase, Shape, TypedShape};
 #[cfg(feature = "dim3")]
 use crate::geometry::{Cone, Cylinder};
-use crate::math::{Isometry, Point, Real, Translation, Vector, DIM};
+use crate::math::{Isometry, Point, Real, Vector, DIM};
 use crate::pipeline::debug_render_pipeline::debug_render_backend::DebugRenderObject;
 use crate::pipeline::debug_render_pipeline::DebugRenderStyle;
 use crate::utils::WBasis;
@@ -87,6 +85,7 @@ impl DebugRenderPipeline {
         self.render_contacts(backend, colliders, narrow_phase);
     }
 
+    /// Render contact.
     pub fn render_contacts(
         &mut self,
         backend: &mut impl DebugRenderBackend,

--- a/src/pipeline/debug_render_pipeline/debug_render_style.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_style.rs
@@ -38,6 +38,14 @@ pub struct DebugRenderStyle {
     pub sleep_color_multiplier: [f32; 4],
     /// The length of the local coordinate axes rendered for a rigid-body.
     pub rigid_body_axes_length: Real,
+    /// The collor for the segments joining the two contact points.
+    pub contact_depth_color: DebugColor,
+    /// The color of the contact normals.
+    pub contact_normal_color: DebugColor,
+    /// The length of the contact normals.
+    pub contact_normal_length: Real,
+    /// The color of the colliders AABBs.
+    pub collider_aabb_color: DebugColor,
 }
 
 impl Default for DebugRenderStyle {
@@ -55,6 +63,10 @@ impl Default for DebugRenderStyle {
             multibody_joint_separation_color: [0.0, 1.0, 0.4, 1.0],
             sleep_color_multiplier: [1.0, 1.0, 0.2, 1.0],
             rigid_body_axes_length: 0.5,
+            contact_depth_color: [120.0, 1.0, 0.4, 1.0],
+            contact_normal_color: [0.0, 1.0, 1.0, 1.0],
+            contact_normal_length: 0.3,
+            collider_aabb_color: [124.0, 1.0, 0.4, 1.0],
         }
     }
 }

--- a/src_testbed/debug_render.rs
+++ b/src_testbed/debug_render.rs
@@ -25,7 +25,7 @@ impl Plugin for RapierDebugRenderPlugin {
         ))
         .insert_resource(DebugRenderPipeline::new(
             Default::default(),
-            !DebugRenderMode::RIGID_BODY_AXES,
+            !DebugRenderMode::RIGID_BODY_AXES & !DebugRenderMode::COLLIDER_AABBS,
         ))
         .add_system_to_stage(CoreStage::Update, debug_render_scene);
     }
@@ -68,5 +68,6 @@ fn debug_render_scene(
         &harness.physics.colliders,
         &harness.physics.impulse_joints,
         &harness.physics.multibody_joints,
+        &harness.physics.narrow_phase,
     );
 }

--- a/src_testbed/lines/debuglines.wgsl
+++ b/src_testbed/lines/debuglines.wgsl
@@ -25,9 +25,13 @@ struct FragmentOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = view.view_proj * vec4<f32>(vertex.pos, 1.0);
-    //out.color = vertex.color;
     // https://github.com/bevyengine/bevy/blob/328c26d02c50de0bc77f0d24a376f43ba89517b1/examples/2d/mesh2d_manual.rs#L234
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(8u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
+    // ... except the above doesn't seem to work in 3d.  Not sure what's going on there.
+    var r = f32(vertex.color & 255u) / 255.0;
+    var g = f32(vertex.color >> 8u & 255u) / 255.0;
+    var b = f32(vertex.color >> 16u & 255u) / 255.0;
+    var a = f32(vertex.color >> 24u & 255u) / 255.0;
+    out.color = vec4<f32>(r, g, b, a);
 
     return out;
 }

--- a/src_testbed/lines/debuglines2d.wgsl
+++ b/src_testbed/lines/debuglines2d.wgsl
@@ -17,10 +17,11 @@ struct VertexOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = view.view_proj * vec4<f32>(vertex.place, 1.0);
-    // What is this craziness?
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
-    //out.color = vertex.color;
-    //out.color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    var r = f32(vertex.color & 255u) / 255.0;
+    var g = f32(vertex.color >> 8u & 255u) / 255.0;
+    var b = f32(vertex.color >> 16u & 255u) / 255.0;
+    var a = f32(vertex.color >> 24u & 255u) / 255.0;
+    out.color = vec4<f32>(r, g, b, a);
 
     return out;
 }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -691,12 +691,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                         .collect();
                     let num_to_delete = (impulse_joints.len() / 10).max(1);
                     for to_delete in &impulse_joints[..num_to_delete] {
-                        self.harness.physics.impulse_joints.remove(
-                            *to_delete,
-                            &mut self.harness.physics.islands,
-                            &mut self.harness.physics.bodies,
-                            true,
-                        );
+                        self.harness.physics.impulse_joints.remove(*to_delete, true);
                     }
                 }
                 KeyCode::A => {
@@ -710,12 +705,10 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                         .collect();
                     let num_to_delete = (multibody_joints.len() / 10).max(1);
                     for to_delete in &multibody_joints[..num_to_delete] {
-                        self.harness.physics.multibody_joints.remove(
-                            *to_delete,
-                            &mut self.harness.physics.islands,
-                            &mut self.harness.physics.bodies,
-                            true,
-                        );
+                        self.harness
+                            .physics
+                            .multibody_joints
+                            .remove(*to_delete, true);
                     }
                 }
                 KeyCode::M => {
@@ -731,12 +724,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                         self.harness
                             .physics
                             .multibody_joints
-                            .remove_multibody_articulations(
-                                to_delete,
-                                &mut self.harness.physics.islands,
-                                &mut self.harness.physics.bodies,
-                                true,
-                            );
+                            .remove_multibody_articulations(to_delete, true);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
- Fix bug where the CCD thickness wasn’t initialized properly.
- Fix bug where the contact compliance would result in undesired tunneling, despite CCD being enabled.
- Debug-renderer: add rendering of contacts, solver contacts, and collider AABBs
- Add the option to automatically wake-up rigid-bodies a new joint is attached to