### PR TITLE
feat: make the constraints regularization coefficients confiugrable with angular frequency instead of explicit ERP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,21 @@
 
 ### Modified
 
+- The contact constraints regularization parameters have been changed from `erp/damping_ratio` to
+  `natural_frequency/damping_ratio`. This helps define them in a timestep-length independent way. The new variables
+  are named `IntegrationParameters::contact_natural_frequency` and `IntegrationParameters::contact_damping_ratio`.
+- The `IntegrationParameters::normalized_max_penetration_correction` has been replaced
+  by `::normalized_max_corrective_velocity`
+  to make the parameter more timestep-length independent. It is now set to a non-infinite value to eliminate aggressive
+  "popping effects".
 - The `Multibody::forward_kinematics` method will no longer automatically update the poses of the `RigidBody` associated
   to each joint. Instead `Multibody::update_rigid_bodies` has to be called explicitly.
 - The `Multibody::forward_kinematics` method will automatically adjust the multibody’s degrees of freedom if the root
   rigid-body changed type (between dynamic and non-dynamic). It can also optionally apply the root’s rigid-body pose
   instead of the root link’s pose (useful for example if you modified the root rigid-body pose externally and wanted
   to propagate it to the multibody).
+- Remove an internal special-case for contact constraints on fast contacts. The doesn’t seem necessary with the substep
+  solver.
 
 ## v0.19.0 (05 May 2024)
 

--- a/benchmarks3d/all_benchmarks3.rs
+++ b/benchmarks3d/all_benchmarks3.rs
@@ -20,6 +20,7 @@ mod joint_fixed3;
 mod joint_prismatic3;
 mod joint_revolute3;
 mod keva3;
+mod many_pyramids3;
 mod many_sleep3;
 mod many_static3;
 mod pyramid3;
@@ -66,6 +67,7 @@ pub fn main() {
         ("ImpulseJoint fixed", joint_fixed3::init_world),
         ("ImpulseJoint revolute", joint_revolute3::init_world),
         ("ImpulseJoint prismatic", joint_prismatic3::init_world),
+        ("Many pyramids", many_pyramids3::init_world),
         ("Keva tower", keva3::init_world),
     ];
 

--- a/benchmarks3d/many_pyramids3.rs
+++ b/benchmarks3d/many_pyramids3.rs
@@ -1,0 +1,80 @@
+use rapier3d::prelude::*;
+use rapier_testbed3d::Testbed;
+
+fn create_pyramid(
+    bodies: &mut RigidBodySet,
+    colliders: &mut ColliderSet,
+    offset: Vector<f32>,
+    stack_height: usize,
+    rad: f32,
+) {
+    let shift = rad * 2.0;
+
+    for i in 0usize..stack_height {
+        for j in i..stack_height {
+            let fj = j as f32;
+            let fi = i as f32;
+            let x = (fi * shift / 2.0) + (fj - fi) * shift;
+            let y = fi * shift;
+
+            // Build the rigid body.
+            let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y, 0.0] + offset);
+            let handle = bodies.insert(rigid_body);
+            let collider = ColliderBuilder::cuboid(rad, rad, rad);
+            colliders.insert_with_parent(collider, handle, bodies);
+        }
+    }
+}
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
+
+    let rad = 0.5;
+    let pyramid_count = 40;
+    let spacing = 4.0;
+
+    /*
+     * Ground
+     */
+    let ground_size = 50.0;
+    let ground_height = 0.1;
+
+    let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0]);
+    let ground_handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(
+        ground_size,
+        ground_height,
+        pyramid_count as f32 * spacing / 2.0 + ground_size,
+    );
+    colliders.insert_with_parent(collider, ground_handle, &mut bodies);
+
+    /*
+     * Create the cubes
+     */
+    for pyramid_index in 0..pyramid_count {
+        let bottomy = rad;
+        create_pyramid(
+            &mut bodies,
+            &mut colliders,
+            vector![
+                0.0,
+                bottomy,
+                (pyramid_index as f32 - pyramid_count as f32 / 2.0) * spacing
+            ],
+            20,
+            rad,
+        );
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
+    testbed.look_at(point![100.0, 100.0, 100.0], Point::origin());
+}

