### PR TITLE
Narrow-phase methods renames + some re-exports

### DIFF
--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -203,7 +203,7 @@ impl IslandManager {
             stack: &mut Vec<RigidBodyHandle>,
         ) {
             for collider_handle in &rb_colliders.0 {
-                for inter in narrow_phase.contacts_with(*collider_handle) {
+                for inter in narrow_phase.contact_pairs_with(*collider_handle) {
                     for manifold in &inter.manifolds {
                         if !manifold.data.solver_contacts.is_empty() {
                             let other = crate::utils::select_other(

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -17,7 +17,9 @@ pub use self::narrow_phase::NarrowPhase;
 pub use self::collider::{Collider, ColliderBuilder};
 pub use self::collider_set::ColliderSet;
 
-pub use parry::query::TrackedContact;
+pub use parry::bounding_volume::BoundingVolume;
+pub use parry::query::{PointQuery, PointQueryWithLocation, RayCast, TrackedContact};
+pub use parry::shape::SharedShape;
 
 use crate::math::{Real, Vector};
 
@@ -53,7 +55,6 @@ pub type RayIntersection = parry::query::RayIntersection;
 pub type PointProjection = parry::query::PointProjection;
 /// The the time of impact between two shapes.
 pub type TOI = parry::query::TOI;
-pub use parry::shape::SharedShape;
 
 bitflags::bitflags! {
     /// Flags providing more information regarding a collision event.

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -109,7 +109,10 @@ impl NarrowPhase {
     ///
     /// It is strongly recommended to use the [`NarrowPhase::contacts_with`] method instead. This
     /// method can be used if the generation number of the collider handle isn't known.
-    pub fn contacts_with_unknown_gen(&self, collider: u32) -> impl Iterator<Item = &ContactPair> {
+    pub fn contact_pairs_with_unknown_gen(
+        &self,
+        collider: u32,
+    ) -> impl Iterator<Item = &ContactPair> {
         self.graph_indices
             .get_unknown_gen(collider)
             .map(|id| id.contact_graph_index)
@@ -118,8 +121,12 @@ impl NarrowPhase {
             .map(|pair| pair.2)
     }
 
-    /// All the contacts involving the given collider.
-    pub fn contacts_with<'a>(
+    /// All the contact pairs involving the given collider.
+    ///
+    /// The returned contact pairs identify pairs of colliders with intersecting bounding-volumes.
+    /// To check if any geometric contact happened between the collider shapes, check
+    /// [`ContactPair::has_any_active_contact`].
+    pub fn contact_pairs_with<'a>(
         &self,
         collider: ColliderHandle,
     ) -> impl Iterator<Item = &ContactPair> {
@@ -131,11 +138,11 @@ impl NarrowPhase {
             .map(|pair| pair.2)
     }
 
-    /// All the intersections involving the given collider.
+    /// All the intersection pairs involving the given collider.
     ///
     /// It is strongly recommended to use the [`NarrowPhase::intersections_with`]  method instead.
     /// This method can be used if the generation number of the collider handle isn't known.
-    pub fn intersections_with_unknown_gen(
+    pub fn intersection_pairs_with_unknown_gen(
         &self,
         collider: u32,
     ) -> impl Iterator<Item = (ColliderHandle, ColliderHandle, bool)> + '_ {
@@ -150,8 +157,13 @@ impl NarrowPhase {
             })
     }
 
-    /// All the intersections involving the given collider.
-    pub fn intersections_with(
+    /// All the intersection pairs involving the given collider, where at least one collider
+    /// involved in the intersection is a sensor.
+    ///
+    /// The returned contact pairs identify pairs of colliders (where at least one is a sensor) with
+    /// intersecting bounding-volumes. To check if any geometric overlap happened between the collider shapes, check
+    /// the returned boolean.
+    pub fn intersection_pairs_with(
         &self,
         collider: ColliderHandle,
     ) -> impl Iterator<Item = (ColliderHandle, ColliderHandle, bool)> + '_ {

--- a/src/pipeline/collision_pipeline.rs
+++ b/src/pipeline/collision_pipeline.rs
@@ -210,7 +210,7 @@ mod tests {
 
         let mut hit = false;
 
-        for (_, _, intersecting) in narrow_phase.intersections_with(a_handle) {
+        for (_, _, intersecting) in narrow_phase.intersection_pairs_with(a_handle) {
             if intersecting {
                 hit = true;
             }
@@ -262,7 +262,7 @@ mod tests {
 
         let mut hit = false;
 
-        for (_, _, intersecting) in narrow_phase.intersections_with(a_handle) {
+        for (_, _, intersecting) in narrow_phase.intersection_pairs_with(a_handle) {
             if intersecting {
                 hit = true;
             }


### PR DESCRIPTION
- Renames `NarrowPhase::contacts_with` to`contact_pairs_with`; and `intersections_with` to `intersection_pairs_with` for better clarity.
- Re-export BoundingVolume, RayCast, PointQuery, PointQueryWithLocation from parry.

Fix #574.