### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   a port of the vehicle controller from Bullet physics).
 - Add `RigidBody::user_force` and `RigidBody::user_torque` to read the forces or torques added by the user to a
   dynamic rigid-body.
+- Add `RigidBody::locked_axes` to get the rigid-body axes that were locked by the user.
 
 ### Modified
 - Add the `QueryPipeline` as an optional argument to `PhysicsPipeline::step` and `CollisionPipeline::step`. If this
@@ -18,6 +19,7 @@
   these other pipelines. In that case, calling `QueryPipeline::update` a `PhysicsPipeline::step` isn’t needed.
 - `RigidBody::set_body_type` now takes an extra boolean argument indicating if the rigid-body should be woken-up
   (if it becomes dynamic).
+- `RigidBody::mass_properties` now also returns the world-space mass-properties of the rigid-body.
 
 ### Fix
 - Fix bug resulting in rigid-bodies being awakened after they are created, even if they are created sleeping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## Unreleased
+## v0.17.0 (15 Jan. 2022)
 ### Added
 - Add `RigidBody::set_enabled`, `RigidBody::is_enabled`, `RigidBodyBuilder::enabled` to enable/disable a rigid-body
   without having to delete it. Disabling a rigid-body attached to a multibody joint isn’t supported yet.

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.16.1"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -51,9 +51,9 @@ required-features = [ "dim2", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ], optional = true }
 num-traits = "0.2"
-nalgebra = "0.31"
-parry2d-f64 = "0.12"
-simba = "0.7"
+nalgebra = "0.32"
+parry2d-f64 = "0.13"
+simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -51,9 +51,9 @@ required-features = [ "dim2", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ], optional = true }
 num-traits = "0.2"
-nalgebra = "0.31"
-parry2d = "0.12"
-simba = "0.7"
+nalgebra = "0.32"
+parry2d = "0.13"
+simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.16.1"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -51,9 +51,9 @@ required-features = [ "dim3", "f64" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ], optional = true }
 num-traits = "0.2"
-nalgebra = "0.31"
-parry3d-f64 = "0.12"
-simba = "0.7"
+nalgebra = "0.32"
+parry3d-f64 = "0.13"
+simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.16.1"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.16.1"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://docs.rs/rapier3d"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -51,9 +51,9 @@ required-features = [ "dim3", "f32" ]
 vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = [ "now" ], optional = true }
 num-traits = "0.2"
-nalgebra = "0.31"
-parry3d = "0.12"
-simba = "0.7"
+nalgebra = "0.32"
+parry3d = "0.13"
+simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -28,7 +28,7 @@ other-backends = [ "wrapped2d" ]
 features = ["parallel", "other-backends"]
 
 [dependencies]
-nalgebra   = { version = "0.31", features = [ "rand" ] }
+nalgebra   = { version = "0.32", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -40,17 +40,17 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.16"
-bevy_ecs = "0.8"
+bevy_egui = "0.18"
+bevy_ecs = "0.9"
 #bevy_prototype_debug_lines = "0.7"
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render", "x11"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render", "x11"]}
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
 [dependencies.rapier]

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -56,5 +56,5 @@ bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.16.0"
+version = "0.17.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -28,7 +28,7 @@ other-backends = [ "wrapped2d" ]
 features = ["parallel", "other-backends"]
 
 [dependencies]
-nalgebra   = { version = "0.31", features = [ "rand" ] }
+nalgebra   = { version = "0.32", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -40,17 +40,17 @@ bincode = "1"
 Inflector  = "0.11"
 md5 = "0.7"
 
-bevy_egui = "0.16"
-bevy_ecs = "0.8"
+bevy_egui = "0.18"
+bevy_ecs = "0.9"
 #bevy_prototype_debug_lines = "0.7"
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render", "x11"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render", "x11"]}
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
 [dependencies.rapier]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -56,5 +56,5 @@ bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.16.0"
+version = "0.17.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -55,5 +55,5 @@ bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.16.0"
+version = "0.17.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -27,7 +27,7 @@ parallel = [ "rapier/parallel", "num_cpus" ]
 features = ["parallel"]
 
 [dependencies]
