### PR TITLE
Fix the max_force_direction magnitude

### DIFF
--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -170,7 +170,6 @@ impl ContactForceEvent {
         //       because it’s an input of this function already
         //       assumed to be a force instead of an impulse.
         result.total_force *= inv_dt;
-        result.max_force_direction *= inv_dt;
         result.max_force_magnitude *= inv_dt;
         result
     }


### PR DESCRIPTION
Since the direction is unit-sized, it shouldn’t be divided by the timestep length.