### PR TITLE
Make Collider::set_rotation and RigidBody::set_rotation take a rotation instead of an axis-angle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+### Modified
+- The methods `Collider::set_rotation`, `RigidBody::set_rotation`, and `RigidBody::set_next_kinematic_rotation` now
+  take a rotation (`UnitQuaternion` or `UnitComplex`) instead of a vector/angle.
+
+
 ## v0.14.0 (09 July 2022)
 ### Fixed
 - Fix unpredictable broad-phase panic when using small colliders in the simulation.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -681,9 +681,7 @@ impl RigidBody {
 
     /// Sets the rotational part of this rigid-body's position.
     #[inline]
-    pub fn set_rotation(&mut self, rotation: AngVector<Real>, wake_up: bool) {
-        let rotation = Rotation::new(rotation);
-
+    pub fn set_rotation(&mut self, rotation: Rotation<Real>, wake_up: bool) {
         if self.pos.position.rotation != rotation || self.pos.next_position.rotation != rotation {
             self.changes.insert(RigidBodyChanges::POSITION);
             self.pos.position.rotation = rotation;

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -161,9 +161,9 @@ impl Collider {
     }
 
     /// Sets the rotational part of this collider's position.
-    pub fn set_rotation(&mut self, rotation: AngVector<Real>) {
+    pub fn set_rotation(&mut self, rotation: Rotation<Real>) {
         self.changes.insert(ColliderChanges::POSITION);
-        self.pos.0.rotation = Rotation::new(rotation);
+        self.pos.0.rotation = rotation;
     }
 
     /// Sets the position of this collider.


### PR DESCRIPTION
This was frequently reported as inconsistant by the community.