### PR TITLE
Fix KinematicCharacterController max_slope_climb_anlge handling

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -500,7 +500,7 @@ impl KinematicCharacterController {
         //       slow speed.
         let climbing = self.up.dot(&slope_translation) >= 0.0 && self.up.dot(&hit.normal1) > 0.0;
 
-        if climbing && angle_with_floor >= self.max_slope_climb_angle {
+        if climbing && angle_with_floor <= self.max_slope_climb_angle {
             // Prevent horizontal movement from pushing through the slope.
             vertical_translation
         } else if !climbing && angle_with_floor <= self.min_slope_slide_angle {


### PR DESCRIPTION
This fixes a previously flipped check for the max slope to climb. This caused the character controller to get stuck on near vertical walls rather than slide along them and to not climb slopes that it should. See #611.