### PR TITLE
`user_data` for joints

### DIFF
--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -223,6 +223,8 @@ pub struct GenericJoint {
     pub contacts_enabled: bool,
     /// Whether or not the joint is enabled.
     pub enabled: JointEnabled,
+    /// User-defined data associated to this joint.
+    pub user_data: u128,
 }
 
 impl Default for GenericJoint {
@@ -238,6 +240,7 @@ impl Default for GenericJoint {
             motors: [JointMotor::default(); SPATIAL_DIM],
             contacts_enabled: true,
             enabled: JointEnabled::Enabled,
+            user_data: 0,
         }
     }
 }
@@ -666,6 +669,12 @@ impl GenericJointBuilder {
     #[must_use]
     pub fn motor_max_force(mut self, axis: JointAxis, max_force: Real) -> Self {
         self.0.set_motor_max_force(axis, max_force);
+        self
+    }
+
+    /// An arbitrary user-defined 128-bit integer associated to the joints built by this builder.
+    pub fn user_data(mut self, data: u128) -> Self {
+        self.0.user_data = data;
         self
     }
 


### PR DESCRIPTION
Removes inconsistency with other entities, such as rigid bodies and colliders - they all have `user_data` field. 

## Motivation

This field is usually used to store a pointer/handle to game/engine/etc entities associated with a rigid body/collider/joint. And the lack of `user_data` field causing troubles in Fyrox - I forced to use a hash map like `HashMap<Handle<Stuff>, JointHandle>` to bypass this issue, which has both performance and usability impact.