### PR TITLE
Enable more features when documenting on docs.rs

### DIFF
--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = [ ]
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[package.metadata.docs.rs]
+features = ["parallel", "simd-stable", "serde-serialize", "enhanced-determinism", "debug-render"]
+
 [lib]
 name = "rapier2d_f64"
 path = "../../src/lib.rs"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = [ ]
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[package.metadata.docs.rs]
+features = ["parallel", "simd-stable", "serde-serialize", "enhanced-determinism", "debug-render"]
+
 [lib]
 name = "rapier2d"
 path = "../../src/lib.rs"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = [ ]
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[package.metadata.docs.rs]
+features = ["parallel", "simd-stable", "serde-serialize", "enhanced-determinism", "debug-render"]
+
 [lib]
 name = "rapier3d_f64"
 path = "../../src/lib.rs"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = [ ]
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[package.metadata.docs.rs]
+features = ["parallel", "simd-stable", "serde-serialize", "enhanced-determinism", "debug-render"]
+
 [lib]
 name = "rapier3d"
 path = "../../src/lib.rs"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -24,6 +24,8 @@ dim2 = [ ]
 parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "wrapped2d" ]
 
+[package.metadata.docs.rs]
+features = ["parallel", "other-backends"]
 
 [dependencies]
 nalgebra   = { version = "0.31", features = [ "rand" ] }

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -24,6 +24,8 @@ dim2 = [ ]
 parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "wrapped2d" ]
 
+[package.metadata.docs.rs]
+features = ["parallel", "other-backends"]
 
 [dependencies]
 nalgebra   = { version = "0.31", features = [ "rand" ] }

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -23,6 +23,9 @@ default = [ "dim3" ]
 dim3 = [ ]
 parallel = [ "rapier/parallel", "num_cpus" ]
 
+[package.metadata.docs.rs]
+features = ["parallel"]
+
 [dependencies]
 nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -24,6 +24,9 @@ dim3 = [ ]
 parallel = [ "rapier/parallel", "num_cpus" ]
 other-backends = [ "physx", "physx-sys", "glam" ]
 
+[package.metadata.docs.rs]
+features = ["parallel", "other-backends"]
+
 [dependencies]
 nalgebra   = { version = "0.31", features = [ "rand" ] }
 rand       = "0.8"


### PR DESCRIPTION
I was looking for `DebugRenderPipeline` on docs.rs and ended on a 404 page when clicked on the link [here](https://docs.rs/bevy_rapier2d/latest/bevy_rapier2d/render/struct.DebugRenderContext.html#structfield.pipeline). It's simply because the related features were not enabled when building on docs.rs. This should fix it.