### PR TITLE
Improve the API for initializing/setting mass-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Unreleased
+### Fixed
+
+### Modified
+- The `RigidBodyBuilder::additional_mass` method will now result in the additional angular inertia
+  being automatically computed based on the shapes of the colliders attached to the rigid-body.
+- Remove the deprecated methods `RigidBodyBuilder::mass`, `::principal_angular_inertia`, `::principal_inertia`.
+- Remove the methods `RigidBodyBuilder::additional_principal_angular_inertia`. Use
+  `RigidBodyBuilder::additional_mass_properties` instead.
+
+### Added
+- Add `RigidBody::recompute_mass_properties_from_colliders` to force the immediate computation
+  of a rigid-body’s mass properties (instead of waiting for them to be recomputed during the next
+  timestep). This is useful to be able to read immediately the result of a change of a rigid-body
+  additional mass-properties or a change of one of its collider’s mass-properties.
+- Add `RigidBody::set_additional_mass` to set the additional mass for the collider. The additional
+  angular inertia is automatically computed based on the attached colliders shapes.
+- Add `Collider::set_density`, `::set_mass`, `set_mass_properties`, to alter a collider’s mass
+  properties. Note that `::set_mass` will result in the collider’s angular inertia being automatically
+  computed based on this mass and on its shape.
+- Add `ColliderBuilder::mass` to set the mass of the collider instead of its density. Its angular
+  inertia tensor will be automatically computed based on this mass and its shape.
+
 ## v0.13.0 (31 May 2022)
 ### Fixed
 - Fix incorrect sensor events being generated after collider removal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove the deprecated methods `RigidBodyBuilder::mass`, `::principal_angular_inertia`, `::principal_inertia`.
 - Remove the methods `RigidBodyBuilder::additional_principal_angular_inertia`. Use
   `RigidBodyBuilder::additional_mass_properties` instead.
+- The `Collider::density` method now always returns a `Real` (instead of an `Option<Real>`).
 
 ### Added
 - Add `RigidBody::recompute_mass_properties_from_colliders` to force the immediate computation
@@ -20,6 +21,7 @@
   computed based on this mass and on its shape.
 - Add `ColliderBuilder::mass` to set the mass of the collider instead of its density. Its angular
   inertia tensor will be automatically computed based on this mass and its shape.
+- Add `Collider::mass` and `Collider::volume` to retrieve the mass or volume of a collider.
 
 ## v0.13.0 (31 May 2022)
 ### Fixed

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1,14 +1,14 @@
 use crate::dynamics::{
-    LockedAxes, MassProperties, RigidBodyActivation, RigidBodyCcd, RigidBodyChanges,
-    RigidBodyColliders, RigidBodyDamping, RigidBodyDominance, RigidBodyForces, RigidBodyIds,
-    RigidBodyMassProps, RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
+    LockedAxes, MassProperties, RigidBodyActivation, RigidBodyAdditionalMassProps, RigidBodyCcd,
+    RigidBodyChanges, RigidBodyColliders, RigidBodyDamping, RigidBodyDominance, RigidBodyForces,
+    RigidBodyIds, RigidBodyMassProps, RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
 };
 use crate::geometry::{
-    Collider, ColliderHandle, ColliderMassProps, ColliderParent, ColliderPosition, ColliderShape,
+    Collider, ColliderHandle, ColliderMassProps, ColliderParent, ColliderPosition, ColliderSet,
+    ColliderShape,
 };
 use crate::math::{AngVector, Isometry, Point, Real, Rotation, Vector};
-use crate::utils::{self, WCross};
-use na::ComplexField;
+use crate::utils::WCross;
 use num::Zero;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -123,7 +123,7 @@ impl RigidBody {
         }
     }
 
