### PR TITLE
should allow grounding with no movement counter to the up direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   violation recovers over a few steps instead of catapulting the bodies.
 - Python: `DynamicRayCastVehicleController.update_vehicle` now excludes the chassis body from
   the suspension raycasts by default (their origins sit on its own collider).
+- The character controller's snap-to-ground now triggers on any movement that isn't upwards,
+  including movements exactly orthogonal to the up vector, instead of requiring a downward
+  motion larger than an arbitrary epsilon. Purely lateral movement along the ground no longer
+  flickers the `grounded` flag when snap-to-ground is enabled (PR #481 by @ChrisJanssens).
 
 ### Modified
 

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -463,7 +463,7 @@ impl KinematicCharacterController {
         result: &mut EffectiveCharacterMovement,
     ) -> Option<(ColliderHandle, ShapeCastHit)> {
         if let Some(snap_distance) = self.snap_to_ground {
-            if result.translation.dot(self.up) < -1.0e-5 {
+            if result.translation.dot(self.up) <= 0.0 {
                 let snap_distance = snap_distance.eval(dims.y);
                 let offset = self.offset.eval(dims.y);
                 if let Some((hit_handle, hit)) = queries.cast_shape(


### PR DESCRIPTION
It looks like we are taking the dot product of the movement and up direction here to ensure the vector is negative to the up direction. Is this necessary? I was using grounded to determine when my character controller can "jump". Allowing this value to be zero or lower allows my character controller lateral movement along a collider that is on the opposed side of my character to that of the up direction.