### PR TITLE
Update ActiveEvents Rustdoc to Remove Reference to EventHandler::handle_intersection_event()

### DIFF
--- a/src/pipeline/event_handler.rs
+++ b/src/pipeline/event_handler.rs
@@ -6,8 +6,8 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     /// Flags affecting the events generated for this collider.
     pub struct ActiveEvents: u32 {
-        /// If set, Rapier will call `EventHandler::handle_intersection_event` and
-        /// `EventHandler::handle_contact_event` whenever relevant for this collider.
+        /// If set, Rapier will call `EventHandler::handle_contact_event`
+        /// whenever relevant for this collider.
         const COLLISION_EVENTS = 0b0001;
     }
 }


### PR DESCRIPTION
The current `ActiveEvents` docs mention a `handle_intersection_event()` function of the `EventHandler` trait that no longer exists. This change removes that reference from the `ActiveEvents` docs.