### PR TITLE
Rename restrict_translation/rotation to set_allowed_translation/rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Remove the methods `RigidBodyBuilder::additional_principal_angular_inertia`. Use
   `RigidBodyBuilder::additional_mass_properties` instead.
 - The `Collider::density` method now always returns a `Real` (instead of an `Option<Real>`).
+- Rename `RigidBody::restrict_rotations` and `RigidBody::restrict_translations` to
+  `RigidBody::set_allowed_rotations` and `RigidBody::set_allowed_translations`.
+- Rename `RigidBodyBuilder::restrict_rotations` and `RigidBodyBuilder::restrict_translations` to
+  `RigidBodyBuilder::allowed_rotations` and `RigidBodyBuilder::allowed_translations`.
 
 ### Added
 - Add `RigidBody::recompute_mass_properties_from_colliders` to force the immediate computation

--- a/examples3d/locked_rotations3.rs
+++ b/examples3d/locked_rotations3.rs
@@ -30,7 +30,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let rigid_body = RigidBodyBuilder::dynamic()
         .translation(vector![0.0, 3.0, 0.0])
         .lock_translations()
-        .restrict_rotations(true, false, false);
+        .allowed_rotations(true, false, false);
     let handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::cuboid(0.2, 0.6, 2.0);
     colliders.insert_with_parent(collider, handle, &mut bodies);

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -204,7 +204,12 @@ impl RigidBody {
         allow_rotations_z: bool,
         wake_up: bool,
     ) {
-        self.set_allowed_rotations(allow_rotations_x, allow_rotations_y, allow_rotations_z, wake_up);
+        self.set_allowed_rotations(
+            allow_rotations_x,
+            allow_rotations_y,
+            allow_rotations_z,
+            wake_up,
+        );
     }
 
     #[inline]
@@ -277,7 +282,8 @@ impl RigidBody {
         self.set_allowed_translations(
             allow_translation_x,
             allow_translation_y,
-            #[cfg(feature = "dim3")] allow_translation_z,
+            #[cfg(feature = "dim3")]
+            allow_translation_z,
             wake_up,
         )
     }
@@ -1125,7 +1131,8 @@ impl RigidBodyBuilder {
         self.allowed_translations(
             allow_translations_x,
             allow_translations_y,
-            #[cfg(feature = "dim3")] allow_translations_z,
+            #[cfg(feature = "dim3")]
+            allow_translations_z,
         )
     }
 
@@ -1164,7 +1171,6 @@ impl RigidBodyBuilder {
     ) -> Self {
         self.allowed_rotations(allow_rotations_x, allow_rotations_y, allow_rotations_z)
     }
-
 
     /// Sets the damping factor for the linear part of the rigid-body motion.
     ///

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -167,7 +167,7 @@ impl RigidBody {
 
     #[inline]
     /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
-    pub fn restrict_rotations(
+    pub fn set_allowed_rotations(
         &mut self,
         allow_rotations_x: bool,
         allow_rotations_y: bool,
@@ -195,6 +195,18 @@ impl RigidBody {
         }
     }
 
+    /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
+    #[deprecated(note = "Use `set_allowed_rotations` instead")]
+    pub fn restrict_rotations(
+        &mut self,
+        allow_rotations_x: bool,
+        allow_rotations_y: bool,
+        allow_rotations_z: bool,
+        wake_up: bool,
+    ) {
+        self.set_allowed_rotations(allow_rotations_x, allow_rotations_y, allow_rotations_z, wake_up);
+    }
+
     #[inline]
     /// Locks or unlocks all the rotations of this rigid-body.
     pub fn lock_translations(&mut self, locked: bool, wake_up: bool) {
@@ -212,7 +224,7 @@ impl RigidBody {
 
     #[inline]
     /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
-    pub fn restrict_translations(
+    pub fn set_allowed_translations(
         &mut self,
         allow_translation_x: bool,
         allow_translation_y: bool,
@@ -250,6 +262,24 @@ impl RigidBody {
             .flags
             .set(LockedAxes::TRANSLATION_LOCKED_Z, !allow_translation_z);
         self.update_world_mass_properties();
+    }
+
+    #[inline]
+    #[deprecated(note = "Use `set_allowed_translations` instead")]
+    /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
+    pub fn restrict_translations(
+        &mut self,
+        allow_translation_x: bool,
+        allow_translation_y: bool,
+        #[cfg(feature = "dim3")] allow_translation_z: bool,
+        wake_up: bool,
+    ) {
+        self.set_allowed_translations(
+            allow_translation_x,
+            allow_translation_y,
+            #[cfg(feature = "dim3")] allow_translation_z,
+            wake_up,
+        )
     }
 
     /// Are the translations of this rigid-body locked?
@@ -1068,7 +1098,7 @@ impl RigidBodyBuilder {
     }
 
     /// Only allow translations of this rigid-body around specific coordinate axes.
-    pub fn restrict_translations(
+    pub fn allowed_translations(
         mut self,
         allow_translations_x: bool,
         allow_translations_y: bool,
@@ -1084,6 +1114,21 @@ impl RigidBodyBuilder {
         self
     }
 
+    #[deprecated(note = "Use `allowed_translations` instead")]
+    /// Only allow translations of this rigid-body around specific coordinate axes.
+    pub fn restrict_translations(
+        self,
+        allow_translations_x: bool,
+        allow_translations_y: bool,
+        #[cfg(feature = "dim3")] allow_translations_z: bool,
+    ) -> Self {
+        self.allowed_translations(
+            allow_translations_x,
+            allow_translations_y,
+            #[cfg(feature = "dim3")] allow_translations_z,
+        )
+    }
+
     /// Prevents this rigid-body from rotating because of forces.
     pub fn lock_rotations(mut self) -> Self {
         self.mprops_flags.set(LockedAxes::ROTATION_LOCKED_X, true);
@@ -1094,7 +1139,7 @@ impl RigidBodyBuilder {
 
     /// Only allow rotations of this rigid-body around specific coordinate axes.
     #[cfg(feature = "dim3")]
-    pub fn restrict_rotations(
+    pub fn allowed_rotations(
         mut self,
         allow_rotations_x: bool,
         allow_rotations_y: bool,
@@ -1108,6 +1153,18 @@ impl RigidBodyBuilder {
             .set(LockedAxes::ROTATION_LOCKED_Z, !allow_rotations_z);
         self
     }
+
+    /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
+    #[deprecated(note = "Use `allowed_rotations` instead")]
+    pub fn restrict_rotations(
+        self,
+        allow_rotations_x: bool,
+        allow_rotations_y: bool,
+        allow_rotations_z: bool,
+    ) -> Self {
+        self.allowed_rotations(allow_rotations_x, allow_rotations_y, allow_rotations_z)
+    }
+
 
     /// Sets the damping factor for the linear part of the rigid-body motion.
     ///

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1163,6 +1163,7 @@ impl RigidBodyBuilder {
 
     /// Locks or unlocks rotations of this rigid-body along each cartesian axes.
     #[deprecated(note = "Use `allowed_rotations` instead")]
+    #[cfg(feature = "dim3")]
     pub fn restrict_rotations(
         self,
         allow_rotations_x: bool,


### PR DESCRIPTION
This was a common source of confusion. Users calling `rigid_body.restrict_translations(true, false, false)` would assume that it meant that the translation along the X axis would be locked. In reality, it mean the opposite: X is free, but Y and Z are locked.

This PR clarifies the situation by renaming the `restrict` methods as `set_allowed_translations` and `set_allowed_rotations`.