-    /// The mass properties of this rigid-body.
+    /// The mass-properties of this rigid-body.
     #[inline]
     pub fn mass_properties(&self) -> &MassProperties {
         &self.mprops.local_mprops
@@ -310,26 +310,82 @@ impl RigidBody {
         self.ccd.ccd_active
     }
 
-    /// Sets the rigid-body's additional mass properties.
+    /// Recompute the mass-properties of this rigid-bodies based on its currently attached colliders.
+    pub fn recompute_mass_properties_from_colliders(&mut self, colliders: &ColliderSet) {
+        self.mprops.recompute_mass_properties_from_colliders(
+            colliders,
+            &self.colliders,
+            &self.pos.position,
+        );
+    }
+
+    /// Sets the rigid-body's additional mass.
+    ///
+    /// The total angular inertia of the rigid-body will be scaled automatically based on this
+    /// additional mass. If this scaling effect isn’t desired, use [`Self::additional_mass_properties`]
+    /// instead of this method.
+    ///
+    /// This is only the "additional" mass because the total mass of the  rigid-body is
+    /// equal to the sum of this additional mass and the mass computed from the colliders
+    /// (with non-zero densities) attached to this rigid-body.
+    ///
+    /// That total mass (which includes the attached colliders’ contributions)
+    /// will be updated at the name physics step, or can be updated manually with
+    /// [`Self::recompute_mass_properties_from_colliders`].
+    ///
+    /// This will override any previous mass-properties set by [`Self::set_additional_mass`],
+    /// [`Self::set_additional_mass_properties`], [`RigidBodyBuilder::additional_mass`], or
+    /// [`RigidBodyBuilder::additional_mass_properties`] for this rigid-body.
+    ///
+    /// If `wake_up` is `true` then the rigid-body will be woken up if it was
+    /// put to sleep because it did not move for a while.
+    #[inline]
+    pub fn set_additional_mass(&mut self, additional_mass: Real, wake_up: bool) {
+        self.do_set_additional_mass_properties(
+            RigidBodyAdditionalMassProps::Mass(additional_mass),
+            wake_up,
+        )
+    }
+
+    /// Sets the rigid-body's additional mass-properties.
+    ///
+    /// This is only the "additional" mass-properties because the total mass-properties of the
+    /// rigid-body is equal to the sum of this additional mass-properties and the mass computed from
+    /// the colliders (with non-zero densities) attached to this rigid-body.
+    ///
+    /// That total mass-properties (which include the attached colliders’ contributions)
+    /// will be updated at the name physics step, or can be updated manually with
+    /// [`Self::recompute_mass_properties_from_colliders`].
+    ///
+    /// This will override any previous mass-properties set by [`Self::set_additional_mass`],
+    /// [`Self::set_additional_mass_properties`], [`RigidBodyBuilder::additional_mass`], or
+    /// [`RigidBodyBuilder::additional_mass_properties`] for this rigid-body.
     ///
     /// If `wake_up` is `true` then the rigid-body will be woken up if it was
     /// put to sleep because it did not move for a while.
     #[inline]
     pub fn set_additional_mass_properties(&mut self, props: MassProperties, wake_up: bool) {
-        if let Some(add_mprops) = &mut self.mprops.additional_local_mprops {
-            self.mprops.local_mprops += props;
-            self.mprops.local_mprops -= **add_mprops;
-            **add_mprops = props;
-        } else {
-            self.mprops.additional_local_mprops = Some(Box::new(props));
-            self.mprops.local_mprops += props;
-        }
+        self.do_set_additional_mass_properties(
+            RigidBodyAdditionalMassProps::MassProps(props),
+            wake_up,
+        )
+    }
 
-        if self.is_dynamic() && wake_up {
-            self.wake_up(true);
-        }
+    fn do_set_additional_mass_properties(
+        &mut self,
+        props: RigidBodyAdditionalMassProps,
+        wake_up: bool,
+    ) {
+        let new_mprops = Some(Box::new(props));
 
-        self.update_world_mass_properties();
+        if self.mprops.additional_local_mprops != new_mprops {
+            self.changes.insert(RigidBodyChanges::LOCAL_MASS_PROPERTIES);
+            self.mprops.additional_local_mprops = new_mprops;
+
+            if self.is_dynamic() && wake_up {
+                self.wake_up(true);
+            }
+        }
     }
 
     /// The handles of colliders attached to this rigid body.
@@ -432,12 +488,6 @@ impl RigidBody {
         if let Some(i) = self.colliders.0.iter().position(|e| *e == handle) {
             self.changes.set(RigidBodyChanges::COLLIDERS, true);
             self.colliders.0.swap_remove(i);
-
-            let mass_properties = coll
-                .mass_properties()
-                .transform_by(coll.position_wrt_parent().unwrap());
-            self.mprops.local_mprops -= mass_properties;
-            self.update_world_mass_properties();
         }
     }
 
@@ -859,8 +909,8 @@ pub struct RigidBodyBuilder {
     pub angular_damping: Real,
     body_type: RigidBodyType,
     mprops_flags: LockedAxes,
-    /// The additional mass properties of the rigid-body being built. See [`RigidBodyBuilder::additional_mass_properties`] for more information.
-    pub additional_mass_properties: MassProperties,
+    /// The additional mass-properties of the rigid-body being built. See [`RigidBodyBuilder::additional_mass_properties`] for more information.
+    additional_mass_properties: RigidBodyAdditionalMassProps,
     /// Whether or not the rigid-body to be created can sleep if it reaches a dynamic equilibrium.
     pub can_sleep: bool,
     /// Whether or not the rigid-body is to be created asleep.
@@ -887,7 +937,7 @@ impl RigidBodyBuilder {
             angular_damping: 0.0,
             body_type,
             mprops_flags: LockedAxes::empty(),
-            additional_mass_properties: MassProperties::zero(),
+            additional_mass_properties: RigidBodyAdditionalMassProps::default(),
             can_sleep: true,
             sleeping: false,
             ccd_enabled: false,
@@ -968,18 +1018,41 @@ impl RigidBodyBuilder {
         self
     }
 
-    /// Sets the additional mass properties of the rigid-body being built.
+    /// Sets the additional mass-properties of the rigid-body being built.
     ///
-    /// Note that "additional" means that the final mass properties of the rigid-bodies depends
+    /// This will be overridden by a call to [`Self::additional_mass`] so it only makes sense to call
+    /// either [`Self::additional_mass`] or [`Self::additional_mass_properties`].    
+    ///
+    /// Note that "additional" means that the final mass-properties of the rigid-bodies depends
     /// on the initial mass-properties of the rigid-body (set by this method)
     /// to which is added the contributions of all the colliders with non-zero density
     /// attached to this rigid-body.
     ///
-    /// Therefore, if you want your provided mass properties to be the final
-    /// mass properties of your rigid-body, don't attach colliders to it, or
+    /// Therefore, if you want your provided mass-properties to be the final
+    /// mass-properties of your rigid-body, don't attach colliders to it, or
     /// only attach colliders with densities equal to zero.
-    pub fn additional_mass_properties(mut self, props: MassProperties) -> Self {
-        self.additional_mass_properties = props;
+    pub fn additional_mass_properties(mut self, mprops: MassProperties) -> Self {
+        self.additional_mass_properties = RigidBodyAdditionalMassProps::MassProps(mprops);
+        self
+    }
+
+    /// Sets the additional mass of the rigid-body being built.
+    ///
+    /// This will be overridden by a call to [`Self::additional_mass_properties`] so it only makes
+    /// sense to call either [`Self::additional_mass`] or [`Self::additional_mass_properties`].    
+    ///
+    /// This is only the "additional" mass because the total mass of the  rigid-body is
+    /// equal to the sum of this additional mass and the mass computed from the colliders
+    /// (with non-zero densities) attached to this rigid-body.
+    ///
+    /// The total angular inertia of the rigid-body will be scaled automatically based on this
+    /// additional mass. If this scaling effect isn’t desired, use [`Self::additional_mass_properties`]
+    /// instead of this method.
+    ///
+    /// # Parameters
+    /// * `mass`- The mass that will be added to the created rigid-body.
+    pub fn additional_mass(mut self, mass: Real) -> Self {
+        self.additional_mass_properties = RigidBodyAdditionalMassProps::Mass(mass);
         self
     }
 
@@ -1035,78 +1108,6 @@ impl RigidBodyBuilder {
         self.mprops_flags
             .set(LockedAxes::ROTATION_LOCKED_Z, !allow_rotations_z);
         self
-    }
-
-    /// Sets the additional mass of the rigid-body being built.
-    ///
-    /// This is only the "additional" mass because the total mass of the  rigid-body is
-    /// equal to the sum of this additional mass and the mass computed from the colliders
-    /// (with non-zero densities) attached to this rigid-body.
-    pub fn additional_mass(mut self, mass: Real) -> Self {
-        self.additional_mass_properties.set_mass(mass, false);
-        self
-    }
-
-    /// Sets the additional mass of the rigid-body being built.
-    ///
-    /// This is only the "additional" mass because the total mass of the  rigid-body is
-    /// equal to the sum of this additional mass and the mass computed from the colliders
-    /// (with non-zero densities) attached to this rigid-body.
-    #[deprecated(note = "renamed to `additional_mass`.")]
-    pub fn mass(self, mass: Real) -> Self {
-        self.additional_mass(mass)
-    }
-
-    /// Sets the additional angular inertia of this rigid-body.
-    ///
-    /// This is only the "additional" angular inertia because the total angular inertia of
-    /// the rigid-body is equal to the sum of this additional value and the angular inertia
-    /// computed from the colliders (with non-zero densities) attached to this rigid-body.
-    #[cfg(feature = "dim2")]
-    pub fn additional_principal_angular_inertia(mut self, inertia: Real) -> Self {
-        self.additional_mass_properties.inv_principal_inertia_sqrt =
-            utils::inv(ComplexField::sqrt(inertia.max(0.0)));
-        self
-    }
-
-    /// Sets the angular inertia of this rigid-body.
-    #[cfg(feature = "dim2")]
-    #[deprecated(note = "renamed to `additional_principal_angular_inertia`.")]
-    pub fn principal_angular_inertia(self, inertia: Real) -> Self {
-        self.additional_principal_angular_inertia(inertia)
-    }
-
-    /// Use `self.principal_angular_inertia` instead.
-    #[cfg(feature = "dim2")]
-    #[deprecated(note = "renamed to `additional_principal_angular_inertia`.")]
-    pub fn principal_inertia(self, inertia: Real) -> Self {
-        self.additional_principal_angular_inertia(inertia)
-    }
-
-    /// Sets the additional principal angular inertia of this rigid-body.
-    ///
-    /// This is only the "additional" angular inertia because the total angular inertia of
-    /// the rigid-body is equal to the sum of this additional value and the angular inertia
-    /// computed from the colliders (with non-zero densities) attached to this rigid-body.
-    #[cfg(feature = "dim3")]
-    pub fn additional_principal_angular_inertia(mut self, inertia: AngVector<Real>) -> Self {
-        self.additional_mass_properties.inv_principal_inertia_sqrt =
-            inertia.map(|e| utils::inv(ComplexField::sqrt(e.max(0.0))));
-        self
-    }
-
-    /// Sets the principal angular inertia of this rigid-body.
-    #[cfg(feature = "dim3")]
-    #[deprecated(note = "renamed to `additional_principal_angular_inertia`.")]
-    pub fn principal_angular_inertia(self, inertia: AngVector<Real>) -> Self {
-        self.additional_principal_angular_inertia(inertia)
-    }
-
-    /// Use `self.principal_angular_inertia` instead.
-    #[cfg(feature = "dim3")]
-    #[deprecated(note = "renamed to `additional_principal_angular_inertia`.")]
-    pub fn principal_inertia(self, inertia: AngVector<Real>) -> Self {
-        self.additional_principal_angular_inertia(inertia)
     }
 
     /// Sets the damping factor for the linear part of the rigid-body motion.
@@ -1169,9 +1170,11 @@ impl RigidBodyBuilder {
         rb.body_type = self.body_type;
         rb.user_data = self.user_data;
 
-        if self.additional_mass_properties != MassProperties::default() {
+        if self.additional_mass_properties
+            != RigidBodyAdditionalMassProps::MassProps(MassProperties::zero())
+            && self.additional_mass_properties != RigidBodyAdditionalMassProps::Mass(0.0)
+        {
             rb.mprops.additional_local_mprops = Some(Box::new(self.additional_mass_properties));
-            rb.mprops.local_mprops = self.additional_mass_properties;
         }
 
         rb.mprops.flags = self.mprops_flags;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -4,8 +4,7 @@ use crate::dynamics::{
     RigidBodyIds, RigidBodyMassProps, RigidBodyPosition, RigidBodyType, RigidBodyVelocity,
 };
 use crate::geometry::{
-    Collider, ColliderHandle, ColliderMassProps, ColliderParent, ColliderPosition, ColliderSet,
-    ColliderShape,
+    ColliderHandle, ColliderMassProps, ColliderParent, ColliderPosition, ColliderSet, ColliderShape,
 };
 use crate::math::{AngVector, Isometry, Point, Real, Rotation, Vector};
 use crate::utils::WCross;
@@ -484,7 +483,7 @@ impl RigidBody {
     }
 
     /// Removes a collider from this rigid-body.
-    pub(crate) fn remove_collider_internal(&mut self, handle: ColliderHandle, coll: &Collider) {
+    pub(crate) fn remove_collider_internal(&mut self, handle: ColliderHandle) {
         if let Some(i) = self.colliders.0.iter().position(|e| *e == handle) {
             self.changes.set(RigidBodyChanges::COLLIDERS, true);
             self.colliders.0.swap_remove(i);

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -237,12 +237,32 @@ impl Collider {
         &self.material
     }
 
-    /// The density of this collider, if set.
-    pub fn density(&self) -> Option<Real> {
+    /// The volume (or surface in 2D) of this collider.
+    pub fn volume(&self) -> Real {
+        self.shape.mass_properties(1.0).mass()
+    }
+
+    /// The density of this collider.
+    pub fn density(&self) -> Real {
         match &self.mprops {
-            ColliderMassProps::Density(density) => Some(*density),
-            ColliderMassProps::Mass(_) => None,
-            ColliderMassProps::MassProperties(_) => None,
+            ColliderMassProps::Density(density) => *density,
+            ColliderMassProps::Mass(mass) => {
+                let inv_volume = self.shape.mass_properties(1.0).inv_mass;
+                mass * inv_volume
+            }
+            ColliderMassProps::MassProperties(mprops) => {
+                let inv_volume = self.shape.mass_properties(1.0).inv_mass;
+                mprops.mass() * inv_volume
+            }
+        }
+    }
+
+    /// The mass of this collider.
+    pub fn mass(&self) -> Real {
+        match &self.mprops {
+            ColliderMassProps::Density(density) => self.shape.mass_properties(*density).mass(),
+            ColliderMassProps::Mass(mass) => *mass,
+            ColliderMassProps::MassProperties(mprops) => mprops.mass(),
         }
     }
 

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -137,7 +137,7 @@ impl ColliderSet {
 
             if let Some(parent_handle) = curr_parent {
                 if let Some(rb) = bodies.get_mut(parent_handle) {
-                    rb.remove_collider_internal(handle, &*collider);
+                    rb.remove_collider_internal(handle);
                 }
             }
 
@@ -189,7 +189,7 @@ impl ColliderSet {
             if let Some(parent_rb) =
                 bodies.get_mut_internal_with_modification_tracking(parent.handle)
             {
-                parent_rb.remove_collider_internal(handle, &collider);
+                parent_rb.remove_collider_internal(handle);
 
                 if wake_up {
                     islands.wake_up(bodies, parent.handle, true);

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -407,6 +407,9 @@ impl PhysicsPipeline {
         hooks: &dyn PhysicsHooks,
         events: &dyn EventHandler,
     ) {
+        self.counters.reset();
+        self.counters.step_started();
+
         // Apply some of delayed wake-ups.
         for handle in impulse_joints
             .to_wake_up
@@ -417,18 +420,15 @@ impl PhysicsPipeline {
         }
 
         // Apply modifications.
-        let modified_bodies = bodies.take_modified();
         let mut modified_colliders = colliders.take_modified();
         let mut removed_colliders = colliders.take_removed();
-
-        self.counters.reset();
-        self.counters.step_started();
-
         super::user_changes::handle_user_changes_to_colliders(
             bodies,
             colliders,
             &modified_colliders[..],
         );
+
+        let modified_bodies = bodies.take_modified();
         super::user_changes::handle_user_changes_to_rigid_bodies(
             Some(islands),
             bodies,

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -338,7 +338,7 @@ impl PhysxWorld {
                 let densities: Vec<_> = rb
                     .colliders()
                     .iter()
-                    .map(|h| colliders[*h].density().unwrap_or(0.0))
+                    .map(|h| colliders[*h].density())
                     .collect();
 
                 unsafe {


### PR DESCRIPTION
The goal of this PR is to cover a few recurrent requests regarding mass-properties of rigid-bodies and colliders:
- It is now possible to modify a collider’s density/mass-properties after its creation.
- It is now possible to specify the collider’s mass explicitly (instead of its density). In this case, the angular inertia tensor will be computed automatically (fix #203)
- When specifying a rigid-body’s additional mass, its additional angular inertia tensor will also be computed automatically based on its attached colliders. This resolves common issues users are having when setting only the additional mass not knowing that it would create an imbalance between linear and angular resistances to motion.