### PR TITLE
Fix check for motor constraints on angular DoF

### DIFF
--- a/src/dynamics/solver/joint_constraint/joint_generic_velocity_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/joint_generic_velocity_constraint.rs
@@ -89,7 +89,7 @@ impl JointGenericVelocityConstraint {
 
         let start = len;
         for i in DIM..SPATIAL_DIM {
-            if (motor_axes >> DIM) & (1 << i) != 0 {
+            if motor_axes & (1 << i) != 0 {
                 out[len] = builder.motor_angular_generic(
                     params,
                     jacobians,
@@ -385,7 +385,7 @@ impl JointGenericVelocityGroundConstraint {
 
         let start = len;
         for i in DIM..SPATIAL_DIM {
-            if (motor_axes >> DIM) & (1 << i) != 0 {
+            if motor_axes & (1 << i) != 0 {
                 out[len] = builder.motor_angular_generic_ground(
                     params,
                     jacobians,


### PR DESCRIPTION
It looks like `motor_axes` is just a mask of axes, similar to `locked_axes`. It shouldn't need to be shifted by `DIM` for these checks.