### PR TITLE
Fix one body joints limits not being flipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix kinematic bodies not being affected by gravity after being switched back to dynamic.
 - Fix regression on contact force reporting from contact force events.
 - Fix kinematic character controller getting stuck against vertical walls.
+- Fix joint limits/motors occasionally not being applied properly when one of the attached
+  rigid-bodies is fixed.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ resolver = "2"
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
-parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
-parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
+parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
+parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
+parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 [profile.release]
 #debug = true

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -496,6 +496,26 @@ impl GenericJoint {
         self.motors[i].damping = damping;
         self
     }
+
+    /// Flips the orientation of the joint, including limits and motors.
+    pub fn flip(&mut self) -> &mut Self {
+        std::mem::swap(&mut self.local_frame1, &mut self.local_frame2);
+
+        let coupled_bits = self.coupled_axes.bits();
+
+        for dim in 0..SPATIAL_DIM {
+            if coupled_bits & (1 << dim) == 0 {
+                let limit = self.limits[dim];
+                self.limits[dim].min = -limit.max;
+                self.limits[dim].max = -limit.min;
+            }
+
+            self.motors[dim].target_vel = -self.motors[dim].target_vel;
+            self.motors[dim].target_pos = -self.motors[dim].target_pos;
+        }
+
+        self
+    }
 }
 
 macro_rules! joint_conversion_methods(

--- a/src/dynamics/joint/generic_joint.rs
+++ b/src/dynamics/joint/generic_joint.rs
@@ -498,7 +498,7 @@ impl GenericJoint {
     }
 
     /// Flips the orientation of the joint, including limits and motors.
-    pub fn flip(&mut self) -> &mut Self {
+    pub fn flip(&mut self) {
         std::mem::swap(&mut self.local_frame1, &mut self.local_frame2);
 
         let coupled_bits = self.coupled_axes.bits();
@@ -513,8 +513,6 @@ impl GenericJoint {
             self.motors[dim].target_vel = -self.motors[dim].target_vel;
             self.motors[dim].target_pos = -self.motors[dim].target_pos;
         }
-
-        self
     }
 }
 

--- a/src/dynamics/solver/joint_constraint/joint_constraint_builder.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint_builder.rs
@@ -198,7 +198,7 @@ impl JointOneBodyConstraintBuilder {
 
         if flipped {
             std::mem::swap(&mut handle1, &mut handle2);
-            std::mem::swap(&mut joint_data.local_frame1, &mut joint_data.local_frame2);
+            joint_data.flip();
         };
 
         let rb1 = &bodies[handle1];

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -710,7 +710,6 @@ impl NarrowPhase {
             let co1 = &colliders[handle1];
             let co2 = &colliders[handle2];
 
-            // TODO: remove the `loop` once labels on blocks is stabilized.
             'emit_events: {
                 if !co1.changes.needs_narrow_phase_update()
                     && !co2.changes.needs_narrow_phase_update()
@@ -768,7 +767,6 @@ impl NarrowPhase {
                 edge.weight.intersecting = query_dispatcher
                     .intersection_test(&pos12, &*co1.shape, &*co2.shape)
                     .unwrap_or(false);
-                break 'emit_events;
             }
 
             let active_events = co1.flags.active_events | co2.flags.active_events;
@@ -812,7 +810,6 @@ impl NarrowPhase {
             let co1 = &colliders[pair.collider1];
             let co2 = &colliders[pair.collider2];
 
-            // TODO: remove the `loop` once labels on blocks are supported.
             'emit_events: {
                 if !co1.changes.needs_narrow_phase_update()
                     && !co2.changes.needs_narrow_phase_update()
@@ -1058,8 +1055,6 @@ impl NarrowPhase {
                     sort_solver_contacts(&mut manifold.data.solver_contacts);
                     */
                 }
-
-                break 'emit_events;
             }
 
             let active_events = co1.flags.active_events | co2.flags.active_events;


### PR DESCRIPTION
This PR attempts to fix #549

I am not 100% convenient in the correctness of this change, but it does fix the issue I was experiencing in my program. Especially the changes to `JointGenericVelocityOneBodyExternalConstraintBuilder`, since as far as I can tell this is used with multibodies, which I do not use. But I followed the same logic I did with `JointOneBodyConstraintBuilder`.

I also removed some outdated TODO comments that are no longer relevant I think.