### PR TITLE
Expose method for setting multibody joint position

### DIFF
--- a/src/dynamics/joint/multibody_joint/multibody_joint.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint.rs
@@ -41,7 +41,8 @@ impl MultibodyJoint {
         Self::new(FixedJointBuilder::new().local_frame1(pos).build().into())
     }
 
-    pub(crate) fn set_free_pos(&mut self, pos: Isometry<Real>) {
+    /// Sets multibody joint position
+    pub fn set_free_pos(&mut self, pos: Isometry<Real>) {
         self.coords
             .fixed_rows_mut::<DIM>(0)
             .copy_from(&pos.translation.vector);


### PR DESCRIPTION
Exposing the `set_free_pos` method publicly is necessary in order to initialize a multibody joint in different position than the reference zero-position of the joint represented by the local frames.

This is necessary e.g. in robotics simulation, when a robot needs to be initialized in various postures represented by joint rotation deltas with regard to a default reference posture, which represents zero-positions of joints.