### PR TITLE
feat: character controller improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,20 @@
 
 ### Modified
 
-- Renamed `BroadPhase` to `BroadPhaseMultiSap`. The `BroadPhase` is no a trait that can be
+**May shape-casting related functions/structs were renamed. Check out the CHANGELOG for parry 0.15.0 for
+additional details.**
+
+- Renamed `BroadPhase` to `BroadPhaseMultiSap`. The `BroadPhase` is now a trait that can be
   implemented for providing a custom broad-phase to rapier. Equivalently, the `DefaultBroadPhase` type
   alias can be used in place of `BroadPhaseMultiSap`.
+- The kinematic character controller autostepping is now disabled by default.
+- Add `KinematicCharacterController::normal_nudge_factor` used to help getting the character unstuck
+  due to rounding errors.
+- Rename `TOI` to `ShapeCastHit`.
+- Rename many fields from `toi` to `time_of_impact`.
+- The `QueryPipeline::cast_shape` method now takes a `ShapeCastOptions` instead of the `max_toi`
+  and `stop_at_penetration` parameters. This allows a couple of extra configurations, including the
+  ability to have the shape-cast target a specific distance instead of actual shape overlap.
 
 ## v0.18.0 (24 Jan. 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix crash when simulating a spring joint between two dynamic bodies.
 - Fix kinematic bodies not being affected by gravity after being switched back to dynamic.
 - Fix regression on contact force reporting from contact force events.
+- Fix kinematic character controller getting stuck against vertical walls.
 
 ### Added
 
@@ -16,7 +17,7 @@
 
 ### Modified
 
-**May shape-casting related functions/structs were renamed. Check out the CHANGELOG for parry 0.15.0 for
+**Many shape-casting related functions/structs were renamed. Check out the CHANGELOG for parry 0.15.0 for
 additional details.**
 
 - Renamed `BroadPhase` to `BroadPhaseMultiSap`. The `BroadPhase` is now a trait that can be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ resolver = "2"
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-#parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
-#parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-#parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
-#parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+parry2d = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
+parry3d = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
+parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
+parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "shape-cast-renamings" }
 
 [profile.release]
 #debug = true

--- a/examples2d/character_controller2.rs
+++ b/examples2d/character_controller2.rs
@@ -27,7 +27,7 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let rigid_body = RigidBodyBuilder::kinematic_position_based().translation(vector![-3.0, 5.0]);
     let character_handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(0.15, 0.3);
+    let collider = ColliderBuilder::capsule_y(0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
 
     /*
@@ -94,12 +94,16 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let wall_angle = PI / 2.;
     let wall_size = 2.0;
+    let wall_pos = vector![
+        ground_size + slope_size * 2.0 + impossible_slope_size + 0.35,
+        -ground_height + 2.5 * 2.3
+    ];
     let collider = ColliderBuilder::cuboid(wall_size, ground_height)
-        .translation(vector![
-            ground_size + slope_size * 2.0 + impossible_slope_size + 0.35,
-            -ground_height + 2.5 * 2.3
-        ])
+        .translation(wall_pos)
         .rotation(wall_angle);
+    colliders.insert(collider);
+
+    let collider = ColliderBuilder::cuboid(wall_size, ground_height).translation(wall_pos);
     colliders.insert(collider);
 
     /*

--- a/examples3d/character_controller3.rs
+++ b/examples3d/character_controller3.rs
@@ -13,21 +13,37 @@ pub fn init_world(testbed: &mut Testbed) {
     /*
      * Ground
      */
+    let scale = 1.0; // Set to a larger value to check if it still works with larger units.
     let ground_size = 5.0;
     let ground_height = 0.1;
 
-    let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0]);
+    let rigid_body =
+        RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0] * scale);
     let floor_handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
+    let collider = ColliderBuilder::cuboid(
+        ground_size * scale,
+        ground_height * scale,
+        ground_size * scale,
+    );
+    colliders.insert_with_parent(collider, floor_handle, &mut bodies);
+
+    let rigid_body =
+        RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, -ground_size] * scale); //.rotation(vector![-0.1, 0.0, 0.0]);
+    let floor_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(
+        ground_size * scale,
+        ground_size * scale,
+        ground_height * scale,
+    );
     colliders.insert_with_parent(collider, floor_handle, &mut bodies);
 
     /*
      * Character we will control manually.
      */
     let rigid_body =
-        RigidBodyBuilder::kinematic_position_based().translation(vector![-3.0, 5.0, 0.0]);
+        RigidBodyBuilder::kinematic_position_based().translation(vector![-3.0, 5.0, 0.0] * scale);
     let character_handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::capsule_y(0.3, 0.15); // 0.15, 0.3, 0.15);
