### PR TITLE
fix lock_translations & lock_rotations doesn't work both ways

### DIFF
--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -193,7 +193,7 @@ impl RigidBody {
     #[inline]
     /// Locks or unlocks all the rotations of this rigid-body.
     pub fn lock_rotations(&mut self, locked: bool, wake_up: bool) {
-        if !self.mprops.flags.contains(LockedAxes::ROTATION_LOCKED) {
+        if locked != self.mprops.flags.contains(LockedAxes::ROTATION_LOCKED) {
             if self.is_dynamic() && wake_up {
                 self.wake_up(true);
             }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -255,7 +255,7 @@ impl RigidBody {
     #[inline]
     /// Locks or unlocks all the rotations of this rigid-body.
     pub fn lock_translations(&mut self, locked: bool, wake_up: bool) {
-        if !self.mprops.flags.contains(LockedAxes::TRANSLATION_LOCKED) {
+        if locked != self.mprops.flags.contains(LockedAxes::TRANSLATION_LOCKED) {
             if self.is_dynamic() && wake_up {
                 self.wake_up(true);
             }


### PR DESCRIPTION
rigidbody.lock_translations and lock_rotations methods were able to lock but not unlock.