### PR TITLE
Add force reporting

### DIFF
--- a/examples2d/ccd2.rs
+++ b/examples2d/ccd2.rs
@@ -87,7 +87,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     // Callback that will be executed on the main loop to handle proximities.
     testbed.add_callback(move |mut graphics, physics, events, _| {
-        while let Ok(prox) = events.events.try_recv() {
+        while let Ok(prox) = events.collision_events.try_recv() {
             let color = if prox.started() {
                 [1.0, 1.0, 0.0]
             } else {

--- a/examples2d/sensor2.rs
+++ b/examples2d/sensor2.rs
@@ -68,7 +68,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     // Callback that will be executed on the main loop to handle proximities.
     testbed.add_callback(move |mut graphics, physics, events, _| {
-        while let Ok(prox) = events.events.try_recv() {
+        while let Ok(prox) = events.collision_events.try_recv() {
             let color = if prox.started() {
                 [1.0, 1.0, 0.0]
             } else {

--- a/examples3d/ccd3.rs
+++ b/examples3d/ccd3.rs
@@ -112,7 +112,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     // Callback that will be executed on the main loop to handle proximities.
     testbed.add_callback(move |mut graphics, physics, events, _| {
-        while let Ok(prox) = events.events.try_recv() {
+        while let Ok(prox) = events.collision_events.try_recv() {
             let color = if prox.started() {
                 [1.0, 1.0, 0.0]
             } else {

--- a/examples3d/sensor3.rs
+++ b/examples3d/sensor3.rs
@@ -72,7 +72,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     // Callback that will be executed on the main loop to handle proximities.
     testbed.add_callback(move |mut graphics, physics, events, _| {
-        while let Ok(prox) = events.events.try_recv() {
+        while let Ok(prox) = events.collision_events.try_recv() {
             let color = if prox.started() {
                 [1.0, 1.0, 0.0]
             } else {

--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -347,8 +347,11 @@ impl ContactManifoldData {
     }
 }
 
+/// Additional methods for the contact manifold.
 pub trait ContactManifoldExt {
+    /// Computes the sum of all the impulses applied by contacts from this contact manifold.
     fn total_impulse(&self) -> Real;
+    /// Computes the maximum impulse applied by contacts from this contact manifold.
     fn max_impulse(&self) -> Real;
 }
 

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -16,6 +16,8 @@ pub use self::collider_set::ColliderSet;
 
 pub use parry::query::TrackedContact;
 
+use crate::math::{Real, Vector};
+
 /// A contact between two colliders.
 pub type Contact = parry::query::TrackedContact<ContactData>;
 /// A contact manifold between two colliders.
@@ -114,6 +116,28 @@ impl CollisionEvent {
             }
         }
     }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+/// Event occurring when the sum of the magnitudes of the contact forces
+/// between two colliders exceed a threshold.
+pub struct CollisionForceEvent {
+    /// The first collider involved in the contact.
+    pub collider1: ColliderHandle,
+    /// The second collider involved in the contact.
+    pub collider2: ColliderHandle,
+    /// The sum of all the forces between the two colliders.
+    pub total_force: Vector<Real>,
+    /// The sum of the magnitudes of each force between the two colliders.
+    ///
+    /// Note that this is **not** the same as the magnitude of `self.total_force`.
+    /// Here we are summing the magnitude of all the forces, instead of taking
+    /// the magnitude of their sum.
+    pub total_force_magnitude: Real,
+    /// The world-space (unit) direction of the force with strongest magnitude.
+    pub max_force_direction: Vector<Real>,
+    /// The magnitude of the largest force at a contact point of this contact pair.
+    pub max_force_magnitude: Real,
 }
 
 pub(crate) use self::broad_phase_multi_sap::SAPProxyIndex;

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -371,6 +371,16 @@ impl PhysicsPipeline {
         hooks: &dyn PhysicsHooks,
         events: &dyn EventHandler,
     ) {
+        // Apply some of delayed wake-ups.
+        for handle in impulse_joints
+            .to_wake_up
+            .drain(..)
+            .chain(multibody_joints.to_wake_up.drain(..))
+        {
+            islands.wake_up(bodies, handle, true);
+        }
+
+        // Apply modifications.
         let modified_bodies = bodies.take_modified();
         let mut modified_colliders = colliders.take_modified();
         let mut removed_colliders = colliders.take_removed();

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -11,10 +11,10 @@ use crate::dynamics::{
 use crate::dynamics::{JointGraphEdge, ParallelIslandSolver as IslandSolver};
 use crate::geometry::{
     BroadPhase, BroadPhasePairEvent, ColliderChanges, ColliderHandle, ColliderPair,
-    ContactManifoldIndex, NarrowPhase,
+    ContactManifoldIndex, NarrowPhase, TemporaryInteractionIndex,
 };
 use crate::math::{Real, Vector};
-use crate::pipeline::{EventHandler, PhysicsHooks};
+use crate::pipeline::{ActiveEvents, EventHandler, PhysicsHooks};
 use {crate::dynamics::RigidBodySet, crate::geometry::ColliderSet};
 
 /// The physics pipeline, responsible for stepping the whole physics simulation.
@@ -31,6 +31,7 @@ use {crate::dynamics::RigidBodySet, crate::geometry::ColliderSet};
 pub struct PhysicsPipeline {
     /// Counters used for benchmarking only.
     pub counters: Counters,
+    contact_pair_indices: Vec<TemporaryInteractionIndex>,
     manifold_indices: Vec<Vec<ContactManifoldIndex>>,
     joint_constraint_indices: Vec<Vec<ContactManifoldIndex>>,
     broadphase_collider_pairs: Vec<ColliderPair>,
@@ -55,11 +56,12 @@ impl PhysicsPipeline {
     pub fn new() -> PhysicsPipeline {
         PhysicsPipeline {
             counters: Counters::new(true),
-            solvers: Vec::new(),
-            manifold_indices: Vec::new(),
-            joint_constraint_indices: Vec::new(),
-            broadphase_collider_pairs: Vec::new(),
-            broad_phase_events: Vec::new(),
+            solvers: vec![],
+            contact_pair_indices: vec![],
+            manifold_indices: vec![],
+            joint_constraint_indices: vec![],
+            broadphase_collider_pairs: vec![],
+            broad_phase_events: vec![],
         }
     }
 
@@ -148,6 +150,7 @@ impl PhysicsPipeline {
         colliders: &mut ColliderSet,
         impulse_joints: &mut ImpulseJointSet,
         multibody_joints: &mut MultibodyJointSet,
+        events: &dyn EventHandler,
     ) {
         self.counters.stages.island_construction_time.resume();
         islands.update_active_set_with_contacts(
@@ -175,6 +178,7 @@ impl PhysicsPipeline {
         narrow_phase.select_active_contacts(
             islands,
             bodies,
+            &mut self.contact_pair_indices,
             &mut manifolds,
             &mut self.manifold_indices,
         );
@@ -275,6 +279,34 @@ impl PhysicsPipeline {
                     });
             });
         }
+
+        // Generate contact force events if needed.
+        let inv_dt = crate::utils::inv(integration_parameters.dt);
+        for pair_id in self.contact_pair_indices.drain(..) {
+            let pair = narrow_phase.contact_pair_at_index(pair_id);
+            let co1 = &colliders[pair.collider1];
+            let co2 = &colliders[pair.collider2];
+            let threshold = co1
+                .contact_force_event_threshold
+                .min(co2.contact_force_event_threshold);
+
+            if threshold < Real::MAX {
+                let total_magnitude = pair.total_impulse_magnitude() * inv_dt;
+
+                // NOTE: the strict inequality is important here, so we don’t
+                //       trigger an event if the force is 0.0 and the threshold is 0.0.
+                if total_magnitude > threshold {
+                    events.handle_contact_force_event(
+                        integration_parameters.dt,
+                        bodies,
+                        colliders,
+                        pair,
+                        total_magnitude,
+                    );
+                }
+            }
+        }
+
         self.counters.stages.solver_time.pause();
     }
 
@@ -507,6 +539,7 @@ impl PhysicsPipeline {
                 colliders,
                 impulse_joints,
                 multibody_joints,
+                events,
             );
 
             // If CCD is enabled, execute the CCD motion clamping.

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -14,7 +14,7 @@ use crate::geometry::{
     ContactManifoldIndex, NarrowPhase, TemporaryInteractionIndex,
 };
 use crate::math::{Real, Vector};
-use crate::pipeline::{ActiveEvents, EventHandler, PhysicsHooks};
+use crate::pipeline::{EventHandler, PhysicsHooks};
 use {crate::dynamics::RigidBodySet, crate::geometry::ColliderSet};
 
 /// The physics pipeline, responsible for stepping the whole physics simulation.

--- a/src_testbed/harness/mod.rs
+++ b/src_testbed/harness/mod.rs
@@ -86,10 +86,13 @@ type Callbacks =
 #[allow(dead_code)]
 impl Harness {
     pub fn new_empty() -> Self {
-        let event_channel = crossbeam::channel::unbounded();
-        let event_handler = ChannelEventCollector::new(event_channel.0);
+        let collision_event_channel = crossbeam::channel::unbounded();
+        let contact_force_event_channel = crossbeam::channel::unbounded();
+        let event_handler =
+            ChannelEventCollector::new(collision_event_channel.0, contact_force_event_channel.0);
         let events = PhysicsEvents {
-            events: event_channel.1,
+            collision_events: collision_event_channel.1,
+            contact_force_events: contact_force_event_channel.1,
         };
         let physics = PhysicsState::new();
         let state = RunState::new();

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -3,7 +3,7 @@ use rapier::dynamics::{
     CCDSolver, ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointSet,
     RigidBodySet,
 };
-use rapier::geometry::{BroadPhase, ColliderSet, CollisionEvent, NarrowPhase};
+use rapier::geometry::{BroadPhase, ColliderSet, CollisionEvent, CollisionForceEvent, NarrowPhase};
 use rapier::math::{Real, Vector};
 use rapier::pipeline::{PhysicsHooks, PhysicsPipeline, QueryPipeline};
 
@@ -107,11 +107,13 @@ impl PhysicsState {
 }
 
 pub struct PhysicsEvents {
-    pub events: Receiver<CollisionEvent>,
+    pub collision_events: Receiver<CollisionEvent>,
+    pub contact_force_events: Receiver<CollisionForceEvent>,
 }
 
 impl PhysicsEvents {
     pub fn poll_all(&self) {
-        while let Ok(_) = self.events.try_recv() {}
+        while let Ok(_) = self.collision_events.try_recv() {}
+        while let Ok(_) = self.contact_force_events.try_recv() {}
     }
 }


### PR DESCRIPTION
This add force reporting to the `EventHandler` trait. Contact force events are generated whenever the sum of the magnitudes of all the forces between two colliders is greater than `Collider::contact_force_event_threshold`.

This also fix #352 