### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,38 @@
-## Unlereased
+## v0.18.0 (24 Jan. 2024)
+The main highlight of this release is the implementation of a new non-linear constraints solver for better stability
+and increased convergence rates. See [#579](https://github.com/dimforge/rapier/pull/579) for additional information.
+
+In order to adjust the number of iterations of the new solver, simply adjust `IntegrationParameters::num_solver_iterations`.
+If recovering the old solver behavior is useful to you, call `IntegrationParameters::switch_to_standard_pgs_solver()`.
+
+It is now possible to specify some additional solver iteration for specific rigid-bodies (and everything interacting
+with it directly or indirectly through contacts and joints): `RigidBodyBuilder::additional_solver_iterations` and
+`RigidBodyBuilder::set_additional_solver_iterations`. This allows for higher-accuracy on subsets of the physics scene
+without affecting performance of the other parts of the simulation.
+
 ### Fix
 - Fix bug causing angular joint limits and motor to sometimes only take into account half of the angles specified by the user.
+- Fix bug where collisions would not be re-computed after a collider was re-enabled.
 
 ### Added
+- Add a `SpringJoint` and `SpringJointBuilder` for simulating springs with customizable stiffness and damping coefficients.
 - Add `SphericalJoint::local_frame1/2`, `::set_local_frame1/2`, and `SphericalJointBuilder::local_frame1/2` to set both
   the joint’s anchor and reference orientation.
 - Add `EffectiveCharacterMovement::is_sliding_down_slope` to indicate if the character controlled by the kinematic
   character controller is sliding on a slope that is too steep.
 - Add `Wheel::side_friction_stiffness` to customize the side friction applied to the vehicle controller’s wheel.
+- Add `Wheel::raycast_info` to access more wheel information relative to the ground.
 - Add `DebugRenderStyle::disabled_color_multiplier` to make the debug-renderer color disabled object differently.
+- Fix incorrect update of angular degrees-of-freedoms on spherical multibody joints.
+- Fix debug-renderer showing moved kinematic rigid-bodies only at their initial position.
 
 ### Modified
 - Make `Wheel::friction_slip` public to customize the front friction applied to the vehicle controller’s wheels.
 - Add the `DebugRenderBackend::filter_object` predicate that can be implemented to apply custom filtering rules
   on the objects being rendered.
-- Switch the testbed to `bevy 0.11` and use its new Gizmos API for rendering lines.
+- Switch the testbed to `bevy 0.12` and use its new Gizmos API for rendering lines.
+- Rename `NarrowPhase::contacts_with` to `NarrowPhase::contact_pairs_with`.
+- Rename `NarrowPhase::intersections_with` to `NarrowPhase::intersection_pairs_with`.
 
 ## v0.17.2 (26 Feb. 2023)
 ### Fix

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d-f64"
-version = "0.17.2"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier2d"
-version = "0.17.2"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d-f64"
-version = "0.17.2"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier3d"
-version = "0.17.2"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d-f64"
-version = "0.17.0"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = {version = "0.12", default-features = false, features = ["bevy_asset", "b
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.17.2"
+version = "0.18.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed2d"
-version = "0.17.0"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = {version = "0.12", default-features = false, features = ["bevy_sprite", "
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.17.2"
+version = "0.18.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d-f64"
-version = "0.17.0"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -58,5 +58,5 @@ bevy = {version = "0.12", default-features = false, features = ["bevy_winit", "t
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.17.2"
+version = "0.18.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rapier_testbed3d"
-version = "0.17.0"
+version = "0.18.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -62,5 +62,5 @@ bevy = {version = "0.12", default-features = false, features = ["bevy_winit", "t
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.17.2"
+version = "0.18.0"
 features = [ "serde-serialize", "debug-render", "profiler" ]


### PR DESCRIPTION
## v0.18.0 (24 Jan. 2024)
The main highlight of this release is the implementation of a new non-linear constraints solver for better stability
and increased convergence rates. See [#579](https://github.com/dimforge/rapier/pull/579) for additional information.

In order to adjust the number of iterations of the new solver, simply adjust `IntegrationParameters::num_solver_iterations`.
If recovering the old solver behavior is useful to you, call `IntegrationParameters::switch_to_standard_pgs_solver()`.

It is now possible to specify some additional solver iteration for specific rigid-bodies (and everything interacting
with it directly or indirectly through contacts and joints): `RigidBodyBuilder::additional_solver_iterations` and
`RigidBodyBuilder::set_additional_solver_iterations`. This allows for higher-accuracy on subsets of the physics scene
without affecting performance of the other parts of the simulation.

### Fix
- Fix bug causing angular joint limits and motor to sometimes only take into account half of the angles specified by the user.
- Fix bug where collisions would not be re-computed after a collider was re-enabled.

### Added
- Add a `SpringJoint` and `SpringJointBuilder` for simulating springs with customizable stiffness and damping coefficients.
- Add `SphericalJoint::local_frame1/2`, `::set_local_frame1/2`, and `SphericalJointBuilder::local_frame1/2` to set both
  the joint’s anchor and reference orientation.
- Add `EffectiveCharacterMovement::is_sliding_down_slope` to indicate if the character controlled by the kinematic
  character controller is sliding on a slope that is too steep.
- Add `Wheel::side_friction_stiffness` to customize the side friction applied to the vehicle controller’s wheel.
- Add `Wheel::raycast_info` to access more wheel information relative to the ground.
- Add `DebugRenderStyle::disabled_color_multiplier` to make the debug-renderer color disabled object differently.
- Fix incorrect update of angular degrees-of-freedoms on spherical multibody joints.
- Fix debug-renderer showing moved kinematic rigid-bodies only at their initial position.

### Modified
- Make `Wheel::friction_slip` public to customize the front friction applied to the vehicle controller’s wheels.
- Add the `DebugRenderBackend::filter_object` predicate that can be implemented to apply custom filtering rules
  on the objects being rendered.
- Switch the testbed to `bevy 0.11` and use its new Gizmos API for rendering lines.
- Switch the testbed to `bevy 0.12` and use its new Gizmos API for rendering lines.
- Rename `NarrowPhase::contacts_with` to `NarrowPhase::contact_pairs_with`.
- Rename `NarrowPhase::intersections_with` to `NarrowPhase::intersection_pairs_with`.