### PR TITLE
add bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,7 +67,7 @@
             "name": "Debug executable 'all_examples2'",
             "cargo": {
                 "args": [
-                    "build",
+                    "run",
                     "--bin=all_examples2",
                     "--package=rapier-examples-2d"
                 ],
@@ -104,7 +104,8 @@
             "name": "Debug executable 'all_benchmarks2'",
             "cargo": {
                 "args": [
-                    "build",
+                    "run",
+                    "--release",
                     "--bin=all_benchmarks2",
                     "--package=rapier-benchmarks-2d"
                 ],

--- a/examples2d/debug_box_ball2.rs
+++ b/examples2d/debug_box_ball2.rs
@@ -1,4 +1,4 @@
-use rapier2d::prelude::*;
+use rapier2d::{prelude::*, parry};
 use rapier_testbed2d::Testbed;
 
 pub fn init_world(testbed: &mut Testbed) {
@@ -10,28 +10,49 @@ pub fn init_world(testbed: &mut Testbed) {
     let impulse_joints = ImpulseJointSet::new();
     let multibody_joints = MultibodyJointSet::new();
 
+    // Bug
+
+    let shape1 = SharedShape::capsule_y(5.0, 10.0);
+    let mut vec = Vec::<Point::<Real>>::with_capacity(3);
+    unsafe {
+        vec.push(Point::<Real> { coords : vector![64.0, 507.0] });
+        vec.push(Point::<Real> { coords : vector![440.0, 326.0] });
+        vec.push(Point::<Real> { coords : vector![1072.0, 507.0] });
+    }
+    let shape2 = SharedShape::convex_polyline(vec);
+    let shape2 = shape2.unwrap();
+    let transform1 = Isometry::new(vector![381.592, 348.491], 0.0);
+    let transform2 = Isometry::new(vector![0.0, 0.0], 0.0);
+
     /*
      * Ground
      */
     let rad = 1.0;
     let rigid_body = RigidBodyBuilder::fixed()
-        .translation(vector![0.0, -rad])
-        .rotation(std::f32::consts::PI / 4.0);
+        .translation(vector![0.0, 0.0])
+        .rotation(0.0);
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(rad, rad);
-    colliders.insert_with_parent(collider, handle, &mut bodies);
+    //let collider = ColliderBuilder::cuboid(rad, rad);
+    colliders.insert_with_parent(ColliderBuilder::new(shape2.clone()), handle, &mut bodies);
 
     // Build the dynamic box rigid body.
-    let rigid_body = RigidBodyBuilder::dynamic()
-        .translation(vector![0.0, 3.0 * rad])
+    let rigid_body = RigidBodyBuilder::fixed()
+        .translation(vector![381.592, 348.491])
         .can_sleep(false);
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::ball(rad);
-    colliders.insert_with_parent(collider, handle, &mut bodies);
-
+    //let collider = ColliderBuilder::ball(rad);
+    colliders.insert_with_parent(ColliderBuilder::new(shape1.clone()), handle, &mut bodies);
+    
+    if let Ok(Some(contact)) = parry::query::contact(
+        &transform1, shape1.as_ref(), &transform2, shape2.as_ref(), 1.0
+    ) {
+        panic!("collision");
+    } else {
+        print!("no collision");
+    }
     /*
      * Set up the testbed.
      */
     testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
-    testbed.look_at(point![0.0, 0.0], 50.0);
+    testbed.look_at(point![381.592, 348.491], 1.0);
 }


### PR DESCRIPTION
Made a PR so you can view the bug I am experiencing. Here is the image of how the example looks like:

![image](https://github.com/dimforge/rapier/assets/2369380/98077422-5cc9-4a07-8833-e16aa6f4b3da)

What is happening here, I am calling the `parry::query::contact` and getting No collision, even though the shapes are obviously colliding.

From my investigation, the code goes to [epa2.rs](https://github.com/dimforge/parry/blob/af38912c942afd260e3d65931c750e57beb7c4b0/src/query/epa/epa2.rs#L161)

And then it stops at:

```
if niter > 10000 {
    return None;
}
```

It seems to be adding the same face over and over 1000 times to the heap and removing it, and then it stops.