### PR TITLE
Fix enabling disabled collider

### DIFF
--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -79,7 +79,7 @@ impl ColliderChanges {
     /// Do these changes justify a broad-phase update?
     pub fn needs_broad_phase_update(self) -> bool {
         self.intersects(
-            ColliderChanges::PARENT | ColliderChanges::POSITION | ColliderChanges::SHAPE,
+            ColliderChanges::PARENT | ColliderChanges::POSITION | ColliderChanges::SHAPE | ColliderChanges::ENABLED_OR_DISABLED,
         )
     }
 

--- a/src/geometry/collider_components.rs
+++ b/src/geometry/collider_components.rs
@@ -79,7 +79,10 @@ impl ColliderChanges {
     /// Do these changes justify a broad-phase update?
     pub fn needs_broad_phase_update(self) -> bool {
         self.intersects(
-            ColliderChanges::PARENT | ColliderChanges::POSITION | ColliderChanges::SHAPE | ColliderChanges::ENABLED_OR_DISABLED,
+            ColliderChanges::PARENT
+                | ColliderChanges::POSITION
+                | ColliderChanges::SHAPE
+                | ColliderChanges::ENABLED_OR_DISABLED,
         )
     }
 


### PR DESCRIPTION
If collider was enabled and no other attributes were changed its collisions were not detected.
This was caused by `needs_broad_phase_update` function not handling the case of changed enabled status.
Fixes dimforge/bevy_rapier#435