### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Unreleased
+## v0.13.0 (31 Jun. 2022)
+### Fixed
+- Fix incorrect sensor events being generated after collider removal.
+- Fix bug where the CCD thickness wasn’t initialized properly.
+- Fix bug where the contact compliance would result in undesired tunneling, despite CCD being enabled.
+
 ### Modified
 - Add a `wake_up: bool` argument to the `ImpulseJointSet::insert` and `MultibodyJointSet::insert` to
   automatically wake-up the rigid-bodies attached to the inserted joint.
@@ -6,6 +11,15 @@
   `MultibodyJointSet::remove/remove_joints_attached_to_rigid_body` and
   `MultibodyjointSet::remove_multibody_articulations` no longer require the `bodies`
   and `islands` arguments.
+- Make the `instant` dependency optional, behind a `profiler` cargo feature.
+- Rename STATIC to FIXED in the `ActiveCollisionTypes` flags.
+- Rename `ImpulseJointSet::joints_with` to `::attached_joints`. Add the joint’s handle to the closure arguments.
+- Make the default debug-render less noisy out-of-the-box by only rendering joints, rigid-bodies, and colliders
+  by default.
+
+### Added
+- Debug-renderer: add rendering of contacts, solver contacts, and collider AABBs
+- Add `MultibodyJointSet::attached_joints` to return all the multibody joints attached to a given rigid-body.
 
 ## v0.12.0 (30 Apr. 2022)
 ### Fixed

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.12.0"
+version = "0.13.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.12.0"
+version = "0.13.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -52,5 +52,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.12.0"
+version = "0.13.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.12.0"
+version = "0.13.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -56,5 +56,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.12.0"
+version = "0.13.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]


### PR DESCRIPTION
### Fixed
- Fix incorrect sensor events being generated after collider removal.
- Fix bug where the CCD thickness wasn’t initialized properly.
- Fix bug where the contact compliance would result in undesired tunneling, despite CCD being enabled.

### Modified
- Add a `wake_up: bool` argument to the `ImpulseJointSet::insert` and `MultibodyJointSet::insert` to
  automatically wake-up the rigid-bodies attached to the inserted joint.
- The methods `ImpulseJointSet::remove/remove_joints_attached_to_rigid_body`,
  `MultibodyJointSet::remove/remove_joints_attached_to_rigid_body` and
  `MultibodyjointSet::remove_multibody_articulations` no longer require the `bodies`
  and `islands` arguments.
- Make the `instant` dependency optional, behind a `profiler` cargo feature.
- Rename STATIC to FIXED in the `ActiveCollisionTypes` flags.
- Rename `ImpulseJointSet::joints_with` to `::attached_joints`. Add the joint’s handle to the closure arguments.
- Make the default debug-render less noisy out-of-the-box by only rendering joints, rigid-bodies, and colliders
  by default.

### Added
- Debug-renderer: add rendering of contacts, solver contacts, and collider AABBs
- Add `MultibodyJointSet::attached_joints` to return all the multibody joints attached to a given rigid-body.