### PR TITLE
Use the absolute value of the up attribute when calculating up_extent and side_extent

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -521,7 +521,7 @@ impl KinematicCharacterController {
 
     fn compute_dims(&self, character_shape: &dyn Shape) -> Vector2<Real> {
         let extents = character_shape.compute_local_aabb().extents();
-        let up_extent = extents.dot(&self.up);
+        let up_extent = extents.dot(&self.up.abs());
         let side_extent = (extents - *self.up * up_extent).norm();
         Vector2::new(side_extent, up_extent)
     }
@@ -679,7 +679,7 @@ impl KinematicCharacterController {
         filter: QueryFilter,
     ) {
         let extents = character_shape.compute_local_aabb().extents();
-        let up_extent = extents.dot(&self.up);
+        let up_extent = extents.dot(&self.up.abs());
         let movement_to_transfer =
             *collision.toi.normal1 * collision.translation_remaining.dot(&collision.toi.normal1);
         let prediction = self.predict_ground(up_extent);

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -522,7 +522,7 @@ impl KinematicCharacterController {
     fn compute_dims(&self, character_shape: &dyn Shape) -> Vector2<Real> {
         let extents = character_shape.compute_local_aabb().extents();
         let up_extent = extents.dot(&self.up.abs());
-        let side_extent = (extents - *self.up * up_extent).norm();
+        let side_extent = (extents - (*self.up).abs() * up_extent).norm();
         Vector2::new(side_extent, up_extent)
     }
 


### PR DESCRIPTION
Fixes https://github.com/dimforge/bevy_rapier/issues/413

I think that we should use the absolute value of the `up` attribute of a `KinematicCharacterController` when calculating the value of the `up_extent` and `side_extent` variables.
Concerning the `up_extent` variable, if you make the `up` attribute point downward, parry will make the app crash because of the `assert` in the `loosened` function of the `AABB` struct since the amount of loosening would be negative.
And concerning the `side_extent` variable, the value would not be the same if the `up` attribute points upward or downward.