### PR TITLE
Prevent parallel wasm builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ extern crate num_traits as num;
 // #[macro_use]
 // extern crate array_macro;
 
+#[cfg(all(target_family = "wasm", feature = "parallel"))]
+std::compile_error!("Rapier does not currently support parallelism on WebAssembly.");
+
 #[cfg(feature = "parallel")]
 pub use rayon;
 


### PR DESCRIPTION
Attempting to target wasm with the parallel feature on fails because `rayon` does not natively support it.

Parallelism on WebAssembly is technically achievable through the Web Workers API, but until such functionality is stable, this should provide a better error message.