### PR TITLE
Update `bevy_egui`

### DIFF
--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -38,7 +38,7 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.15"
+bevy_egui = "0.16"
 bevy_ecs = "0.8"
 #bevy_prototype_debug_lines = "0.7"
 

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -38,7 +38,7 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.15"
+bevy_egui = "0.16"
 bevy_ecs = "0.8"
 #bevy_prototype_debug_lines = "0.7"
 

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -36,7 +36,7 @@ md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.15"
+bevy_egui = "0.16"
 bevy_ecs = "0.8"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -40,7 +40,7 @@ md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.15"
+bevy_egui = "0.16"
 bevy_ecs = "0.8"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 

--- a/examples2d/add_remove2.rs
+++ b/examples2d/add_remove2.rs
@@ -1,4 +1,4 @@
-use rapier2d::prelude::*;
+use rapier2d::{na::UnitComplex, prelude::*};
 use rapier_testbed2d::Testbed;
 
 pub fn init_world(testbed: &mut Testbed) {
@@ -27,7 +27,7 @@ pub fn init_world(testbed: &mut Testbed) {
         let rot = state.time * -1.0;
         for rb_handle in &platform_handles {
             let rb = physics.bodies.get_mut(*rb_handle).unwrap();
-            rb.set_next_kinematic_rotation(rot);
+            rb.set_next_kinematic_rotation(UnitComplex::new(rot));
         }
 
         if state.timestep_id % 10 == 0 {


### PR DESCRIPTION
(also fixes a build error introduced in https://github.com/dimforge/rapier/commit/68d250f0ad80bb2e5e10e43f2fd1b8824e2a1216 so that the examples build again)