### PR TITLE
Added support for collision events regardless if started was called: CollisionEvent::Active

### DIFF
--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -101,6 +101,22 @@ impl IntersectionPair {
             None,
         );
     }
+
+    pub(crate) fn emit_active_event(
+        &mut self,
+        bodies: &RigidBodySet,
+        colliders: &ColliderSet,
+        collider1: ColliderHandle,
+        collider2: ColliderHandle,
+        events: &dyn EventHandler,
+    ) {
+        events.handle_collision_event(
+            bodies,
+            colliders,
+            CollisionEvent::Active(collider1, collider2, CollisionEventFlags::SENSOR),
+            None,
+        );
+    }
 }
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -228,6 +244,20 @@ impl ContactPair {
             bodies,
             colliders,
             CollisionEvent::Stopped(self.collider1, self.collider2, CollisionEventFlags::empty()),
+            Some(self),
+        );
+    }
+
+    pub(crate) fn emit_active_event(
+        &mut self,
+        bodies: &RigidBodySet,
+        colliders: &ColliderSet,
+        events: &dyn EventHandler,
+    ) {
+        events.handle_collision_event(
+            bodies,
+            colliders,
+            CollisionEvent::Active(self.collider1, self.collider2, CollisionEventFlags::empty()),
             Some(self),
         );
     }

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -76,6 +76,9 @@ pub enum CollisionEvent {
     Started(ColliderHandle, ColliderHandle, CollisionEventFlags),
     /// Event occurring when two colliders stop colliding.
     Stopped(ColliderHandle, ColliderHandle, CollisionEventFlags),
+    /// Event occurring when two colliders are actively colliding.
+    /// Even after `CollisionEvent::Started` has already been called.
+    Active(ColliderHandle, ColliderHandle, CollisionEventFlags),
 }
 
 impl CollisionEvent {
@@ -92,21 +95,21 @@ impl CollisionEvent {
     /// The handle of the first collider involved in this collision event.
     pub fn collider1(self) -> ColliderHandle {
         match self {
-            Self::Started(h, _, _) | Self::Stopped(h, _, _) => h,
+            Self::Started(h, _, _) | Self::Stopped(h, _, _) | Self::Active(h, _, _) => h,
         }
     }
 
     /// The handle of the second collider involved in this collision event.
     pub fn collider2(self) -> ColliderHandle {
         match self {
-            Self::Started(_, h, _) | Self::Stopped(_, h, _) => h,
+            Self::Started(_, h, _) | Self::Stopped(_, h, _) | Self::Active(_, h, _) => h,
         }
     }
 
     /// Was at least one of the colliders involved in the collision a sensor?
     pub fn sensor(self) -> bool {
         match self {
-            Self::Started(_, _, f) | Self::Stopped(_, _, f) => {
+            Self::Started(_, _, f) | Self::Stopped(_, _, f) | Self::Active(_, _, f) => {
                 f.contains(CollisionEventFlags::SENSOR)
             }
         }
@@ -115,7 +118,7 @@ impl CollisionEvent {
     /// Was at least one of the colliders involved in the collision removed?
     pub fn removed(self) -> bool {
         match self {
-            Self::Started(_, _, f) | Self::Stopped(_, _, f) => {
+            Self::Started(_, _, f) | Self::Stopped(_, _, f) | Self::Active(_, _, f) => {
                 f.contains(CollisionEventFlags::REMOVED)
             }
         }

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -762,6 +762,11 @@ impl NarrowPhase {
 
             let active_events = co1.flags.active_events | co2.flags.active_events;
 
+            if had_intersection && active_events.contains(ActiveEvents::ACTIVE_COLLISION_EVENTS) {
+                edge.weight
+                    .emit_active_event(bodies, colliders, handle1, handle2, events);
+            }
+
             if active_events.contains(ActiveEvents::COLLISION_EVENTS)
                 && had_intersection != edge.weight.intersecting
             {
@@ -992,6 +997,12 @@ impl NarrowPhase {
             }
 
             let active_events = co1.flags.active_events | co2.flags.active_events;
+
+            if pair.has_any_active_contact
+                && active_events.contains(ActiveEvents::ACTIVE_COLLISION_EVENTS)
+            {
+                pair.emit_active_event(bodies, colliders, events);
+            }
 
             if pair.has_any_active_contact != had_any_active_contact {
                 if active_events.contains(ActiveEvents::COLLISION_EVENTS) {

--- a/src/pipeline/event_handler.rs
+++ b/src/pipeline/event_handler.rs
@@ -13,6 +13,10 @@ bitflags::bitflags! {
         /// If set, Rapier will call `EventHandler::handle_contact_force_event`
         /// whenever relevant for this collider.
         const CONTACT_FORCE_EVENTS = 0b0010;
+        /// If set, Rapier will call `EventHandler::handle_collision_event`
+        /// whenever relevant for this collider. Even after `CollisionEvent::Started`
+        /// has already been called.
+        const ACTIVE_COLLISION_EVENTS = 0b0100;
     }
 }
 


### PR DESCRIPTION
This adds support for receiving collision events even after Started was called.

**Why not just cache that ``CollisionEvent::Started`` was called and invoke logic every loop update until ``CollisionEvent::Stopped`` is called?**

This works great for linear games.  However, it makes games that make use of mechanics such as a network rollback algorithm difficult.  It requires us to look up the previous state in the rollback and see if a collision started or not, adding additional complexity.  It is much easier to keep each update loop as stateless as possible (ideally completely stateless).  Which means we can update the gameplay loop without having to concern ourselves with the previous or next state.

Feel free to accept or reject our PRs.  This is simply Lange Studio's way of giving back to beautiful open source devs such as yourselves as we migrate Blocky Ball from Unity to Godot!  We keep our own forks in sync and contribute back PRs so the original authors have the option to take our changes if they want them.  This is proving to be a great physics engine for us and I look forward to testing it at scale on our servers!

And if you are interested in the game that is soon to be leveraging this engine, here is a shameless link drop of our **Unity + Unity Physics** soon to be **Godot + Rapier** game Blocky Ball! :)

https://store.steampowered.com/app/1343040/Blocky_Ball/