### PR TITLE
Fix doc-links for `ColliderBuilder` and `RigidBodyBuilder`

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -13,7 +13,7 @@ use num::Zero;
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 /// A rigid body.
 ///
-/// To create a new rigid-body, use the `RigidBodyBuilder` structure.
+/// To create a new rigid-body, use the [`RigidBodyBuilder`] structure.
 #[derive(Debug, Clone)]
 pub struct RigidBody {
     pub(crate) pos: RigidBodyPosition,

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -16,7 +16,7 @@ use parry::shape::{Shape, TriMeshFlags};
 #[derive(Clone)]
 /// A geometric entity that can be attached to a body so it can be affected by contacts and proximity queries.
 ///
-/// To build a new collider, use the `ColliderBuilder` structure.
+/// To build a new collider, use the [`ColliderBuilder`] structure.
 pub struct Collider {
     pub(crate) coll_type: ColliderType,
     pub(crate) shape: ColliderShape,


### PR DESCRIPTION
Fix the doc-links to `ColliderBuilder` and `RigidBodyBuilder` from their respective types.