### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.19.0 (05 May 2024)
 
 ### Fix
 
@@ -8,14 +8,32 @@
 - Fix kinematic character controller getting stuck against vertical walls.
 - Fix joint limits/motors occasionally not being applied properly when one of the attached
   rigid-bodies is fixed.
+- Fix an issue where contacts would be completely ignored between two convex shapes.
 
 ### Added
+
+**Many stability improvements were added as part of this release. To see illustrations of some of these
+changes, see [#625](https://github.com/dimforge/rapier/pull/625).**
 
 - Add `RigidBody::predict_position_using_velocity` to predict the next position of the rigid-body
   based only on its current velocity.
 - Add `Collider::copy_from` to copy most collider attributes to an existing collider.
 - Add `RigidBody::copy_from` to copy most rigid-body attributes to an existing rigid-body.
 - Add the `BroadPhase` trait and expect an implementor of this trait as input to `PhysicsPipeline::step`.
+- Implement a 2D block-solver as well as warmstarting. Significantly improves stacking capabilities. Generally reduces
+  the "pop" effect that can happen due to penetration corrections.
+- Add `RigidBodyBuilder::soft_ccd_prediction` and `RigidBody::set_soft_ccd_prediction` to enable `soft-ccd`: a form of
+  CCD based on predictive contacts. This is helpful for objects moving moderately fast. This form of CCD is generally
+  cheaper than the normal (time-dropping) CCD implemented so far. It is possible to combine both soft-ccd and
+  time-dropping ccd.
+- Add a `ColliderBuilder::contact_skin`, `Collider::set_contact_skin`, and `Collider::contact_skin`. This forces the
+  solver te maintain a gap between colliders with non-zero contact skin, as if they had a slight margin around them.
+  This helps performance and stability for thin objects (like triangle meshes).
+- Internal edges were reworked to avoid dropping contacts that would help with stability, and improve stability of
+  collisions between two triangle meshes. The `TriMeshFlags::FIX_INTERNAL_EDGES` and
+  `HeightFieldFlags::FIX_INTERNAL_EDGES` flags were added to enable internal edges handling.
+- Add `IntegrationParameters::length_units` to automatically adjust internal thresholds when the user relies on custom
+  length units (e.g. pixels in 2D).
 
 ### Modified
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ resolver = "2"
 
 #kiss3d = { git = "https://github.com/sebcrozet/kiss3d" }
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
-parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry2d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry3d = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
+#parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 [profile.release]
 #debug = true

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -52,7 +52,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.32"
-parry2d-f64 = "0.14.0"
+parry2d-f64 = "0.15.0"
 simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -52,7 +52,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.32"
-parry2d = "0.14.0"
+parry2d = "0.15.0"
 simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -52,7 +52,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.32"
-parry3d-f64 = "0.14.0"
+parry3d-f64 = "0.15.0"
 simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -52,7 +52,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.32"
-parry3d = "0.14.0"
+parry3d = "0.15.0"
 simba = "0.8"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_asset", "
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.18.0"
+version = "0.19.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_sprite", 
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.18.0"
+version = "0.19.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -58,5 +58,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.18.0"
+version = "0.19.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -62,5 +62,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.18.0"
+version = "0.19.0"
 features = ["serde-serialize", "debug-render", "profiler"]


### PR DESCRIPTION
### Fix

- Fix crash when simulating a spring joint between two dynamic bodies.
- Fix kinematic bodies not being affected by gravity after being switched back to dynamic.
- Fix regression on contact force reporting from contact force events.
- Fix kinematic character controller getting stuck against vertical walls.
- Fix joint limits/motors occasionally not being applied properly when one of the attached
  rigid-bodies is fixed.
- Fix an issue where contacts would be completely ignored between two convex shapes.

### Added

**Many stability improvements were added as part of this release. To see illustrations of some of these
changes, see [#625](https://github.com/dimforge/rapier/pull/625).**

- Add `RigidBody::predict_position_using_velocity` to predict the next position of the rigid-body
  based only on its current velocity.
- Add `Collider::copy_from` to copy most collider attributes to an existing collider.
- Add `RigidBody::copy_from` to copy most rigid-body attributes to an existing rigid-body.
- Add the `BroadPhase` trait and expect an implementor of this trait as input to `PhysicsPipeline::step`.
- Implement a 2D block-solver as well as warmstarting. Significantly improves stacking capabilities. Generally reduces
  the "pop" effect that can happen due to penetration corrections.
- Add `RigidBodyBuilder::soft_ccd_prediction` and `RigidBody::set_soft_ccd_prediction` to enable `soft-ccd`: a form of
  CCD based on predictive contacts. This is helpful for objects moving moderately fast. This form of CCD is generally
  cheaper than the normal (time-dropping) CCD implemented so far. It is possible to combine both soft-ccd and
  time-dropping ccd.
- Add a `ColliderBuilder::contact_skin`, `Collider::set_contact_skin`, and `Collider::contact_skin`. This forces the
  solver te maintain a gap between colliders with non-zero contact skin, as if they had a slight margin around them.
  This helps performance and stability for thin objects (like triangle meshes).
- Internal edges were reworked to avoid dropping contacts that would help with stability, and improve stability of
  collisions between two triangle meshes. The `TriMeshFlags::FIX_INTERNAL_EDGES` and
  `HeightFieldFlags::FIX_INTERNAL_EDGES` flags were added to enable internal edges handling.
- Add `IntegrationParameters::length_units` to automatically adjust internal thresholds when the user relies on custom
  length units (e.g. pixels in 2D).

### Modified

**Many shape-casting related functions/structs were renamed. Check out the CHANGELOG for parry 0.15.0 for
additional details.**

- Renamed `BroadPhase` to `BroadPhaseMultiSap`. The `BroadPhase` is now a trait that can be
  implemented for providing a custom broad-phase to rapier. Equivalently, the `DefaultBroadPhase` type
  alias can be used in place of `BroadPhaseMultiSap`.
- The kinematic character controller autostepping is now disabled by default.
- Add `KinematicCharacterController::normal_nudge_factor` used to help getting the character unstuck
  due to rounding errors.
- Rename `TOI` to `ShapeCastHit`.
- Rename many fields from `toi` to `time_of_impact`.
- The `QueryPipeline::cast_shape` method now takes a `ShapeCastOptions` instead of the `max_toi`
  and `stop_at_penetration` parameters. This allows a couple of extra configurations, including the
  ability to have the shape-cast target a specific distance instead of actual shape overlap.
