### PR TITLE
Fix typo in clippy fix.

### DIFF
--- a/benchmarks2d/all_benchmarks2.rs
+++ b/benchmarks2d/all_benchmarks2.rs
@@ -66,7 +66,7 @@ pub fn main() {
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.
-    builders.sort_by(|a, b| match (a.0.starts_with('('), b.0.starts_with(')')) {
+    builders.sort_by(|a, b| match (a.0.starts_with('('), b.0.starts_with('(')) {
         (true, true) | (false, false) => a.0.cmp(b.0),
         (true, false) => Ordering::Greater,
         (false, true) => Ordering::Less,


### PR DESCRIPTION
This was supposed to be a `'('`, not a `')'`.

Fixes #596.