### PR TITLE
#465 Add is_sliding_down_slope field to EffectiveCharacterMovement

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -261,7 +261,8 @@ impl KinematicCharacterController {
                     &mut result,
                 ) {
                     // No stairs, try to move along slopes.
-                    translation_remaining = self.handle_slopes(&toi, &translation_remaining, &mut result);
+                    translation_remaining =
+                        self.handle_slopes(&toi, &translation_remaining, &mut result);
                 }
             } else {
                 // No interference along the path.
@@ -475,7 +476,12 @@ impl KinematicCharacterController {
         false
     }
 
-    fn handle_slopes(&self, hit: &TOI, translation_remaining: &Vector<Real>, result: &mut EffectiveCharacterMovement) -> Vector<Real> {
+    fn handle_slopes(
+        &self,
+        hit: &TOI,
+        translation_remaining: &Vector<Real>,
+        result: &mut EffectiveCharacterMovement,
+    ) -> Vector<Real> {
         let [vertical_translation, horizontal_translation] =
             self.split_into_components(translation_remaining);
         let slope_translation = subtract_hit(*translation_remaining, hit);

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -6,7 +6,6 @@ use crate::math::{Isometry, Point, Real, Vector};
 use crate::{dynamics::RigidBodySet, geometry::ColliderSet};
 use parry::partitioning::{QbvhDataGenerator, QbvhUpdateWorkspace};
 use parry::query::details::{
-    IntersectionCompositeShapeShapeBestFirstVisitor,
     NonlinearTOICompositeShapeShapeBestFirstVisitor, PointCompositeShapeProjBestFirstVisitor,
     PointCompositeShapeProjWithFeatureBestFirstVisitor,
     RayCompositeShapeToiAndNormalBestFirstVisitor, RayCompositeShapeToiBestFirstVisitor,
@@ -539,12 +538,16 @@ impl QueryPipeline {
         filter: QueryFilter,
     ) -> Option<ColliderHandle> {
         let pipeline_shape = self.as_composite_shape(bodies, colliders, filter);
-        let mut visitor = IntersectionCompositeShapeShapeBestFirstVisitor::new(
-            &*self.query_dispatcher,
-            shape_pos,
-            &pipeline_shape,
-            shape,
-        );
+        #[allow(deprecated)]
+        // TODO: replace this with IntersectionCompositeShapeShapeVisitor when it
+        //        can return the shape part id.
+        let mut visitor =
+            parry::query::details::IntersectionCompositeShapeShapeBestFirstVisitor::new(
+                &*self.query_dispatcher,
+                shape_pos,
+                &pipeline_shape,
+                shape,
+            );
 
         self.qbvh
             .traverse_best_first(&mut visitor)


### PR DESCRIPTION
Resolves #465 
This change adds the `is_sliding_down_slope` field to the EffectiveCharacterMovement output struct for `move_shape` KinematicCharacterController function

This field will be true when the entity is sliding down at least one slope.

From my testing, this field will be true when sliding into a wall. So if the consumer does not want a player to move while sliding, make sure to check for that edge case.