### PR TITLE
Calculate world center of mass from local com in debug renderer

### DIFF
--- a/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
@@ -242,7 +242,10 @@ impl DebugRenderPipeline {
                     [120.0 * coeff[0], 1.0 * coeff[1], 0.1 * coeff[2], coeff[3]],
                     [240.0 * coeff[0], 1.0 * coeff[1], 0.2 * coeff[2], coeff[3]],
                 ];
-                let com = rb.mprops.world_com;
+
+                let com = rb
+                    .position()
+                    .transform_point(&rb.mprops.local_mprops.local_com);
 
                 for k in 0..DIM {
                     let axis = basis.column(k) * self.style.rigid_body_axes_length;


### PR DESCRIPTION
Kinematic bodies that were moved after creation don't have their world_com mass properties re-calculated. This isn't a complete solution since I think ideally the `rb.mrprops.world_com` should be updated in that case, but fixes the debug renderer for now.