+    let collider = ColliderBuilder::capsule_y(0.3 * scale, 0.15 * scale); // 0.15, 0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
 
     /*
@@ -47,9 +63,9 @@ pub fn init_world(testbed: &mut Testbed) {
                 let y = j as f32 * shift + centery;
                 let z = k as f32 * shift + centerx;
 
-                let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y, z]);
+                let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y, z] * scale);
                 let handle = bodies.insert(rigid_body);
-                let collider = ColliderBuilder::cuboid(rad, rad, rad);
+                let collider = ColliderBuilder::cuboid(rad * scale, rad * scale, rad * scale);
                 colliders.insert_with_parent(collider, handle, &mut bodies);
             }
         }
@@ -64,8 +80,12 @@ pub fn init_world(testbed: &mut Testbed) {
         let x = i as f32 * stair_width / 2.0;
         let y = i as f32 * stair_height * 1.5 + 3.0;
 
-        let collider = ColliderBuilder::cuboid(stair_width / 2.0, stair_height / 2.0, stair_width)
-            .translation(vector![x, y, 0.0]);
+        let collider = ColliderBuilder::cuboid(
+            stair_width / 2.0 * scale,
+            stair_height / 2.0 * scale,
+            stair_width * scale,
+        )
+        .translation(vector![x * scale, y * scale, 0.0]);
         colliders.insert(collider);
     }
 
@@ -74,9 +94,13 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let slope_angle = 0.2;
     let slope_size = 2.0;
-    let collider = ColliderBuilder::cuboid(slope_size, ground_height, slope_size)
-        .translation(vector![ground_size + slope_size, -ground_height + 0.4, 0.0])
-        .rotation(Vector::z() * slope_angle);
+    let collider = ColliderBuilder::cuboid(
+        slope_size * scale,
+        ground_height * scale,
+        slope_size * scale,
+    )
+    .translation(vector![ground_size + slope_size, -ground_height + 0.4, 0.0] * scale)
+    .rotation(Vector::z() * slope_angle);
     colliders.insert(collider);
 
     /*
@@ -84,22 +108,29 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let impossible_slope_angle = 0.9;
     let impossible_slope_size = 2.0;
-    let collider = ColliderBuilder::cuboid(slope_size, ground_height, ground_size)
-        .translation(vector![
+    let collider = ColliderBuilder::cuboid(
+        slope_size * scale,
+        ground_height * scale,
+        ground_size * scale,
+    )
+    .translation(
+        vector![
             ground_size + slope_size * 2.0 + impossible_slope_size - 0.9,
             -ground_height + 2.3,
             0.0
-        ])
-        .rotation(Vector::z() * impossible_slope_angle);
+        ] * scale,
+    )
+    .rotation(Vector::z() * impossible_slope_angle);
     colliders.insert(collider);
 
     /*
      * Create a moving platform.
      */
-    let body = RigidBodyBuilder::kinematic_velocity_based().translation(vector![-8.0, 1.5, 0.0]);
+    let body =
+        RigidBodyBuilder::kinematic_velocity_based().translation(vector![-8.0, 1.5, 0.0] * scale);
     // .rotation(-0.3);
     let platform_handle = bodies.insert(body);
-    let collider = ColliderBuilder::cuboid(2.0, ground_height, 2.0);
+    let collider = ColliderBuilder::cuboid(2.0 * scale, ground_height * scale, 2.0 * scale);
     colliders.insert_with_parent(collider, platform_handle, &mut bodies);
 
     /*
@@ -113,18 +144,18 @@ pub fn init_world(testbed: &mut Testbed) {
             + (j as f32 * ground_size.z / (nsubdivs as f32) / 2.0).cos()
     });
 
-    let collider =
-        ColliderBuilder::heightfield(heights, ground_size).translation(vector![-8.0, 5.0, 0.0]);
+    let collider = ColliderBuilder::heightfield(heights, ground_size * scale)
+        .translation(vector![-8.0, 5.0, 0.0] * scale);
     colliders.insert(collider);
 
     /*
      * A tilting dynamic body with a limited joint.
      */
-    let ground = RigidBodyBuilder::fixed().translation(vector![0.0, 5.0, 0.0]);
+    let ground = RigidBodyBuilder::fixed().translation(vector![0.0, 5.0, 0.0] * scale);
     let ground_handle = bodies.insert(ground);
-    let body = RigidBodyBuilder::dynamic().translation(vector![0.0, 5.0, 0.0]);
+    let body = RigidBodyBuilder::dynamic().translation(vector![0.0, 5.0, 0.0] * scale);
     let handle = bodies.insert(body);
-    let collider = ColliderBuilder::cuboid(1.0, 0.1, 2.0);
+    let collider = ColliderBuilder::cuboid(1.0 * scale, 0.1 * scale, 2.0 * scale);
     colliders.insert_with_parent(collider, handle, &mut bodies);
     let joint = RevoluteJointBuilder::new(Vector::z_axis()).limits([-0.3, 0.3]);
     impulse_joints.insert(ground_handle, handle, joint, true);
@@ -137,7 +168,7 @@ pub fn init_world(testbed: &mut Testbed) {
             (run_state.time * 2.0).sin() * 2.0,
             (run_state.time * 5.0).sin() * 1.5,
             0.0
-        ];
+        ] * scale;
         // let angvel = run_state.time.sin() * 0.5;
 
         // Update the velocity-based kinematic body by setting its velocity.

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -112,7 +112,7 @@ pub struct CharacterCollision {
     /// The translations that was still waiting to be applied to the character when the hit happens.
     pub translation_remaining: Vector<Real>,
     /// Geometric information about the hit.
-    pub toi: ShapeCastHit,
+    pub hit: ShapeCastHit,
 }
 
 /// A character controller for kinematic bodies.
