### PR TITLE
Release v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.14.0 (09 July 2022)
 ### Fixed
 - Fix unpredictable broad-phase panic when using small colliders in the simulation.
 - Fix collision events being incorrectly generated for any shape that produces multiple

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -38,7 +38,7 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.13"
+bevy_egui = "0.14"
 bevy_ecs = "0.7"
 #bevy_prototype_debug_lines = "0.7"
 
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.13.0"
+version = "0.14.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -38,7 +38,7 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.13"
+bevy_egui = "0.14"
 bevy_ecs = "0.7"
 #bevy_prototype_debug_lines = "0.7"
 
@@ -54,5 +54,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.13.0"
+version = "0.14.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -36,7 +36,7 @@ md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.13"
+bevy_egui = "0.14"
 bevy_ecs = "0.7"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 
@@ -52,5 +52,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.13.0"
+version = "0.14.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.13.0"
+version = "0.14.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -32,7 +32,7 @@ instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
 glam       = { version = "0.12", optional = true }
 num_cpus   = { version = "1", optional = true }
-physx      = { version = "0.11", optional = true }
+physx      = { version = "0.12", features = [ "glam" ], optional = true }
 physx-sys = { version = "0.4", optional = true }
 crossbeam = "0.8"
 bincode = "1"
@@ -40,7 +40,7 @@ md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.13"
+bevy_egui = "0.14"
 bevy_ecs = "0.7"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 
@@ -56,5 +56,5 @@ bevy = {version = "0.7", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.13.0"
+version = "0.14.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/src_testbed/box2d_backend.rs
+++ b/src_testbed/box2d_backend.rs
@@ -170,7 +170,7 @@ impl Box2dWorld {
 
         fixture_def.restitution = collider.material().restitution;
         fixture_def.friction = collider.material().friction;
-        fixture_def.density = collider.density().unwrap_or(1.0);
+        fixture_def.density = collider.density();
         fixture_def.is_sensor = collider.is_sensor();
         fixture_def.filter = b2::Filter::new();
 

--- a/src_testbed/physx_backend.rs
+++ b/src_testbed/physx_backend.rs
@@ -78,10 +78,20 @@ impl IntoPhysx for Point3<f32> {
     }
 }
 
+impl IntoPhysx for UnitQuaternion<f32> {
+    type Output = PxQuat;
+    fn into_physx(self) -> Self::Output {
+        PxQuat::new(self.i, self.j, self.k, self.w)
+    }
+}
+
 impl IntoPhysx for Isometry3<f32> {
     type Output = PxTransform;
     fn into_physx(self) -> Self::Output {
-        self.into_glam().into()
+        PxTransform::from_translation_rotation(
+            &self.translation.vector.into_physx(),
+            &self.rotation.into_physx(),
+        )
     }
 }
 
@@ -164,7 +174,7 @@ impl PhysxWorld {
                 gravity: gravity.into_physx(),
                 thread_count: num_threads as u32,
                 broad_phase_type: BroadPhaseType::AutomaticBoxPruning,
-                solver_type: SolverType::PGS,
+                solver_type: SolverType::Pgs,
                 friction_type,
                 ccd_max_passes: integration_parameters.max_ccd_substeps as u32,
                 ..SceneDescriptor::new(())
@@ -361,7 +371,7 @@ impl PhysxWorld {
                     if rb.is_ccd_enabled() {
                         physx_sys::PxRigidBody_setRigidBodyFlag_mut(
                             actor,
-                            RigidBodyFlag::EnableCCD as u32,
+                            RigidBodyFlag::EnableCcd as u32,
                             true,
                         );
                     }


### PR DESCRIPTION
### Fixed
- Fix unpredictable broad-phase panic when using small colliders in the simulation.
- Fix collision events being incorrectly generated for any shape that produces multiple
  contact manifolds (like triangle meshes).
- Fix panic in the `CollisionPipeline` if a collider is both added and removed before a call
  to `CollisionPipeline::step`.

### Modified
- The `RigidBodyBuilder::additional_mass` method will now result in the additional angular inertia
  being automatically computed based on the shapes of the colliders attached to the rigid-body.
- Remove the deprecated methods `RigidBodyBuilder::mass`, `::principal_angular_inertia`, `::principal_inertia`.
- Remove the methods `RigidBodyBuilder::additional_principal_angular_inertia`. Use
  `RigidBodyBuilder::additional_mass_properties` instead.
- The `Collider::density` method now always returns a `Real` (instead of an `Option<Real>`).
- Rename `RigidBody::restrict_rotations` and `RigidBody::restrict_translations` to
  `RigidBody::set_enabled_rotations` and `RigidBody::set_enabled_translations`.
- Rename `RigidBodyBuilder::restrict_rotations` and `RigidBodyBuilder::restrict_translations` to
  `RigidBodyBuilder::enabled_rotations` and `RigidBodyBuilder::enabled_translations`.

### Added
- Add `RigidBody::recompute_mass_properties_from_colliders` to force the immediate computation
  of a rigid-body’s mass properties (instead of waiting for them to be recomputed during the next
  timestep). This is useful to be able to read immediately the result of a change of a rigid-body
  additional mass-properties or a change of one of its collider’s mass-properties.
- Add `RigidBody::set_additional_mass` to set the additional mass for the collider. The additional
  angular inertia is automatically computed based on the attached colliders shapes.
- Add `Collider::set_density`, `::set_mass`, `set_mass_properties`, to alter a collider’s mass
  properties. Note that `::set_mass` will result in the collider’s angular inertia being automatically
  computed based on this mass and on its shape.
- Add `ColliderBuilder::mass` to set the mass of the collider instead of its density. Its angular
  inertia tensor will be automatically computed based on this mass and its shape.
- Add `Collider::mass` and `Collider::volume` to retrieve the mass or volume of a collider.
- Add the `QueryFilter` that is now used by all the scene queries instead of the `CollisionGroups` and `Fn(ColliderHandle) -> bool`
  closure. This `QueryFilter` provides easy access to most common filtering strategies (e.g. dynamic bodies only,
  excluding one particular collider, etc.) for scene queries.
- Add force reporting based on contact force events. The `EventHandler` trait has been modified to include
  the method `EventHandler::handle_contact_force_event`. Contact force events are generated whenever the sum of the
  magnitudes of all the forces between two colliders is greater than any of their
  `Collider::contact_force_event_threshold` values (only the colliders wit the  `ActiveEvents::CONTACT_FORCE_EVENT` flag
  set are taken into account for this threshold).
- Add the `ContactForceEvent` struct that is generated by the `ChannelEventCollector` to report
  contact force events.