### PR TITLE
Reexport `BevyMaterial` alias

### DIFF
--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -7,7 +7,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate log;
 
-pub use crate::graphics::GraphicsManager;
+pub use crate::graphics::{BevyMaterial, GraphicsManager};
 pub use crate::harness::plugin::HarnessPlugin;
 pub use crate::physics::PhysicsState;
 pub use crate::plugin::TestbedPlugin;


### PR DESCRIPTION
This type is used in the `TestbedPlugin` trait, and having to re-define the same type alias in every crate using it seems unnecessary.