### PR TITLE
chore: Bump testbed versions

### DIFF
--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.17.0"
+version = "0.17.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.17.0"
+version = "0.17.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.17.0"
+version = "0.17.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.17.0"
+version = "0.17.2"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"


### PR DESCRIPTION
Bevy has been at 0.11 for the testbed since 780ba4a216aa9ef68d7f10db4a2b67b866699f43.