-nalgebra   = { version = "0.31", features = [ "rand" ] }
+nalgebra   = { version = "0.32", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
@@ -39,17 +39,17 @@ md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.16"
-bevy_ecs = "0.8"
+bevy_egui = "0.18"
+bevy_ecs = "0.9"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render", "x11"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render", "x11"]}
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
 [dependencies.rapier]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -28,32 +28,32 @@ other-backends = [ "physx", "physx-sys", "glam" ]
 features = ["parallel", "other-backends"]
 
 [dependencies]
-nalgebra   = { version = "0.31", features = [ "rand" ] }
+nalgebra   = { version = "0.32", features = [ "rand" ] }
 rand       = "0.8"
 rand_pcg   = "0.3"
 instant    = { version = "0.1", features = [ "web-sys", "now" ]}
 bitflags   = "1"
-glam       = { version = "0.12", optional = true }
+glam       = { version = "0.20", optional = true } # For Physx
 num_cpus   = { version = "1", optional = true }
-physx      = { version = "0.12", features = [ "glam" ], optional = true }
-physx-sys = { version = "0.4", optional = true }
+physx      = { version = "0.16", features = [ "glam" ], optional = true }
+physx-sys = { version = "0.8", optional = true }
 crossbeam = "0.8"
 bincode = "1"
 md5 = "0.7"
 Inflector  = "0.11"
 serde = { version = "1", features = [ "derive" ] }
 
