### PR TITLE
docs: Expand "wrt" to "with respect to".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,8 +256,8 @@ Check it out on [rapier.rs](https://www.rapier.rs/docs/user_guides/javascript/ge
 
 ## v0.10.1
 ### Added
-- Add `Collider::set_translation_wrt_parent` to change the translation of a collider wrt. its parent rigid-body.
-- Add `Collider::set_rotation_wrt_parent` to change the translation of a collider wrt. its parent rigid-body.
+- Add `Collider::set_translation_wrt_parent` to change the translation of a collider with respect to its parent rigid-body.
+- Add `Collider::set_rotation_wrt_parent` to change the translation of a collider with respect to its parent rigid-body.
 
 
 ## v0.10.0

--- a/src/data/graph.rs
+++ b/src/data/graph.rs
@@ -1,5 +1,5 @@
 // This is basically a stripped down version of petgraph's UnGraph.
-// - It is not generic wrt. the index type (we always use u32).
+// - It is not generic with respect to the index type (we always use u32).
 // - It preserves associated edge iteration order after Serialization/Deserialization.
 // - It is always undirected.
 //! A stripped-down version of petgraph's UnGraph.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -214,7 +214,7 @@ impl Collider {
         &self.pos.0.rotation
     }
 
-    /// The position of this collider wrt the body it is attached to.
+    /// The position of this collider with respect to the body it is attached to.
     pub fn position_wrt_parent(&self) -> Option<&Isometry<Real>> {
         self.parent.as_ref().map(|p| &p.pos_wrt_parent)
     }
@@ -235,7 +235,7 @@ impl Collider {
         }
     }
 
-    /// Sets the position of this collider wrt. its parent rigid-body.
+    /// Sets the position of this collider with respect to its parent rigid-body.
     ///
     /// Does nothing if the collider is not attached to a rigid-body.
     pub fn set_position_wrt_parent(&mut self, pos_wrt_parent: Isometry<Real>) {

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -95,7 +95,8 @@ impl<'a> ContactModificationContext<'a> {
             CONTACT_CURRENTLY_FORBIDDEN => {
                 // Contacts are forbidden so we need to continue forbidding contacts
                 // until all the contacts are non-penetrating again. In that case, if
-                // the contacts are OK wrt. the contact normal, then we can mark them as allowed.
+                // the contacts are OK with respect to the contact normal, then we can
+                // mark them as allowed.
                 if contact_is_ok && self.solver_contacts.iter().all(|c| c.dist > 0.0) {
                     *self.user_data = CONTACT_CURRENTLY_ALLOWED;
                 } else {

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -630,8 +630,8 @@ impl PhysicsPipeline {
         }
 
         // Finally, make sure we update the world mass-properties of the rigid-bodies
-        // that moved. Otherwise, users may end up applying forces wrt. an outdated
-        // center of mass.
+        // that moved. Otherwise, users may end up applying forces with respect to an
+        // outdated center of mass.
         // TODO: avoid updating the world mass properties twice (here, and
         //       at the beginning of the next timestep) for bodies that were
         //       not modified by the user in the mean time.

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -706,7 +706,7 @@ impl QueryPipeline {
     /// * `stop_at_penetration` - If the casted shape starts in a penetration state with any
     ///    collider, two results are possible. If `stop_at_penetration` is `true` then, the
     ///    result will have a `toi` equal to `start_time`. If `stop_at_penetration` is `false`
-    ///    then the nonlinear shape-casting will see if further motion wrt. the penetration normal
+    ///    then the nonlinear shape-casting will see if further motion with respect to the penetration normal
     ///    would result in tunnelling. If it does not (i.e. we have a separating velocity along
     ///    that normal) then the nonlinear shape-casting will attempt to find another impact,
     ///    at a time `> start_time` that could result in tunnelling.


### PR DESCRIPTION
This makes things more clear as this abbreviation isn't known to everyone.

While the trailing period is common in French, it isn't in English (one might use "w.r.t.").

Fixes #498.