--- a/src/dynamics/solver/contact_constraint/generic_one_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/generic_one_body_constraint.rs
@@ -231,13 +231,8 @@ impl GenericOneBodyConstraintBuilder {
             .unwrap()
             .local_to_world;
 
-        self.inner.update_with_positions(
-            params,
-            solved_dt,
-            pos2,
-            self.ccd_thickness,
-            &mut constraint.inner,
-        );
+        self.inner
+            .update_with_positions(params, solved_dt, pos2, &mut constraint.inner);
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/generic_two_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/generic_two_body_constraint.rs
@@ -342,14 +342,8 @@ impl GenericTwoBodyConstraintBuilder {
             .map(|m| &multibodies[m.multibody].link(m.id).unwrap().local_to_world)
             .unwrap_or_else(|| &bodies[constraint.inner.solver_vel2].position);
 
-        self.inner.update_with_positions(
-            params,
-            solved_dt,
-            pos1,
-            pos2,
-            self.ccd_thickness,
-            &mut constraint.inner,
-        );
+        self.inner
+            .update_with_positions(params, solved_dt, pos1, pos2, &mut constraint.inner);
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/one_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/one_body_constraint.rs
@@ -333,7 +333,8 @@ impl OneBodyConstraintBuilder {
             }
         }
 
-        constraint.cfm_factor = if is_fast_contact { 1.0 } else { cfm_factor };
+        constraint.cfm_factor = cfm_factor;
+        // constraint.cfm_factor = if is_fast_contact { 1.0 } else { cfm_factor };
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/one_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/one_body_constraint.rs
@@ -272,9 +272,9 @@ impl OneBodyConstraintBuilder {
         rb2_pos: &Isometry<Real>,
         constraint: &mut OneBodyConstraint,
     ) {
-        let cfm_factor = params.cfm_factor();
+        let cfm_factor = params.contact_cfm_factor();
         let inv_dt = params.inv_dt();
-        let erp_inv_dt = params.erp_inv_dt();
+        let erp_inv_dt = params.contact_erp_inv_dt();
 
         let all_infos = &self.infos[..constraint.num_contacts as usize];
         let all_elements = &mut constraint.elements[..constraint.num_contacts as usize];

--- a/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
+++ b/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
@@ -261,10 +261,10 @@ impl SimdOneBodyConstraintBuilder {
         _multibodies: &MultibodyJointSet,
         constraint: &mut OneBodyConstraintSimd,
     ) {
-        let cfm_factor = SimdReal::splat(params.cfm_factor());
+        let cfm_factor = SimdReal::splat(params.contact_cfm_factor());
         let inv_dt = SimdReal::splat(params.inv_dt());
         let allowed_lin_err = SimdReal::splat(params.allowed_linear_error());
-        let erp_inv_dt = SimdReal::splat(params.erp_inv_dt());
+        let erp_inv_dt = SimdReal::splat(params.contact_erp_inv_dt());
         let max_corrective_velocity = SimdReal::splat(params.max_corrective_velocity());
         let warmstart_coeff = SimdReal::splat(params.warmstart_coefficient);
 

--- a/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
+++ b/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
@@ -330,7 +330,8 @@ impl SimdOneBodyConstraintBuilder {
             }
         }
 
-        constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+        constraint.cfm_factor = cfm_factor;
+        // constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
+++ b/src/dynamics/solver/contact_constraint/one_body_constraint_simd.rs
@@ -15,7 +15,6 @@ use crate::math::{
 use crate::utils::SimdBasis;
 use crate::utils::{self, SimdAngularInertia, SimdCross, SimdDot};
 use num::Zero;
-use parry::math::SimdBool;
 use parry::utils::SdpMatrix2;
 use simba::simd::{SimdPartialOrd, SimdValue};
 
@@ -263,15 +262,13 @@ impl SimdOneBodyConstraintBuilder {
         constraint: &mut OneBodyConstraintSimd,
     ) {
         let cfm_factor = SimdReal::splat(params.cfm_factor());
-        let dt = SimdReal::splat(params.dt);
         let inv_dt = SimdReal::splat(params.inv_dt());
         let allowed_lin_err = SimdReal::splat(params.allowed_linear_error());
         let erp_inv_dt = SimdReal::splat(params.erp_inv_dt());
-        let max_penetration_correction = SimdReal::splat(params.max_penetration_correction());
+        let max_corrective_velocity = SimdReal::splat(params.max_corrective_velocity());
         let warmstart_coeff = SimdReal::splat(params.warmstart_coefficient);
 
         let rb2 = gather![|ii| &bodies[constraint.solver_vel2[ii]]];
-        let ccd_thickness = SimdReal::from(gather![|ii| rb2[ii].ccd_thickness]);
         let poss2 = Isometry::from(gather![|ii| rb2[ii].position]);
 
         let all_infos = &self.infos[..constraint.num_contacts as usize];
@@ -292,7 +289,6 @@ impl SimdOneBodyConstraintBuilder {
             constraint.dir1.cross(&constraint.tangent1),
         ];
 
-        let mut is_fast_contact = SimdBool::splat(false);
         let solved_dt = SimdReal::splat(solved_dt);
 
         for (info, element) in all_infos.iter().zip(all_elements.iter_mut()) {
@@ -305,12 +301,9 @@ impl SimdOneBodyConstraintBuilder {
             {
                 let rhs_wo_bias =
                     info.normal_rhs_wo_bias + dist.simd_max(SimdReal::zero()) * inv_dt;
-                let rhs_bias = (dist + allowed_lin_err)
-                    .simd_clamp(-max_penetration_correction, SimdReal::zero())
-                    * erp_inv_dt;
+                let rhs_bias = ((dist + allowed_lin_err) * erp_inv_dt)
+                    .simd_clamp(-max_corrective_velocity, SimdReal::zero());
                 let new_rhs = rhs_wo_bias + rhs_bias;
-                is_fast_contact =
-                    is_fast_contact | (-new_rhs * dt).simd_gt(ccd_thickness * SimdReal::splat(0.5));
 
                 element.normal_part.rhs_wo_bias = rhs_wo_bias;
                 element.normal_part.rhs = new_rhs;
@@ -331,7 +324,6 @@ impl SimdOneBodyConstraintBuilder {
         }
 
         constraint.cfm_factor = cfm_factor;
-        // constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/two_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/two_body_constraint.rs
@@ -432,7 +432,8 @@ impl TwoBodyConstraintBuilder {
             }
         }
 
-        constraint.cfm_factor = if is_fast_contact { 1.0 } else { cfm_factor };
+        constraint.cfm_factor = cfm_factor;
+        // constraint.cfm_factor = if is_fast_contact { 1.0 } else { cfm_factor };
     }
 }
 

--- a/src/dynamics/solver/contact_constraint/two_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/two_body_constraint.rs
@@ -373,9 +373,9 @@ impl TwoBodyConstraintBuilder {
         rb2_pos: &Isometry<Real>,
         constraint: &mut TwoBodyConstraint,
     ) {
-        let cfm_factor = params.cfm_factor();
+        let cfm_factor = params.contact_cfm_factor();
         let inv_dt = params.inv_dt();
-        let erp_inv_dt = params.erp_inv_dt();
+        let erp_inv_dt = params.contact_erp_inv_dt();
 
         let all_infos = &self.infos[..constraint.num_contacts as usize];
         let all_elements = &mut constraint.elements[..constraint.num_contacts as usize];

--- a/src/dynamics/solver/contact_constraint/two_body_constraint_simd.rs
+++ b/src/dynamics/solver/contact_constraint/two_body_constraint_simd.rs
@@ -250,10 +250,10 @@ impl TwoBodyConstraintBuilderSimd {
         _multibodies: &MultibodyJointSet,
         constraint: &mut TwoBodyConstraintSimd,
     ) {
-        let cfm_factor = SimdReal::splat(params.cfm_factor());
+        let cfm_factor = SimdReal::splat(params.contact_cfm_factor());
         let inv_dt = SimdReal::splat(params.inv_dt());
         let allowed_lin_err = SimdReal::splat(params.allowed_linear_error());
-        let erp_inv_dt = SimdReal::splat(params.erp_inv_dt());
+        let erp_inv_dt = SimdReal::splat(params.contact_erp_inv_dt());
         let max_corrective_velocity = SimdReal::splat(params.max_corrective_velocity());
         let warmstart_coeff = SimdReal::splat(params.warmstart_coefficient);
 

--- a/src/dynamics/solver/contact_constraint/two_body_constraint_simd.rs
+++ b/src/dynamics/solver/contact_constraint/two_body_constraint_simd.rs
@@ -317,7 +317,8 @@ impl TwoBodyConstraintBuilderSimd {
             }
         }
 
-        constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
+        constraint.cfm_factor = cfm_factor;
+        // constraint.cfm_factor = SimdReal::splat(1.0).select(is_fast_contact, cfm_factor);
     }
 }
 

--- a/src/dynamics/solver/island_solver.rs
+++ b/src/dynamics/solver/island_solver.rs
@@ -47,8 +47,6 @@ impl IslandSolver {
 
         let mut params = *base_params;
         params.dt /= num_solver_iterations as Real;
-        params.damping_ratio /= num_solver_iterations as Real;
-        // params.joint_damping_ratio /= num_solver_iterations as Real;
 
         /*
          *

--- a/src/dynamics/solver/velocity_solver.rs
+++ b/src/dynamics/solver/velocity_solver.rs
@@ -205,17 +205,19 @@ impl VelocitySolver {
             /*
              * Resolution without bias.
              */
-            for _ in 0..params.num_internal_stabilization_iterations {
-                joint_constraints
-                    .solve_wo_bias(&mut self.solver_vels, &mut self.generic_solver_vels);
-                contact_constraints.solve_restitution_wo_bias(
-                    &mut self.solver_vels,
-                    &mut self.generic_solver_vels,
-                );
-            }
+            if params.num_internal_stabilization_iterations > 0 {
+                for _ in 0..params.num_internal_stabilization_iterations {
+                    joint_constraints
+                        .solve_wo_bias(&mut self.solver_vels, &mut self.generic_solver_vels);
+                    contact_constraints.solve_restitution_wo_bias(
+                        &mut self.solver_vels,
+                        &mut self.generic_solver_vels,
+                    );
+                }
 
-            contact_constraints
-                .solve_friction(&mut self.solver_vels, &mut self.generic_solver_vels);
+                contact_constraints
+                    .solve_friction(&mut self.solver_vels, &mut self.generic_solver_vels);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)] // TODO: remove this? I find that in the math code using indices adds clarity.
 #![allow(clippy::module_inception)]
+#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 #[cfg(all(feature = "dim2", feature = "f32"))]
 pub extern crate parry2d as parry;

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_arguments)]
+#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 extern crate nalgebra as na;
 

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -172,8 +172,8 @@ pub fn update_ui(
             );
 
             let mut substep_params = *integration_parameters;
-            substep_params.dt /= substep_params.num_solver_iterations.get() as f32;
-            let curr_erp =  substep_params.erp();
+            substep_params.dt /= substep_params.num_solver_iterations.get() as Real;
+            let curr_erp = substep_params.erp();
             let curr_cfm_factor = substep_params.cfm_factor();
             ui.add(
                 Slider::new(
@@ -220,6 +220,8 @@ pub fn update_ui(
             Slider::new(&mut integration_parameters.min_island_size, 1..=10_000)
                 .text("min island size"),
         );
+        ui.add(Slider::new(&mut state.nsteps, 1..=100).text("sims. per frame"));
+
         let mut frequency = integration_parameters.inv_dt().round() as u32;
         ui.add(Slider::new(&mut frequency, 0..=240).text("frequency (Hz)"));
         integration_parameters.set_inv_dt(frequency as Real);

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -162,7 +162,7 @@ pub fn update_ui(
             ui.add(
                 Slider::new(
                     &mut integration_parameters.num_internal_stabilization_iterations,
-                    1..=100,
+                    0..=100,
                 )
                 .text("max internal stabilization iters."),
             );
@@ -170,12 +170,35 @@ pub fn update_ui(
                 Slider::new(&mut integration_parameters.warmstart_coefficient, 0.0..=1.0)
                     .text("warmstart coefficient"),
             );
-            ui.add(Slider::new(&mut integration_parameters.erp, 0.0..=1.0).text("erp"));
+
+            let mut substep_params = *integration_parameters;
+            substep_params.dt /= substep_params.num_solver_iterations.get() as f32;
+            let curr_erp =  substep_params.erp();
+            let curr_cfm_factor = substep_params.cfm_factor();
             ui.add(
-                Slider::new(&mut integration_parameters.damping_ratio, 0.0..=20.0)
-                    .text("damping ratio"),
+                Slider::new(
+                    &mut integration_parameters.contact_natural_frequency,
+                    0.0..=120.0,
+                )
+                .text(format!("contacts Hz (erp = {:.3})", curr_erp)),
             );
-            ui.add(Slider::new(&mut integration_parameters.joint_erp, 0.0..=1.0).text("joint erp"));
+            ui.add(
+                Slider::new(
+                    &mut integration_parameters.contact_damping_ratio,
+                    0.0..=20.0,
+                )
+                .text(format!(
+                    "damping ratio (cfm-factor = {:.3})",
+                    curr_cfm_factor
+                )),
+            );
+            ui.add(
+                Slider::new(
+                    &mut integration_parameters.joint_natural_frequency,
+                    0.0..=1200000.0,
+                )
+                .text("joint erp"),
+            );
             ui.add(
                 Slider::new(&mut integration_parameters.joint_damping_ratio, 0.0..=20.0)
                     .text("joint damping ratio"),

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -173,19 +173,19 @@ pub fn update_ui(
 
             let mut substep_params = *integration_parameters;
             substep_params.dt /= substep_params.num_solver_iterations.get() as Real;
-            let curr_erp = substep_params.erp();
-            let curr_cfm_factor = substep_params.cfm_factor();
+            let curr_erp = substep_params.contact_erp();
+            let curr_cfm_factor = substep_params.contact_cfm_factor();
             ui.add(
                 Slider::new(
                     &mut integration_parameters.contact_natural_frequency,
-                    0.0..=120.0,
+                    0.01..=120.0,
                 )
                 .text(format!("contacts Hz (erp = {:.3})", curr_erp)),
             );
             ui.add(
                 Slider::new(
                     &mut integration_parameters.contact_damping_ratio,
-                    0.0..=20.0,
+                    0.01..=20.0,
                 )
                 .text(format!(
                     "damping ratio (cfm-factor = {:.3})",


### PR DESCRIPTION
### Modified

- The contact constraints regularization parameters have been changed from `erp/damping_ratio` to
  `natural_frequency/damping_ratio`. This helps define them in a timestep-length independent way. The new variables
  are named `IntegrationParameters::contact_natural_frequency` and `IntegrationParameters::contact_damping_ratio`.
- Remove an internal special-case for contact constraints on fast contacts. The doesn’t seem necessary with the substep
  solver.