### PR TITLE
add reapply_lost_speed to KinematicCharacterController

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -295,7 +295,7 @@ impl KinematicCharacterController {
 
                 let hit_info = self.compute_hit_info(hit);
                 let pre_slide_translation_remaining = translation_remaining;
-                // Try to go up stairs.
+                // Try to go upstairs.
                 if !self.handle_stairs(
                     bodies,
                     colliders,


### PR DESCRIPTION
Adds `reapply_lost_speed: bool` to KinematicCharacterController

When set to true, the velocity lost by sliding will be reapplied to the corrected direction
so the character moves at the same speed wether it's sliding or not
