### PR TITLE
Prefer individual `unexpected_cfgs` allow over global one

### DIFF
--- a/benchmarks2d/all_benchmarks2.rs
+++ b/benchmarks2d/all_benchmarks2.rs
@@ -31,7 +31,7 @@ fn demo_name_from_command_line() -> Option<String> {
     None
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(target_arch = "wasm32")]
 fn demo_name_from_url() -> Option<String> {
     None
     //    let window = stdweb::web::window();
@@ -39,7 +39,7 @@ fn demo_name_from_url() -> Option<String> {
     //    Some(hash[1..].to_string())
 }
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn demo_name_from_url() -> Option<String> {
     None
 }

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = []
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "simd-stable", "serde-serialize", "debug-render"]
 

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = []
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "simd-stable", "serde-serialize", "debug-render"]
 

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = []
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "simd-stable", "serde-serialize", "debug-render"]
 

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -38,6 +38,9 @@ debug-disable-legitimate-fe-exceptions = []
 # Do not enable this unless you are working on the engine internals.
 dev-remove-slow-accessors = []
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "simd-stable", "serde-serialize", "debug-render"]
 

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -24,6 +24,9 @@ dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "other-backends"]
 

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -24,6 +24,9 @@ dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "other-backends"]
 

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -23,6 +23,9 @@ default = ["dim3"]
 dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel"]
 

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -24,6 +24,9 @@ dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["physx", "physx-sys", "glam"]
 
+[lints.rust]
+unexpected_cfgs = "allow"
+
 [package.metadata.docs.rs]
 features = ["parallel", "other-backends"]
 

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -56,7 +56,7 @@ fn demo_name_from_command_line() -> Option<String> {
     None
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(target_arch = "wasm32")]
 fn demo_name_from_url() -> Option<String> {
     None
     //    let window = stdweb::web::window();
@@ -64,7 +64,7 @@ fn demo_name_from_url() -> Option<String> {
     //    Some(hash[1..].to_string())
 }
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn demo_name_from_url() -> Option<String> {
     None
 }

--- a/examples3d-f64/all_examples3-f64.rs
+++ b/examples3d-f64/all_examples3-f64.rs
@@ -23,7 +23,7 @@ fn demo_name_from_command_line() -> Option<String> {
     None
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(target_arch = "wasm32")]
 fn demo_name_from_url() -> Option<String> {
     None
     //    let window = stdweb::web::window();
@@ -35,7 +35,7 @@ fn demo_name_from_url() -> Option<String> {
     //    }
 }
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn demo_name_from_url() -> Option<String> {
     None
 }

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -70,7 +70,7 @@ fn demo_name_from_command_line() -> Option<String> {
     None
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(target_arch = "wasm32")]
 fn demo_name_from_url() -> Option<String> {
     None
     //    let window = stdweb::web::window();
@@ -82,7 +82,7 @@ fn demo_name_from_url() -> Option<String> {
     //    }
 }
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn demo_name_from_url() -> Option<String> {
     None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)] // TODO: remove this? I find that in the math code using indices adds clarity.
 #![allow(clippy::module_inception)]
-#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 #[cfg(all(feature = "dim2", feature = "f32"))]
 pub extern crate parry2d as parry;

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::too_many_arguments)]
-#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 extern crate nalgebra as na;
 


### PR DESCRIPTION
This PR replace the global `#![allow(unexpected_cfgs)]` over individual ones in `crates/*`, so that the main library still gets the benefits of the lint.

This PR also remove obsolete asmjs cfg, since that target was removed some time ago from Rust.