-bevy_egui = "0.16"
-bevy_ecs = "0.8"
+bevy_egui = "0.18"
+bevy_ecs = "0.9"
 #bevy_prototype_debug_lines = { version = "0.7", features = [ "3d" ] }
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render", "x11"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render", "x11"]}
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = {version = "0.8", default-features = false, features = ["bevy_winit", "render"]}
+bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "render"]}
 #bevy_webgl2 = "0.5"
 
 [dependencies.rapier]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = {version = "0.9", default-features = false, features = ["bevy_winit", "re
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.16.0"
+version = "0.17.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -158,8 +158,8 @@ impl RigidBody {
 
     /// The mass-properties of this rigid-body.
     #[inline]
-    pub fn mass_properties(&self) -> &MassProperties {
-        &self.mprops.local_mprops
+    pub fn mass_properties(&self) -> &RigidBodyMassProps {
+        &self.mprops
     }
 
     /// The dominance group of this rigid-body.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -184,6 +184,12 @@ impl RigidBody {
         }
     }
 
+    /// The axes along which this rigid-body cannot translate or rotate.
+    #[inline]
+    pub fn locked_axes(&self) -> LockedAxes {
+        self.mprops.flags
+    }
+
     #[inline]
     /// Locks or unlocks all the rotations of this rigid-body.
     pub fn lock_rotations(&mut self, locked: bool, wake_up: bool) {

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -245,7 +245,7 @@ impl Default for RigidBodyAdditionalMassProps {
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
-/// The mass properties of this rigid-bodies.
+/// The mass properties of a rigid-body.
 pub struct RigidBodyMassProps {
     /// Flags for locking rotation and translation.
     pub flags: LockedAxes,

--- a/src/dynamics/solver/delta_vel.rs
+++ b/src/dynamics/solver/delta_vel.rs
@@ -1,6 +1,6 @@
 use crate::math::{AngVector, Vector, SPATIAL_DIM};
 use crate::utils::WReal;
-use na::{DVectorSlice, DVectorSliceMut, Scalar};
+use na::{DVectorView, DVectorViewMut, Scalar};
 use std::ops::{AddAssign, Sub};
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -20,12 +20,12 @@ impl<N: Scalar + Copy> DeltaVel<N> {
         unsafe { std::mem::transmute(self) }
     }
 
-    pub fn as_vector_slice(&self) -> DVectorSlice<N> {
-        DVectorSlice::from_slice(&self.as_slice()[..], SPATIAL_DIM)
+    pub fn as_vector_slice(&self) -> DVectorView<N> {
+        DVectorView::from_slice(&self.as_slice()[..], SPATIAL_DIM)
     }
 
-    pub fn as_vector_slice_mut(&mut self) -> DVectorSliceMut<N> {
-        DVectorSliceMut::from_slice(&mut self.as_mut_slice()[..], SPATIAL_DIM)
+    pub fn as_vector_slice_mut(&mut self) -> DVectorViewMut<N> {
+        DVectorViewMut::from_slice(&mut self.as_mut_slice()[..], SPATIAL_DIM)
     }
 }
 

--- a/src/dynamics/solver/joint_constraint/joint_generic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_generic_velocity_constraint.rs
@@ -4,7 +4,7 @@ use crate::dynamics::solver::DeltaVel;
 use crate::dynamics::{GenericJoint, IntegrationParameters, JointGraphEdge, JointIndex, Multibody};
 use crate::math::{Isometry, Real, DIM};
 use crate::prelude::SPATIAL_DIM;
-use na::{DVector, DVectorSlice, DVectorSliceMut};
+use na::{DVector, DVectorView, DVectorViewMut};
 
 #[derive(Debug, Copy, Clone)]
 pub struct JointGenericVelocityConstraint {
@@ -222,7 +222,7 @@ impl JointGenericVelocityConstraint {
         &self,
         mj_lambdas: &'a [DeltaVel<Real>],
         generic_mj_lambdas: &'a DVector<Real>,
-    ) -> DVectorSlice<'a, Real> {
+    ) -> DVectorView<'a, Real> {
         if self.is_rigid_body1 {
             mj_lambdas[self.mj_lambda1].as_vector_slice()
         } else {
@@ -234,7 +234,7 @@ impl JointGenericVelocityConstraint {
         &self,
         mj_lambdas: &'a mut [DeltaVel<Real>],
         generic_mj_lambdas: &'a mut DVector<Real>,
-    ) -> DVectorSliceMut<'a, Real> {
+    ) -> DVectorViewMut<'a, Real> {
         if self.is_rigid_body1 {
             mj_lambdas[self.mj_lambda1].as_vector_slice_mut()
         } else {
@@ -246,7 +246,7 @@ impl JointGenericVelocityConstraint {
         &self,
         mj_lambdas: &'a [DeltaVel<Real>],
         generic_mj_lambdas: &'a DVector<Real>,
-    ) -> DVectorSlice<'a, Real> {
+    ) -> DVectorView<'a, Real> {
         if self.is_rigid_body2 {
             mj_lambdas[self.mj_lambda2].as_vector_slice()
         } else {
@@ -258,7 +258,7 @@ impl JointGenericVelocityConstraint {
         &self,
         mj_lambdas: &'a mut [DeltaVel<Real>],
         generic_mj_lambdas: &'a mut DVector<Real>,
-    ) -> DVectorSliceMut<'a, Real> {
+    ) -> DVectorViewMut<'a, Real> {
         if self.is_rigid_body2 {
             mj_lambdas[self.mj_lambda2].as_vector_slice_mut()
         } else {
@@ -275,11 +275,11 @@ impl JointGenericVelocityConstraint {
         let jacobians = jacobians.as_slice();
 
         let mj_lambda1 = self.mj_lambda1(mj_lambdas, generic_mj_lambdas);
-        let j1 = DVectorSlice::from_slice(&jacobians[self.j_id1..], self.ndofs1);
+        let j1 = DVectorView::from_slice(&jacobians[self.j_id1..], self.ndofs1);
         let vel1 = j1.dot(&mj_lambda1);
 
         let mj_lambda2 = self.mj_lambda2(mj_lambdas, generic_mj_lambdas);
-        let j2 = DVectorSlice::from_slice(&jacobians[self.j_id2..], self.ndofs2);
+        let j2 = DVectorView::from_slice(&jacobians[self.j_id2..], self.ndofs2);
         let vel2 = j2.dot(&mj_lambda2);
 
         let dvel = self.rhs + (vel2 - vel1);
@@ -292,11 +292,11 @@ impl JointGenericVelocityConstraint {
         self.impulse = total_impulse;
 
         let mut mj_lambda1 = self.mj_lambda1_mut(mj_lambdas, generic_mj_lambdas);
-        let wj1 = DVectorSlice::from_slice(&jacobians[self.wj_id1()..], self.ndofs1);
+        let wj1 = DVectorView::from_slice(&jacobians[self.wj_id1()..], self.ndofs1);
         mj_lambda1.axpy(delta_impulse, &wj1, 1.0);
 
         let mut mj_lambda2 = self.mj_lambda2_mut(mj_lambdas, generic_mj_lambdas);
-        let wj2 = DVectorSlice::from_slice(&jacobians[self.wj_id2()..], self.ndofs2);
+        let wj2 = DVectorView::from_slice(&jacobians[self.wj_id2()..], self.ndofs2);
         mj_lambda2.axpy(-delta_impulse, &wj2, 1.0);
     }
 
@@ -506,7 +506,7 @@ impl JointGenericVelocityGroundConstraint {
         &self,
         _mj_lambdas: &'a [DeltaVel<Real>],
         generic_mj_lambdas: &'a DVector<Real>,
-    ) -> DVectorSlice<'a, Real> {
+    ) -> DVectorView<'a, Real> {
         generic_mj_lambdas.rows(self.mj_lambda2, self.ndofs2)
     }
 
@@ -514,7 +514,7 @@ impl JointGenericVelocityGroundConstraint {
         &self,
         _mj_lambdas: &'a mut [DeltaVel<Real>],
         generic_mj_lambdas: &'a mut DVector<Real>,
-    ) -> DVectorSliceMut<'a, Real> {
+    ) -> DVectorViewMut<'a, Real> {
         generic_mj_lambdas.rows_mut(self.mj_lambda2, self.ndofs2)
     }
 
@@ -527,7 +527,7 @@ impl JointGenericVelocityGroundConstraint {
         let jacobians = jacobians.as_slice();
 
         let mj_lambda2 = self.mj_lambda2(mj_lambdas, generic_mj_lambdas);
-        let j2 = DVectorSlice::from_slice(&jacobians[self.j_id2..], self.ndofs2);
+        let j2 = DVectorView::from_slice(&jacobians[self.j_id2..], self.ndofs2);
         let vel2 = j2.dot(&mj_lambda2);
 
         let dvel = self.rhs + vel2;
@@ -540,7 +540,7 @@ impl JointGenericVelocityGroundConstraint {
         self.impulse = total_impulse;
 
         let mut mj_lambda2 = self.mj_lambda2_mut(mj_lambdas, generic_mj_lambdas);
-        let wj2 = DVectorSlice::from_slice(&jacobians[self.wj_id2()..], self.ndofs2);
+        let wj2 = DVectorView::from_slice(&jacobians[self.wj_id2()..], self.ndofs2);
         mj_lambda2.axpy(-delta_impulse, &wj2, 1.0);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,11 +157,11 @@ pub mod math {
 
     /// The type of a slice of the constraint Jacobian in twist coordinates.
     #[cfg(feature = "dim2")]
-    pub type JacobianSlice<'a, N> = na::MatrixSlice3xX<'a, N>;
+    pub type JacobianView<'a, N> = na::MatrixView3xX<'a, N>;
 
     /// The type of a mutable slice of the constraint Jacobian in twist coordinates.
     #[cfg(feature = "dim2")]
-    pub type JacobianSliceMut<'a, N> = na::MatrixSliceMut3xX<'a, N>;
+    pub type JacobianViewMut<'a, N> = na::MatrixViewMut3xX<'a, N>;
 
     /// The maximum number of possible rotations and translations of a rigid body.
     #[cfg(feature = "dim2")]
@@ -186,11 +186,11 @@ pub mod math {
 
     /// The type of a slice of the constraint Jacobian in twist coordinates.
     #[cfg(feature = "dim3")]
-    pub type JacobianSlice<'a, N> = na::MatrixSlice6xX<'a, N>;
+    pub type JacobianView<'a, N> = na::MatrixView6xX<'a, N>;
 
     /// The type of a mutable slice of the constraint Jacobian in twist coordinates.
     #[cfg(feature = "dim3")]
-    pub type JacobianSliceMut<'a, N> = na::MatrixSliceMut6xX<'a, N>;
+    pub type JacobianViewMut<'a, N> = na::MatrixViewMut6xX<'a, N>;
 
     /// The maximum number of possible rotations and translations of a rigid body.
     #[cfg(feature = "dim3")]

--- a/src_testbed/debug_render.rs
+++ b/src_testbed/debug_render.rs
@@ -6,6 +6,9 @@ use rapier::pipeline::{
     DebugRenderBackend, DebugRenderMode, DebugRenderObject, DebugRenderPipeline,
 };
 
+#[derive(Resource)]
+pub struct DebugRenderPipelineResource(pub DebugRenderPipeline);
+
 pub struct RapierDebugRenderPlugin {
     depth_test: bool,
 }
@@ -23,10 +26,10 @@ impl Plugin for RapierDebugRenderPlugin {
         app.add_plugin(crate::lines::DebugLinesPlugin::with_depth_test(
             self.depth_test,
         ))
-        .insert_resource(DebugRenderPipeline::new(
+        .insert_resource(DebugRenderPipelineResource(DebugRenderPipeline::new(
             Default::default(),
             !DebugRenderMode::RIGID_BODY_AXES & !DebugRenderMode::COLLIDER_AABBS,
-        ))
+        )))
         .add_system_to_stage(CoreStage::Update, debug_render_scene);
     }
 }
@@ -57,12 +60,12 @@ impl<'a> DebugRenderBackend for BevyLinesRenderBackend<'a> {
 }
 
 fn debug_render_scene(
-    mut pipeline: ResMut<DebugRenderPipeline>,
+    mut pipeline: ResMut<DebugRenderPipelineResource>,
     harness: NonSend<Harness>,
     mut lines: ResMut<DebugLines>,
 ) {
     let mut backend = BevyLinesRenderBackend { lines: &mut *lines };
-    pipeline.render(
+    pipeline.0.render(
         &mut backend,
         &harness.physics.bodies,
         &harness.physics.colliders,

--- a/src_testbed/lines/mod.rs
+++ b/src_testbed/lines/mod.rs
@@ -73,6 +73,7 @@ mod dim {
 pub(crate) const DEBUG_LINES_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 17477439189930443325);
 
+#[derive(Resource)]
 pub(crate) struct DebugLinesConfig {
     depth_test: bool,
 }
@@ -275,7 +276,7 @@ pub(crate) struct RenderDebugLinesMesh;
 ///     );
 /// }
 /// ```
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct DebugLines {
     pub positions: Vec<[f32; 3]>,
     //pub colors: Vec<[f32; 4]>,

--- a/src_testbed/lines/render_dim.rs
+++ b/src_testbed/lines/render_dim.rs
@@ -26,6 +26,7 @@ pub mod r3d {
 
     use crate::lines::{DebugLinesConfig, RenderDebugLinesMesh, DEBUG_LINES_SHADER_HANDLE};
 
+    #[derive(Resource)]
     pub(crate) struct DebugLinePipeline {
         mesh_pipeline: MeshPipeline,
         shader: Handle<Shader>,
@@ -208,6 +209,7 @@ pub mod r2d {
 
     use crate::lines::{RenderDebugLinesMesh, DEBUG_LINES_SHADER_HANDLE};
 
+    #[derive(Resource)]
     pub(crate) struct DebugLinePipeline {
         mesh_pipeline: Mesh2dPipeline,
         shader: Handle<Shader>,

--- a/src_testbed/objects/node.rs
+++ b/src_testbed/objects/node.rs
@@ -44,7 +44,7 @@ impl EntityWithGraphics {
         color: Point3<f32>,
         sensor: bool,
     ) -> Self {
-        let entity = commands.spawn().id();
+        let entity = commands.spawn_empty().id();
 
         let scale = collider_mesh_scale(shape);
         let mesh = prefab_meshs
@@ -108,7 +108,7 @@ impl EntityWithGraphics {
             };
 
             let mut entity_commands = commands.entity(entity);
-            entity_commands.insert_bundle(bundle);
+            entity_commands.insert(bundle);
 
             if sensor {
                 entity_commands.insert(Wireframe);

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -97,6 +97,7 @@ bitflags! {
     }
 }
 
+#[derive(Resource)]
 pub struct TestbedState {
     pub running: RunMode,
     pub draw_colls: bool,
@@ -122,6 +123,7 @@ pub struct TestbedState {
     camera_locked: bool, // Used so that the camera can remain the same before and after we change backend or press the restart button.
 }
 
+#[derive(Resource)]
 struct SceneBuilders(Vec<(&'static str, fn(&mut Testbed))>);
 
 #[cfg(feature = "other-backends")]
@@ -369,23 +371,26 @@ impl TestbedApp {
                 "Rapier: 3D demos".to_string()
             };
 
-            let mut app = App::new();
+            let window_plugin = WindowPlugin {
+                window: WindowDescriptor {
+                    title,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
 
-            app.insert_resource(WindowDescriptor {
-                title,
-                ..Default::default()
-            })
-            .insert_resource(ClearColor(Color::rgb(0.15, 0.15, 0.15)))
-            .insert_resource(Msaa { samples: 4 })
-            .insert_resource(AmbientLight {
-                brightness: 0.3,
-                ..Default::default()
-            })
-            .add_plugins(DefaultPlugins)
-            .add_plugin(OrbitCameraPlugin)
-            .add_plugin(WireframePlugin)
-            .add_plugin(bevy_egui::EguiPlugin)
-            .add_plugin(debug_render::RapierDebugRenderPlugin::default());
+            let mut app = App::new();
+            app.insert_resource(ClearColor(Color::rgb(0.15, 0.15, 0.15)))
+                .insert_resource(Msaa { samples: 4 })
+                .insert_resource(AmbientLight {
+                    brightness: 0.3,
+                    ..Default::default()
+                })
+                .add_plugins(DefaultPlugins.set(window_plugin))
+                .add_plugin(OrbitCameraPlugin)
+                .add_plugin(WireframePlugin)
+                .add_plugin(bevy_egui::EguiPlugin)
+                .add_plugin(debug_render::RapierDebugRenderPlugin::default());
 
             #[cfg(target_arch = "wasm32")]
             app.add_plugin(bevy_webgl2::WebGL2Plugin);
@@ -995,7 +1000,7 @@ fn draw_contacts(_nf: &NarrowPhase, _colliders: &ColliderSet) {
 fn setup_graphics_environment(mut commands: Commands) {
     const HALF_SIZE: f32 = 100.0;
 
-    commands.spawn_bundle(DirectionalLightBundle {
+    commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
             illuminance: 10000.0,
             // Configure the projection to better fit the scene
@@ -1020,7 +1025,7 @@ fn setup_graphics_environment(mut commands: Commands) {
     });
 
     commands
-        .spawn_bundle(Camera3dBundle {
+        .spawn(Camera3dBundle {
             transform: Transform::from_matrix(
                 Mat4::look_at_rh(
                     Vec3::new(-30.0, 30.0, 100.0),
@@ -1053,7 +1058,7 @@ fn setup_graphics_environment(mut commands: Commands) {
     //     ..Default::default()
     // });
     commands
-        .spawn_bundle(Camera2dBundle {
+        .spawn(Camera2dBundle {
             transform: Transform {
                 translation: Vec3::new(0.0, 0.0, 0.0),
                 rotation: Quat::IDENTITY,


### PR DESCRIPTION
### Added
- Add `RigidBody::set_enabled`, `RigidBody::is_enabled`, `RigidBodyBuilder::enabled` to enable/disable a rigid-body
  without having to delete it. Disabling a rigid-body attached to a multibody joint isn’t supported yet.
- Add `Collider::set_enabled`, `Collider::is_enabled`, `ColliderBuilder::enabled` to enable/disable a collider
  without having to delete it.
- Add `GenericJoint::set_enabled`, `GenericJoint::is_enabled` to enable/disable a joint without having to delete it.
  Disabling a multibody joint isn’t supported yet.
- Add `DynamicRayCastVehicleController`, a vehicle controller based on ray-casting and dynamic rigid-bodies (mostly
  a port of the vehicle controller from Bullet physics).
- Add `RigidBody::user_force` and `RigidBody::user_torque` to read the forces or torques added by the user to a
  dynamic rigid-body.
- Add `RigidBody::locked_axes` to get the rigid-body axes that were locked by the user.

### Modified
- Add the `QueryPipeline` as an optional argument to `PhysicsPipeline::step` and `CollisionPipeline::step`. If this
  argument is specified, then the query pipeline will be incrementally (i.e. more efficiently) update at the same time as
  these other pipelines. In that case, calling `QueryPipeline::update` a `PhysicsPipeline::step` isn’t needed.
- `RigidBody::set_body_type` now takes an extra boolean argument indicating if the rigid-body should be woken-up
  (if it becomes dynamic).
- `RigidBody::mass_properties` now also returns the world-space mass-properties of the rigid-body.

### Fix
- Fix bug resulting in rigid-bodies being awakened after they are created, even if they are created sleeping.

