### PR TITLE
Allow customising the time until sleep for a rigid body

### DIFF
--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -176,8 +176,7 @@ impl IslandManager {
 
             update_energy(&mut rb.activation, sq_linvel, sq_angvel, dt);
 
-            if rb.activation.time_since_can_sleep >= RigidBodyActivation::default_time_until_sleep()
-            {
+            if rb.activation.time_since_can_sleep >= rb.activation.time_until_sleep {
                 // Mark them as sleeping for now. This will
                 // be set to false during the graph traversal
                 // if it should not be put to sleep.

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -978,6 +978,8 @@ pub struct RigidBodyActivation {
     pub linear_threshold: Real,
     /// The angular linear velocity bellow which the body can fall asleep.
     pub angular_threshold: Real,
+    /// The amount of time the rigid-body must remain below the thresholds to be put to sleep.
+    pub time_until_sleep: Real,
     /// Since how much time can this body sleep?
     pub time_since_can_sleep: Real,
     /// Is this body sleeping?
@@ -1012,6 +1014,7 @@ impl RigidBodyActivation {
         RigidBodyActivation {
             linear_threshold: Self::default_linear_threshold(),
             angular_threshold: Self::default_angular_threshold(),
+            time_until_sleep: Self::default_time_until_sleep(),
             time_since_can_sleep: 0.0,
             sleeping: false,
         }
@@ -1022,8 +1025,9 @@ impl RigidBodyActivation {
         RigidBodyActivation {
             linear_threshold: Self::default_linear_threshold(),
             angular_threshold: Self::default_angular_threshold(),
-            sleeping: true,
+            time_until_sleep: Self::default_time_until_sleep(),
             time_since_can_sleep: Self::default_time_until_sleep(),
+            sleeping: true,
         }
     }
 
@@ -1055,6 +1059,6 @@ impl RigidBodyActivation {
     #[inline]
     pub fn sleep(&mut self) {
         self.sleeping = true;
-        self.time_since_can_sleep = Self::default_time_until_sleep();
+        self.time_since_can_sleep = self.time_until_sleep;
     }
 }


### PR DESCRIPTION
Currently the time before a body falls asleep cannot be changed and is set to 2 seconds. This PR allows this value to be changed in the `RigidBodyActivation` of the body.