@@ -261,7 +261,7 @@ impl KinematicCharacterController {
             }
 
             // 2. Cast towards the movement direction.
-            if let Some((handle, toi)) = queries.cast_shape(
+            if let Some((handle, hit)) = queries.cast_shape(
                 bodies,
                 colliders,
                 &(Translation::from(result.translation) * character_pos),
@@ -276,7 +276,7 @@ impl KinematicCharacterController {
                 filter,
             ) {
                 // We hit something, compute and apply the allowed interference-free translation.
-                let allowed_dist = toi.time_of_impact;
+                let allowed_dist = hit.time_of_impact;
                 let allowed_translation = *translation_dir * allowed_dist;
                 result.translation += allowed_translation;
                 translation_remaining -= allowed_translation;
@@ -286,10 +286,10 @@ impl KinematicCharacterController {
                     character_pos: Translation::from(result.translation) * character_pos,
                     translation_applied: result.translation,
                     translation_remaining,
-                    toi,
+                    hit,
                 });
 
-                let hit_info = self.compute_hit_info(toi);
+                let hit_info = self.compute_hit_info(hit);
 
                 // Try to go upstairs.
                 if !self.handle_stairs(
@@ -800,7 +800,7 @@ impl KinematicCharacterController {
         let extents = character_shape.compute_local_aabb().extents();
         let up_extent = extents.dot(&self.up.abs());
         let movement_to_transfer =
-            *collision.toi.normal1 * collision.translation_remaining.dot(&collision.toi.normal1);
+            *collision.hit.normal1 * collision.translation_remaining.dot(&collision.hit.normal1);
         let prediction = self.predict_ground(up_extent);
 
         // TODO: allow custom dispatchers.

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -1,11 +1,12 @@
 use crate::dynamics::RigidBodySet;
-use crate::geometry::{ColliderHandle, ColliderSet, ContactManifold, Shape, TOI};
+use crate::geometry::{ColliderHandle, ColliderSet, ContactManifold, Shape, ShapeCastHit};
 use crate::math::{Isometry, Point, Real, UnitVector, Vector};
 use crate::pipeline::{QueryFilter, QueryFilterFlags, QueryPipeline};
 use crate::utils;
 use na::{RealField, Vector2};
 use parry::bounding_volume::BoundingVolume;
 use parry::math::Translation;
+use parry::query::details::ShapeCastOptions;
 use parry::query::{DefaultQueryDispatcher, PersistentQueryDispatcher};
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -15,13 +16,13 @@ pub enum CharacterLength {
     /// The length is specified relative to some of the character shape’s size.
     ///
     /// For example setting `CharacterAutostep::max_height` to `CharacterLength::Relative(0.1)`
-    /// for a shape with an height equal to 20.0 will result in a maximum step height
+    /// for a shape with a height equal to 20.0 will result in a maximum step height
     /// of `0.1 * 20.0 = 2.0`.
     Relative(Real),
     /// The length is specified as an absolute value, independent from the character shape’s size.
     ///
     /// For example setting `CharacterAutostep::max_height` to `CharacterLength::Relative(0.1)`
-    /// for a shape with an height equal to 20.0 will result in a maximum step height
+    /// for a shape with a height equal to 20.0 will result in a maximum step height
     /// of `0.1` (the shape height is ignored in for this value).
     Absolute(Real),
 }
@@ -55,6 +56,13 @@ impl CharacterLength {
     }
 }
 
+#[derive(Debug)]
+struct HitInfo {
+    toi: ShapeCastHit,
+    is_wall: bool,
+    is_nonslip_slope: bool,
+}
+
 /// Configuration for the auto-stepping character controller feature.
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -77,6 +85,21 @@ impl Default for CharacterAutostep {
     }
 }
 
+#[derive(Debug)]
+struct HitDecomposition {
+    normal_part: Vector<Real>,
+    horizontal_tangent: Vector<Real>,
+    vertical_tangent: Vector<Real>,
+    // NOTE: we don’t store the penetration part since we don’t really need it
+    //       for anything.
+}
+
+impl HitDecomposition {
+    pub fn unconstrained_slide_part(&self) -> Vector<Real> {
+        self.normal_part + self.horizontal_tangent + self.vertical_tangent
+    }
+}
+
 /// A collision between the character and its environment during its movement.
 #[derive(Copy, Clone, Debug)]
 pub struct CharacterCollision {
@@ -89,7 +112,7 @@ pub struct CharacterCollision {
     /// The translations that was still waiting to be applied to the character when the hit happens.
     pub translation_remaining: Vector<Real>,
     /// Geometric information about the hit.
-    pub toi: TOI,
+    pub toi: ShapeCastHit,
 }
 
 /// A character controller for kinematic bodies.
@@ -105,7 +128,10 @@ pub struct KinematicCharacterController {
     pub offset: CharacterLength,
     /// Should the character try to slide against the floor if it hits it?
     pub slide: bool,
-    /// Should the character automatically step over small obstacles?
+    /// Should the character automatically step over small obstacles? (disabled by default)
+    ///
+    /// Note that autostepping is currently a very computationally expensive feature, so it
+    /// is disabled by default.
     pub autostep: Option<CharacterAutostep>,
     /// The maximum angle (radians) between the floor’s normal and the `up` vector that the
     /// character is able to climb.
@@ -116,6 +142,15 @@ pub struct KinematicCharacterController {
     /// Should the character be automatically snapped to the ground if the distance between
     /// the ground and its feed are smaller than the specified threshold?
     pub snap_to_ground: Option<CharacterLength>,
+    /// Increase this number if your character appears to get stuck when sliding against surfaces.
+    ///
+    /// This is a small distance applied to the movement toward the contact normals of shapes hit
+    /// by the character controller. This helps shape-casting not getting stuck in an alway-penetrating
+    /// state during the sliding calculation.
+    ///
+    /// This value should remain fairly small since it can introduce artificial "bumps" when sliding
+    /// along a flat surface.
+    pub normal_nudge_factor: Real,
 }
 
 impl Default for KinematicCharacterController {
@@ -128,6 +163,7 @@ impl Default for KinematicCharacterController {
             max_slope_climb_angle: Real::frac_pi_4(),
             min_slope_slide_angle: Real::frac_pi_4(),
             snap_to_ground: Some(CharacterLength::Relative(0.2)),
+            normal_nudge_factor: 1.0e-4,
         }
     }
 }
@@ -231,13 +267,16 @@ impl KinematicCharacterController {
                 &(Translation::from(result.translation) * character_pos),
                 &translation_dir,
                 character_shape,
-                translation_dist + offset,
-                false,
+                ShapeCastOptions {
+                    target_distance: offset,
+                    stop_at_penetration: false,
+                    max_time_of_impact: translation_dist,
+                    compute_impact_geometry_on_penetration: true,
+                },
                 filter,
             ) {
-                // We hit something, compute the allowed self.
-                let allowed_dist =
-                    (toi.toi - (-toi.normal1.dot(&translation_dir)) * offset).max(0.0);
+                // We hit something, compute and apply the allowed interference-free translation.
+                let allowed_dist = toi.time_of_impact;
                 let allowed_translation = *translation_dir * allowed_dist;
                 result.translation += allowed_translation;
                 translation_remaining -= allowed_translation;
@@ -250,7 +289,9 @@ impl KinematicCharacterController {
                     toi,
                 });
 
-                // Try to go up stairs.
+                let hit_info = self.compute_hit_info(toi);
+
+                // Try to go upstairs.
                 if !self.handle_stairs(
                     bodies,
                     colliders,
@@ -260,12 +301,18 @@ impl KinematicCharacterController {
                     &dims,
                     filter,
                     handle,
+                    &hit_info,
                     &mut translation_remaining,
                     &mut result,
                 ) {
                     // No stairs, try to move along slopes.
-                    translation_remaining =
-                        self.handle_slopes(&toi, &translation_remaining, &mut result);
+                    translation_remaining = self.handle_slopes(
+                        &hit_info,
+                        &desired_translation,
+                        &translation_remaining,
+                        self.normal_nudge_factor,
+                        &mut result,
+                    );
                 }
             } else {
                 // No interference along the path.
@@ -319,7 +366,7 @@ impl KinematicCharacterController {
         dims: &Vector2<Real>,
         filter: QueryFilter,
         result: &mut EffectiveCharacterMovement,
-    ) -> Option<(ColliderHandle, TOI)> {
+    ) -> Option<(ColliderHandle, ShapeCastHit)> {
         if let Some(snap_distance) = self.snap_to_ground {
             if result.translation.dot(&self.up) < -1.0e-5 {
                 let snap_distance = snap_distance.eval(dims.y);
@@ -330,12 +377,16 @@ impl KinematicCharacterController {
                     character_pos,
                     &-self.up,
                     character_shape,
-                    snap_distance + offset,
-                    false,
+                    ShapeCastOptions {
+                        target_distance: offset,
+                        stop_at_penetration: false,
+                        max_time_of_impact: snap_distance,
+                        compute_impact_geometry_on_penetration: true,
+                    },
                     filter,
                 ) {
                     // Apply the snap.
-                    result.translation -= *self.up * (hit.toi - offset).max(0.0);
+                    result.translation -= *self.up * hit.time_of_impact;
                     result.grounded = true;
                     return Some((hit_handle, hit));
                 }
@@ -481,42 +532,91 @@ impl KinematicCharacterController {
 
     fn handle_slopes(
         &self,
-        hit: &TOI,
+        hit: &HitInfo,
+        movement_input: &Vector<Real>,
         translation_remaining: &Vector<Real>,
+        normal_nudge_factor: Real,
         result: &mut EffectiveCharacterMovement,
     ) -> Vector<Real> {
-        let [vertical_translation, horizontal_translation] =
-            self.split_into_components(translation_remaining);
-        let slope_translation = subtract_hit(*translation_remaining, hit);
+        let [_vertical_input, horizontal_input] = self.split_into_components(movement_input);
+        let horiz_input_decomp = self.decompose_hit(&horizontal_input, &hit.toi);
+        let input_decomp = self.decompose_hit(&movement_input, &hit.toi);
 
-        // Check if there is a slope to climb.
-        let angle_with_floor = self.up.angle(&hit.normal1);
+        let decomp = self.decompose_hit(&translation_remaining, &hit.toi);
 
-        // We are climbing if the movement along the slope goes upward, and the angle with the
-        // floor is smaller than pi/2 (in which case we hit some some sort of ceiling).
-        //
-        // NOTE: part of the slope will already be handled by auto-stepping if it was enabled.
-        //       Therefore, `climbing` may not always be `true` when climbing on a slope at
-        //       slow speed.
-        let climbing = self.up.dot(&slope_translation) >= 0.0 && self.up.dot(&hit.normal1) > 0.0;
+        // An object is trying to slip if the tangential movement induced by its vertical movement
+        // points downward.
+        let slipping_intent = self.up.dot(&horiz_input_decomp.vertical_tangent) < 0.0;
+        let slipping = self.up.dot(&decomp.vertical_tangent) < 0.0;
 
-        if climbing && angle_with_floor >= self.max_slope_climb_angle {
-            // Prevent horizontal movement from pushing through the slope.
-            vertical_translation
-        } else if !climbing && angle_with_floor <= self.min_slope_slide_angle {
+        // An object is trying to climb if its indirect vertical motion points upward.
+        let climbing_intent = self.up.dot(&input_decomp.vertical_tangent) > 0.0;
+        let climbing = self.up.dot(&decomp.vertical_tangent) > 0.0;
+
+        let allowed_movement = if hit.is_wall && climbing && !climbing_intent {
+            // Can’t climb the slope, remove the vertical tangent motion induced by the forward motion.
+            decomp.horizontal_tangent + decomp.normal_part
+        } else if hit.is_nonslip_slope && slipping && !slipping_intent {
             // Prevent the vertical movement from sliding down.
-            horizontal_translation
+            decomp.horizontal_tangent + decomp.normal_part
         } else {
-            // Let it slide
+            // Let it slide (including climbing the slope).
             result.is_sliding_down_slope = true;
-            slope_translation
-        }
+            decomp.unconstrained_slide_part()
+        };
+
+        allowed_movement + *hit.toi.normal1 * normal_nudge_factor
     }
 
     fn split_into_components(&self, translation: &Vector<Real>) -> [Vector<Real>; 2] {
         let vertical_translation = *self.up * (self.up.dot(translation));
         let horizontal_translation = *translation - vertical_translation;
         [vertical_translation, horizontal_translation]
+    }
+
+    fn compute_hit_info(&self, toi: ShapeCastHit) -> HitInfo {
+        let angle_with_floor = self.up.angle(&toi.normal1);
+        let is_ceiling = self.up.dot(&toi.normal1) < 0.0;
+        let is_wall = angle_with_floor >= self.max_slope_climb_angle && !is_ceiling;
+        let is_nonslip_slope = angle_with_floor <= self.min_slope_slide_angle;
+
+        HitInfo {
+            toi,
+            is_wall,
+            is_nonslip_slope,
+        }
+    }
+
+    fn decompose_hit(&self, translation: &Vector<Real>, hit: &ShapeCastHit) -> HitDecomposition {
+        let dist_to_surface = translation.dot(&hit.normal1);
+        let normal_part;
+        let penetration_part;
+
+        if dist_to_surface < 0.0 {
+            normal_part = Vector::zeros();
+            penetration_part = dist_to_surface * *hit.normal1;
+        } else {
+            penetration_part = Vector::zeros();
+            normal_part = dist_to_surface * *hit.normal1;
+        }
+
+        let tangent = translation - normal_part - penetration_part;
+        #[cfg(feature = "dim3")]
+        let horizontal_tangent_dir = hit.normal1.cross(&self.up);
+        #[cfg(feature = "dim2")]
+        let horizontal_tangent_dir = Vector::zeros();
+
+        let horizontal_tangent_dir = horizontal_tangent_dir
+            .try_normalize(1.0e-5)
+            .unwrap_or_default();
+        let horizontal_tangent = tangent.dot(&horizontal_tangent_dir) * horizontal_tangent_dir;
+        let vertical_tangent = tangent - horizontal_tangent;
+
+        HitDecomposition {
+            normal_part,
+            horizontal_tangent,
+            vertical_tangent,
+        }
     }
 
     fn compute_dims(&self, character_shape: &dyn Shape) -> Vector2<Real> {
@@ -536,13 +636,18 @@ impl KinematicCharacterController {
         dims: &Vector2<Real>,
         mut filter: QueryFilter,
         stair_handle: ColliderHandle,
+        hit: &HitInfo,
         translation_remaining: &mut Vector<Real>,
         result: &mut EffectiveCharacterMovement,
     ) -> bool {
-        let autostep = match self.autostep {
-            Some(autostep) => autostep,
-            None => return false,
+        let Some(autostep) = self.autostep else {
+            return false;
         };
+
+        // Only try to autostep on walls.
+        if !hit.is_wall {
+            return false;
+        }
 
         let offset = self.offset.eval(dims.y);
         let min_width = autostep.min_width.eval(dims.x) + offset;
@@ -565,12 +670,10 @@ impl KinematicCharacterController {
 
         let shifted_character_pos = Translation::from(*self.up * max_height) * character_pos;
 
-        let horizontal_dir = match (*translation_remaining
+        let Some(horizontal_dir) = (*translation_remaining
             - *self.up * translation_remaining.dot(&self.up))
-        .try_normalize(1.0e-5)
-        {
-            Some(dir) => dir,
-            None => return false,
+        .try_normalize(1.0e-5) else {
+            return false;
         };
 
         if queries
@@ -580,8 +683,12 @@ impl KinematicCharacterController {
                 character_pos,
                 &self.up,
                 character_shape,
-                max_height,
-                false,
+                ShapeCastOptions {
+                    target_distance: offset,
+                    stop_at_penetration: false,
+                    max_time_of_impact: max_height,
+                    compute_impact_geometry_on_penetration: true,
+                },
                 filter,
             )
             .is_some()
@@ -597,8 +704,12 @@ impl KinematicCharacterController {
                 &shifted_character_pos,
                 &horizontal_dir,
                 character_shape,
-                min_width,
-                false,
+                ShapeCastOptions {
+                    target_distance: offset,
+                    stop_at_penetration: false,
+                    max_time_of_impact: min_width,
+                    compute_impact_geometry_on_penetration: true,
+                },
                 filter,
             )
             .is_some()
@@ -615,8 +726,12 @@ impl KinematicCharacterController {
             &(Translation::from(horizontal_dir * min_width) * shifted_character_pos),
             &-self.up,
             character_shape,
-            max_height,
-            false,
+            ShapeCastOptions {
+                target_distance: offset,
+                stop_at_penetration: false,
+                max_time_of_impact: max_height,
+                compute_impact_geometry_on_penetration: true,
+            },
             filter,
         ) {
             let [vertical_slope_translation, horizontal_slope_translation] = self
@@ -642,11 +757,15 @@ impl KinematicCharacterController {
                     &(Translation::from(horizontal_dir * min_width) * shifted_character_pos),
                     &-self.up,
                     character_shape,
-                    max_height,
-                    false,
+                    ShapeCastOptions {
+                        target_distance: offset,
+                        stop_at_penetration: false,
+                        max_time_of_impact: max_height,
+                        compute_impact_geometry_on_penetration: true,
+                    },
                     filter,
                 )
-                .map(|hit| hit.1.toi)
+                .map(|hit| hit.1.time_of_impact)
                 .unwrap_or(max_height);
 
         // Remove the step height from the vertical part of the self.
@@ -748,7 +867,7 @@ impl KinematicCharacterController {
     }
 }
 
-fn subtract_hit(translation: Vector<Real>, hit: &TOI) -> Vector<Real> {
+fn subtract_hit(translation: Vector<Real>, hit: &ShapeCastHit) -> Vector<Real> {
     let surface_correction = (-translation).dot(&hit.normal1).max(0.0);
     // This fixes some instances of moving through walls
     let surface_correction = surface_correction * (1.0 + 1.0e-5);

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -145,7 +145,7 @@ pub struct KinematicCharacterController {
     /// Increase this number if your character appears to get stuck when sliding against surfaces.
     ///
     /// This is a small distance applied to the movement toward the contact normals of shapes hit
-    /// by the character controller. This helps shape-casting not getting stuck in an alway-penetrating
+    /// by the character controller. This helps shape-casting not getting stuck in an always-penetrating
     /// state during the sliding calculation.
     ///
     /// This value should remain fairly small since it can introduce artificial "bumps" when sliding

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -540,9 +540,9 @@ impl KinematicCharacterController {
     ) -> Vector<Real> {
         let [_vertical_input, horizontal_input] = self.split_into_components(movement_input);
         let horiz_input_decomp = self.decompose_hit(&horizontal_input, &hit.toi);
-        let input_decomp = self.decompose_hit(&movement_input, &hit.toi);
+        let input_decomp = self.decompose_hit(movement_input, &hit.toi);
 
-        let decomp = self.decompose_hit(&translation_remaining, &hit.toi);
+        let decomp = self.decompose_hit(translation_remaining, &hit.toi);
 
         // An object is trying to slip if the tangential movement induced by its vertical movement
         // points downward.

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -159,7 +159,7 @@ impl Default for KinematicCharacterController {
             up: Vector::y_axis(),
             offset: CharacterLength::Relative(0.01),
             slide: true,
-            autostep: Some(CharacterAutostep::default()),
+            autostep: None,
             max_slope_climb_angle: Real::frac_pi_4(),
             min_slope_slide_angle: Real::frac_pi_4(),
             snap_to_ground: Some(CharacterLength::Relative(0.2)),

--- a/src/control/ray_cast_vehicle_controller.rs
+++ b/src/control/ray_cast_vehicle_controller.rs
@@ -341,7 +341,7 @@ impl DynamicRayCastVehicleController {
         wheel.raycast_info.ground_object = None;
 
         if let Some((collider_hit, mut hit)) = hit {
-            if hit.toi == 0.0 {
+            if hit.time_of_impact == 0.0 {
                 let collider = &colliders[collider_hit];
                 let up_ray = Ray::new(source + rayvector, -rayvector);
                 if let Some(hit2) =
@@ -362,7 +362,7 @@ impl DynamicRayCastVehicleController {
             wheel.raycast_info.is_in_contact = true;
             wheel.raycast_info.ground_object = Some(collider_hit);
 
-            let hit_distance = hit.toi * raylen;
+            let hit_distance = hit.time_of_impact * raylen;
             wheel.raycast_info.suspension_length = hit_distance - wheel.radius;
 
             // clamp on max suspension travel
@@ -372,7 +372,7 @@ impl DynamicRayCastVehicleController {
                 .raycast_info
                 .suspension_length
                 .clamp(min_suspension_length, max_suspension_length);
-            wheel.raycast_info.contact_point_ws = ray.point_at(hit.toi);
+            wheel.raycast_info.contact_point_ws = ray.point_at(hit.time_of_impact);
 
             let denominator = wheel
                 .raycast_info

--- a/src/dynamics/ccd/toi_entry.rs
+++ b/src/dynamics/ccd/toi_entry.rs
@@ -129,7 +129,7 @@ impl TOIEntry {
         //     .ok();
 
         let res_toi = query_dispatcher
-            .nonlinear_time_of_impact(
+            .cast_shapes_nonlinear(
                 &motion_c1,
                 co1.shape.as_ref(),
                 &motion_c2,
@@ -143,7 +143,7 @@ impl TOIEntry {
         let toi = res_toi??;
 
         Some(Self::new(
-            toi.toi,
+            toi.time_of_impact,
             ch1,
             co1.parent.map(|p| p.handle),
             ch2,

--- a/src/dynamics/integration_parameters.rs
+++ b/src/dynamics/integration_parameters.rs
@@ -49,12 +49,12 @@ pub struct IntegrationParameters {
     /// (default `1.0`).
     pub warmstart_coefficient: Real,
 
-    /// The approximate size of most dynamic objects in the scale.
+    /// The approximate size of most dynamic objects in the scene.
     ///
     /// This value is used internally to estimate some length-based tolerance. In particular, the
-    /// values [`IntegrationParametres::allowed_linear_error`],
-    /// [`IntegrationParametres::max_penetration_correction`],
-    /// [`IntegrationParametres::prediction_distance`], [`RigidBodyActivation::linear_threshold`]
+    /// values [`IntegrationParameters::allowed_linear_error`],
+    /// [`IntegrationParameters::max_penetration_correction`],
+    /// [`IntegrationParameters::prediction_distance`], [`RigidBodyActivation::linear_threshold`]
     /// are scaled by this value implicitly.
     ///
     /// This value can be understood as the number of units-per-meter in your physical world compared

--- a/src/geometry/broad_phase.rs
+++ b/src/geometry/broad_phase.rs
@@ -12,7 +12,7 @@ pub type BroadPhaseProxyIndex = u32;
 /// two objects don’t actually touch, but it is incorrect to remove a pair between two objects
 /// that are still touching. In other words, it can have false-positive (though these induce
 /// some computational overhead on the narrow-phase), but cannot have false-negative.
-pub trait BroadPhase {
+pub trait BroadPhase: Send + Sync + 'static {
     /// Updates the broad-phase.
     ///
     /// The results must be output through the `events` struct. The broad-phase algorithm is only

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -158,12 +158,16 @@ impl Collider {
         self.flags.active_collision_types = active_collision_types;
     }
 
-    /// The collision skin of this collider.
+    /// The contact skin of this collider.
+    ///
+    /// See the documentation of [`ColliderBuilder::contact_skin`] for details.
     pub fn contact_skin(&self) -> Real {
         self.contact_skin
     }
 
-    /// Sets the collision skin of this collider.
+    /// Sets the contact skin of this collider.
+    ///
+    /// See the documentation of [`ColliderBuilder::contact_skin`] for details.
     pub fn set_contact_skin(&mut self, skin_thickness: Real) {
         self.contact_skin = skin_thickness;
     }
@@ -451,7 +455,7 @@ impl Collider {
 
     /// Compute the axis-aligned bounding box of this collider.
     ///
-    /// This AABB doesn’t take into account the collider’s collision skin.
+    /// This AABB doesn’t take into account the collider’s contact skin.
     /// [`Collider::contact_skin`].
     pub fn compute_aabb(&self) -> Aabb {
         self.shape.compute_aabb(&self.pos)
@@ -519,7 +523,7 @@ pub struct ColliderBuilder {
     pub enabled: bool,
     /// The total force magnitude beyond which a contact force event can be emitted.
     pub contact_force_event_threshold: Real,
-    /// An extract thickness around the collider shape to keep them further apart when in collision.
+    /// An extra thickness around the collider shape to keep them further apart when colliding.
     pub contact_skin: Real,
 }
 
@@ -973,12 +977,12 @@ impl ColliderBuilder {
         self
     }
 
-    /// Sets the collision skin of the collider.
+    /// Sets the contact skin of the collider.
     ///
-    /// The collision skin acts as if the collider was enlarged with a skin of width `skin_thickness`
+    /// The contact skin acts as if the collider was enlarged with a skin of width `skin_thickness`
     /// around it, keeping objects further apart when colliding.
     ///
-    /// A non-zero collision skin can increase performance, and in some cases, stability. However
+    /// A non-zero contact skin can increase performance, and in some cases, stability. However
     /// it creates a small gap between colliding object (equal to the sum of their skin). If the
     /// skin is sufficiently small, this might not be visually significant or can be hidden by the
     /// rendering assets.

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -51,8 +51,8 @@ pub type Ray = parry::query::Ray;
 pub type RayIntersection = parry::query::RayIntersection;
 /// The projection of a point on a collider.
 pub type PointProjection = parry::query::PointProjection;
-/// The time of impact between two shapes.
-pub type TOI = parry::query::TOI;
+/// The result of a shape-cast between two shapes.
+pub type ShapeCastHit = parry::query::ShapeCastHit;
 /// The default broad-phase implementation recommended for general-purpose usage.
 pub type DefaultBroadPhase = BroadPhaseMultiSap;
 

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -9,12 +9,12 @@ use parry::query::details::{
     NonlinearTOICompositeShapeShapeBestFirstVisitor, NormalConstraints,
     PointCompositeShapeProjBestFirstVisitor, PointCompositeShapeProjWithFeatureBestFirstVisitor,
     RayCompositeShapeToiAndNormalBestFirstVisitor, RayCompositeShapeToiBestFirstVisitor,
-    TOICompositeShapeShapeBestFirstVisitor,
+    ShapeCastOptions, TOICompositeShapeShapeBestFirstVisitor,
 };
 use parry::query::visitors::{
     BoundingVolumeIntersectionsVisitor, PointIntersectionsVisitor, RayIntersectionsVisitor,
 };
-use parry::query::{DefaultQueryDispatcher, NonlinearRigidMotion, QueryDispatcher, TOI};
+use parry::query::{DefaultQueryDispatcher, NonlinearRigidMotion, QueryDispatcher, ShapeCastHit};
 use parry::shape::{FeatureId, Shape, TypedSimdCompositeShape};
 use std::sync::Arc;
 
@@ -679,10 +679,9 @@ impl QueryPipeline {
         shape_pos: &Isometry<Real>,
         shape_vel: &Vector<Real>,
         shape: &dyn Shape,
-        max_toi: Real,
-        stop_at_penetration: bool,
+        options: ShapeCastOptions,
         filter: QueryFilter,
-    ) -> Option<(ColliderHandle, TOI)> {
+    ) -> Option<(ColliderHandle, ShapeCastHit)> {
         let pipeline_shape = self.as_composite_shape(bodies, colliders, filter);
         let mut visitor = TOICompositeShapeShapeBestFirstVisitor::new(
             &*self.query_dispatcher,
@@ -690,8 +689,7 @@ impl QueryPipeline {
             shape_vel,
             &pipeline_shape,
             shape,
-            max_toi,
-            stop_at_penetration,
+            options,
         );
         self.qbvh.traverse_best_first(&mut visitor).map(|h| h.1)
     }
@@ -725,7 +723,7 @@ impl QueryPipeline {
         end_time: Real,
         stop_at_penetration: bool,
         filter: QueryFilter,
-    ) -> Option<(ColliderHandle, TOI)> {
+    ) -> Option<(ColliderHandle, ShapeCastHit)> {
         let pipeline_shape = self.as_composite_shape(bodies, colliders, filter);
         let pipeline_motion = NonlinearRigidMotion::identity();
         let mut visitor = NonlinearTOICompositeShapeShapeBestFirstVisitor::new(


### PR DESCRIPTION
The main objective for this PR is to fix the issue where character controllers might get stuck against vertical walls.

- The kinematic character controller autostepping is now disabled by default.
- Add `KinematicCharacterController::normal_nudge_factor` used to help getting the character unstuck
  due to rounding errors.
- Rename `TOI` to `ShapeCastHit`.
- Rename many fields from `toi` to `time_of_impact`.
- The `QueryPipeline::cast_shape` method now takes a `ShapeCastOptions` instead of the `max_toi`
  and `stop_at_penetration` parameters. This allows a couple of extra configurations, including the
  ability to have the shape-cast target a specific distance instead of actual shape overlap.

Close https://github.com/dimforge/rapier/pull/612 (proposed change was incorrect)
Fix #418
Fix #611 
Fix https://github.com/dimforge/bevy_rapier/issues/489