### PR TITLE
fix(user_changes): Fix RigidBodyType changed to Dynamic not added to active dynamic set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 
 - Fix crash when simulating a spring joint between two dynamic bodies.
+- Fix kinematic bodies not being affected by gravity after being switched back to dynamic.
 
 ## v0.18.0 (24 Jan. 2024)
 

--- a/src/pipeline/user_changes.rs
+++ b/src/pipeline/user_changes.rs
@@ -120,8 +120,8 @@ pub(crate) fn handle_user_changes_to_rigid_bodies(
                         islands.active_kinematic_set.push(*handle);
                     }
 
-                    // Push the body to the active set if it is not
-                    // sleeping and if it is not already inside of the active set, or if type changed to dynamic.
+                    // Push the body to the active set if it is not inside the active set yet, and
+                    // is either not longer sleeping or became dynamic.
                     if (changes.contains(RigidBodyChanges::SLEEP) || changes.contains(RigidBodyChanges::TYPE))
                         && rb.is_enabled()
                         && !rb.activation.sleeping // May happen if the body was put to sleep manually.

--- a/src/pipeline/user_changes.rs
+++ b/src/pipeline/user_changes.rs
@@ -121,8 +121,8 @@ pub(crate) fn handle_user_changes_to_rigid_bodies(
                     }
 
                     // Push the body to the active set if it is not
-                    // sleeping and if it is not already inside of the active set.
-                    if changes.contains(RigidBodyChanges::SLEEP)
+                    // sleeping and if it is not already inside of the active set, or if type changed to dynamic.
+                    if (changes.contains(RigidBodyChanges::SLEEP) || changes.contains(RigidBodyChanges::TYPE))
                         && rb.is_enabled()
                         && !rb.activation.sleeping // May happen if the body was put to sleep manually.
                         && rb.is_dynamic() // Only dynamic bodies are in the active dynamic set.


### PR DESCRIPTION
I ran into what I believe is a bug in which if a rigid body is changed to dynamic from kinematic, it may never end up in active dynamic set. This caused some issues including gravity not being integrated.

I believe in user changes we should add body to dynamic active if its type changed to dynamic. (And is enabled / not sleeping, the existing conditions).

I added a test to reproduce the issue. The failure seems to only occur if pipeline is stepped (at least) once after creating kinematic body, before switching to dynamic. Without the change to user_changes.rs, both conditions will fail in test.

Please let me know if I am somehow using API wrong and this is not a bug.