### PR TITLE
Delete mention of removed `PhysicsPipeline::step_generic`

### DIFF
--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -401,9 +401,6 @@ impl PhysicsPipeline {
     }
 
     /// Executes one timestep of the physics simulation.
-    ///
-    /// This is the same as `self.step_generic`, except that it is specialized
-    /// to work with `RigidBodySet` and `ColliderSet`.
     pub fn step(
         &mut self,
         gravity: &Vector<Real>,


### PR DESCRIPTION
This was removed in version 0.12.0

https://github.com/dimforge/rapier/blob/89e3d7650c84f96893376a79cbc120aeaeb74785/CHANGELOG.md?plain=1#L191