### PR TITLE
Fix trivial todo; removing a private type.

### DIFF
--- a/src/data/pubsub.rs
+++ b/src/data/pubsub.rs
@@ -114,11 +114,7 @@ impl<T> PubSub<T> {
         let cursor = &self.cursors[sub.id as usize];
         let next = cursor.next(self.deleted_messages);
 
-        // TODO: use self.queue.range(next..) once it is stabilised.
-        MessageRange {
-            queue: &self.messages,
-            next,
-        }
+        self.messages.range(next..)
     }
 
     /// Makes the given subscribe acknowledge all the messages in the queue.
@@ -157,21 +153,5 @@ impl<T> PubSub<T> {
             // they will end up overflowing, breaking everything.
             self.reset_shifts();
         }
-    }
-}
-
-struct MessageRange<'a, T> {
-    queue: &'a VecDeque<T>,
-    next: usize,
-}
-
-impl<'a, T> Iterator for MessageRange<'a, T> {
-    type Item = &'a T;
-
-    #[inline(always)]
-    fn next(&mut self) -> Option<&'a T> {
-        let result = self.queue.get(self.next);
-        self.next += 1;
-        result
     }
 }


### PR DESCRIPTION
Seems unblocked since rust 1.51 (~2021)

I think chances are low that it impacts our msrv (minimum rust supported version), as rapier doesn't have such policy (https://github.com/dimforge/rapier/issues/592) ; but still important to consider, I didn't verify.