### PR TITLE
Remove usage of magic numbers in DynamicRaycastVehicleController

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -804,3 +804,12 @@ impl<T> IndexMut2<usize> for [T] {
         }
     }
 }
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+/// One of 3 spatial axes
+pub enum Axis {
+    X = 0,
+    Y = 1,
+    Z = 2,
+}


### PR DESCRIPTION
Usage of magic numbers is discouraged in rust in favor of enums. I've replaced magic numbers that denote axes with an enum that can be converted to an integer when needed. The enum uses less bytes and does not allow invalid states.