### PR TITLE
Rework QueryPipeline update API to take less parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ This release introduces two new crates:
   this change will allow further internal optimizations.
 - `QueryPipeline::update` now doesn't need the `RigidBodySet` as parameter.
 - Removed `QueryPipelineMode`.
-- `QueryPipeline::update_with_mode` now takes `impl QbvhDataGenerator<ColliderHandle>` as parameter.
-  see [`QueryPipeline::updaters`] module for more information.
+- `QueryPipeline::update_with_mode` was renamed to `::update_with_generator` and now takes
+  `impl QbvhDataGenerator<ColliderHandle>` as parameter see [`QueryPipeline::updaters`] module for more information.
 
 ## v0.19.0 (05 May 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ This release introduces two new crates:
   `bevy_rapier` plumbings, but it is no longer useful. Adding a collider must always go througthe `ColliderSet`.
 - `CharacterController::solve_character_collision_impulses` now takes multiple `CharacterCollision` as parameter:
   this change will allow further internal optimizations.
+- `QueryPipeline::update` now doesn't need the `RigidBodySet` as parameter.
+- Removed `QueryPipelineMode`.
+- `QueryPipeline::update_with_mode` now takes `impl QbvhDataGenerator<ColliderHandle>` as parameter.
+  see [`QueryPipeline::updaters`] module for more information.
 
 ## v0.19.0 (05 May 2024)
 

--- a/src/dynamics/ccd/ccd_solver.rs
+++ b/src/dynamics/ccd/ccd_solver.rs
@@ -4,7 +4,7 @@ use crate::geometry::{ColliderParent, ColliderSet, CollisionEvent, NarrowPhase};
 use crate::math::Real;
 use crate::parry::utils::SortedPair;
 use crate::pipeline::{EventHandler, QueryPipeline};
-use crate::prelude::{updaters, ActiveEvents, CollisionEventFlags};
+use crate::prelude::{query_pipeline_generators, ActiveEvents, CollisionEventFlags};
 use parry::query::{DefaultQueryDispatcher, QueryDispatcher};
 use parry::utils::hashmap::HashMap;
 use std::collections::BinaryHeap;
@@ -117,8 +117,13 @@ impl CCDSolver {
         narrow_phase: &NarrowPhase,
     ) -> Option<Real> {
         // Update the query pipeline.
-        self.query_pipeline
-            .update_with_mode(updaters::SweepTestWithNextPosition { bodies, colliders });
+        self.query_pipeline.update_with_generator(
+            query_pipeline_generators::SweptAabbWithPredictedPosition {
+                bodies,
+                colliders,
+                dt,
+            },
+        );
 
         let mut pairs_seen = HashMap::default();
         let mut min_toi = dt;
@@ -235,8 +240,9 @@ impl CCDSolver {
         let mut min_overstep = dt;
 
         // Update the query pipeline.
-        self.query_pipeline
-            .update_with_mode(updaters::SweepTestWithNextPosition { bodies, colliders });
+        self.query_pipeline.update_with_generator(
+            query_pipeline_generators::SweptAabbWithNextPosition { bodies, colliders },
+        );
 
         /*
          *

--- a/src/dynamics/ccd/ccd_solver.rs
+++ b/src/dynamics/ccd/ccd_solver.rs
@@ -3,8 +3,8 @@ use crate::dynamics::{IslandManager, RigidBodyHandle, RigidBodySet};
 use crate::geometry::{ColliderParent, ColliderSet, CollisionEvent, NarrowPhase};
 use crate::math::Real;
 use crate::parry::utils::SortedPair;
-use crate::pipeline::{EventHandler, QueryPipeline, QueryPipelineMode};
-use crate::prelude::{ActiveEvents, CollisionEventFlags};
+use crate::pipeline::{EventHandler, QueryPipeline};
+use crate::prelude::{updaters, ActiveEvents, CollisionEventFlags};
 use parry::query::{DefaultQueryDispatcher, QueryDispatcher};
 use parry::utils::hashmap::HashMap;
 use std::collections::BinaryHeap;
@@ -117,11 +117,8 @@ impl CCDSolver {
         narrow_phase: &NarrowPhase,
     ) -> Option<Real> {
         // Update the query pipeline.
-        self.query_pipeline.update_with_mode(
-            bodies,
-            colliders,
-            QueryPipelineMode::SweepTestWithPredictedPosition { dt },
-        );
+        self.query_pipeline
+            .update_with_mode(updaters::SweepTestWithNextPosition { bodies, colliders });
 
         let mut pairs_seen = HashMap::default();
         let mut min_toi = dt;
@@ -238,11 +235,8 @@ impl CCDSolver {
         let mut min_overstep = dt;
 
         // Update the query pipeline.
-        self.query_pipeline.update_with_mode(
-            bodies,
-            colliders,
-            QueryPipelineMode::SweepTestWithNextPosition,
-        );
+        self.query_pipeline
+            .update_with_mode(updaters::SweepTestWithNextPosition { bodies, colliders });
 
         /*
          *

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -4,7 +4,7 @@ pub use collision_pipeline::CollisionPipeline;
 pub use event_handler::{ActiveEvents, ChannelEventCollector, EventHandler};
 pub use physics_hooks::{ActiveHooks, ContactModificationContext, PairFilterContext, PhysicsHooks};
 pub use physics_pipeline::PhysicsPipeline;
-pub use query_pipeline::{QueryFilter, QueryFilterFlags, QueryPipeline, QueryPipelineMode};
+pub use query_pipeline::{updaters, QueryFilter, QueryFilterFlags, QueryPipeline};
 
 #[cfg(feature = "debug-render")]
 pub use self::debug_render_pipeline::{

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -4,7 +4,9 @@ pub use collision_pipeline::CollisionPipeline;
 pub use event_handler::{ActiveEvents, ChannelEventCollector, EventHandler};
 pub use physics_hooks::{ActiveHooks, ContactModificationContext, PairFilterContext, PhysicsHooks};
 pub use physics_pipeline::PhysicsPipeline;
-pub use query_pipeline::{updaters, QueryFilter, QueryFilterFlags, QueryPipeline};
+pub use query_pipeline::{
+    generators as query_pipeline_generators, QueryFilter, QueryFilterFlags, QueryPipeline,
+};
 
 #[cfg(feature = "debug-render")]
 pub use self::debug_render_pipeline::{

--- a/src/pipeline/query_pipeline/generators.rs
+++ b/src/pipeline/query_pipeline/generators.rs
@@ -1,28 +1,35 @@
-//! This module contains structs implementing [`QbvhDataGenerator<ColliderHandle>`].
-//!
-//! These structs are designed to be passed as a parameters to
-//! [`super::QueryPipeline::update_with_mode`] to update the query pipeline.
+//! Structs implementing [`QbvhDataGenerator<ColliderHandle>`] to be used with [`QueryPipeline::update_with_generator`].
 
 use parry::partitioning::QbvhDataGenerator;
 
 use crate::math::Real;
 use crate::prelude::{Aabb, ColliderHandle, ColliderSet, RigidBodySet};
 
-/// Designed to be passed as a parameters to
-/// [`super::QueryPipeline::update_with_mode`] to update the query pipeline.
+#[cfg(doc)]
+use crate::{
+    dynamics::{IntegrationParameters, RigidBodyPosition},
+    pipeline::QueryPipeline,
+};
+
+/// Generates collider AABBs based on the union of their current AABB and the AABB predicted
+/// from the velocity and forces of their parent rigid-body.
 ///
-/// The `RigidBody::predict_position_using_velocity_and_forces * Collider::position_wrt_parent`
-/// is taken into account for the colliders position.
-pub struct SweepTestWithPredictedPosition<'a> {
+/// The main purpose of this struct is to be passed as a parameters to
+/// [`QueryPipeline::update_with_generator`] to update the [`QueryPipeline`].
+///
+/// The predicted position is calculated as
+/// `RigidBody::predict_position_using_velocity_and_forces * Collider::position_wrt_parent`.
+pub struct SweptAabbWithPredictedPosition<'a> {
     /// The rigid bodies of your simulation.
     pub bodies: &'a RigidBodySet,
     /// The colliders of your simulation.
     pub colliders: &'a ColliderSet,
     /// The delta time to compute predicted position.
-    /// You probably want to set it to [`crate::dynamics::IntegrationParameter::dt`].
+    ///
+    /// You probably want to set it to [`IntegrationParameter::dt`].
     pub dt: Real,
 }
-impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithPredictedPosition<'a> {
+impl<'a> QbvhDataGenerator<ColliderHandle> for SweptAabbWithPredictedPosition<'a> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }
@@ -45,19 +52,22 @@ impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithPredictedPosition<'a
     }
 }
 
-/// Designed to be passed as a parameters to update the query pipeline,
-/// through [`super::QueryPipeline::update_with_mode`].
+/// Generates collider AABBs based on the union of their AABB at their current [`Collider::position`]
+/// and the AABB predicted from their parent’s [`RigidBody::next_position`].
 ///
-/// The `RigidBody::next_position * Collider::position_wrt_parent` is taken into account for
-/// the colliders positions.
-pub struct SweepTestWithNextPosition<'a> {
+/// The main purpose of this struct is to be passed as a parameters to
+/// [`QueryPipeline::update_with_generator`] to update the [`QueryPipeline`].
+///
+/// The predicted position is calculated as
+/// `RigidBody::next_position * Collider::position_wrt_parent`.
+pub struct SweptAabbWithNextPosition<'a> {
     /// The rigid bodies of your simulation.
     pub bodies: &'a RigidBodySet,
     /// The colliders of your simulation.
     pub colliders: &'a ColliderSet,
 }
 
-impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithNextPosition<'a> {
+impl<'a> QbvhDataGenerator<ColliderHandle> for SweptAabbWithNextPosition<'a> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }
@@ -76,16 +86,16 @@ impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithNextPosition<'a> {
     }
 }
 
-/// Designed to be passed as a parameters to update the query pipeline,
-/// through [`super::QueryPipeline::update_with_mode`].
+/// Generates collider AABBs based on the AABB at their current [`Collider::position`].
 ///
-/// The [`super::Collider::position`] is taken into account.
-pub struct CurrentPosition<'a> {
+/// The main purpose of this struct is to be passed as a parameters to
+/// [`QueryPipeline::update_with_generator`] to update the [`QueryPipeline`].
+pub struct CurrentAabb<'a> {
     /// The colliders of your simulation.
     pub colliders: &'a ColliderSet,
 }
 
-impl<'a> QbvhDataGenerator<ColliderHandle> for CurrentPosition<'a> {
+impl<'a> QbvhDataGenerator<ColliderHandle> for CurrentAabb<'a> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -1,3 +1,5 @@
+pub mod updaters;
+
 use crate::dynamics::RigidBodyHandle;
 use crate::geometry::{
     Aabb, Collider, ColliderHandle, InteractionGroups, PointProjection, Qbvh, Ray, RayIntersection,
@@ -227,22 +229,6 @@ impl<'a> QueryFilter<'a> {
     }
 }
 
-/// Indicates how the colliders position should be taken into account when
-/// updating the query pipeline.
-pub enum QueryPipelineMode {
-    /// The `Collider::position` is taken into account.
-    CurrentPosition,
-    /// The `RigidBody::next_position * Collider::position_wrt_parent` is taken into account for
-    /// the colliders positions.
-    SweepTestWithNextPosition,
-    /// The `RigidBody::predict_position_using_velocity_and_forces * Collider::position_wrt_parent`
-    /// is taken into account for the colliders position.
-    SweepTestWithPredictedPosition {
-        /// The time used to integrate the rigid-body's velocity and acceleration.
-        dt: Real,
-    },
-}
-
 impl<'a> TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'a> {
     type PartShape = dyn Shape;
     type PartNormalConstraints = dyn NormalConstraints;
@@ -357,72 +343,17 @@ impl QueryPipeline {
     }
 
     /// Update the acceleration structure on the query pipeline.
-    pub fn update(&mut self, bodies: &RigidBodySet, colliders: &ColliderSet) {
-        self.update_with_mode(bodies, colliders, QueryPipelineMode::CurrentPosition)
+    ///
+    /// Uses [`updaters::CurrentPosition`] to update.
+    pub fn update(&mut self, colliders: &ColliderSet) {
+        self.update_with_mode(updaters::CurrentPosition { colliders })
     }
 
     /// Update the acceleration structure on the query pipeline.
-    pub fn update_with_mode(
-        &mut self,
-        bodies: &RigidBodySet,
-        colliders: &ColliderSet,
-        mode: QueryPipelineMode,
-    ) {
-        struct DataGenerator<'a> {
-            bodies: &'a RigidBodySet,
-            colliders: &'a ColliderSet,
-            mode: QueryPipelineMode,
-        }
-
-        impl<'a> QbvhDataGenerator<ColliderHandle> for DataGenerator<'a> {
-            fn size_hint(&self) -> usize {
-                self.colliders.len()
-            }
-
-            #[inline(always)]
-            fn for_each(&mut self, mut f: impl FnMut(ColliderHandle, Aabb)) {
-                match self.mode {
-                    QueryPipelineMode::CurrentPosition => {
-                        for (h, co) in self.colliders.iter_enabled() {
-                            f(h, co.shape.compute_aabb(&co.pos))
-                        }
-                    }
-                    QueryPipelineMode::SweepTestWithNextPosition => {
-                        for (h, co) in self.colliders.iter_enabled() {
-                            if let Some(co_parent) = co.parent {
-                                let rb_next_pos = &self.bodies[co_parent.handle].pos.next_position;
-                                let next_position = rb_next_pos * co_parent.pos_wrt_parent;
-                                f(h, co.shape.compute_swept_aabb(&co.pos, &next_position))
-                            } else {
-                                f(h, co.shape.compute_aabb(&co.pos))
-                            }
-                        }
-                    }
-                    QueryPipelineMode::SweepTestWithPredictedPosition { dt } => {
-                        for (h, co) in self.colliders.iter_enabled() {
-                            if let Some(co_parent) = co.parent {
-                                let rb = &self.bodies[co_parent.handle];
-                                let predicted_pos = rb.pos.integrate_forces_and_velocities(
-                                    dt, &rb.forces, &rb.vels, &rb.mprops,
-                                );
-
-                                let next_position = predicted_pos * co_parent.pos_wrt_parent;
-                                f(h, co.shape.compute_swept_aabb(&co.pos, &next_position))
-                            } else {
-                                f(h, co.shape.compute_aabb(&co.pos))
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let generator = DataGenerator {
-            bodies,
-            colliders,
-            mode,
-        };
-        self.qbvh.clear_and_rebuild(generator, self.dilation_factor);
+    ///
+    /// See [`updaters`] for available modes.
+    pub fn update_with_mode(&mut self, mode: impl QbvhDataGenerator<ColliderHandle>) {
+        self.qbvh.clear_and_rebuild(mode, self.dilation_factor);
     }
 
     /// Find the closest intersection between a ray and a set of collider.

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -1,4 +1,4 @@
-pub mod updaters;
+pub mod generators;
 
 use crate::dynamics::RigidBodyHandle;
 use crate::geometry::{
@@ -344,15 +344,16 @@ impl QueryPipeline {
 
     /// Update the acceleration structure on the query pipeline.
     ///
-    /// Uses [`updaters::CurrentPosition`] to update.
+    /// Uses [`generators::CurrentAabb`] to update.
     pub fn update(&mut self, colliders: &ColliderSet) {
-        self.update_with_mode(updaters::CurrentPosition { colliders })
+        self.update_with_generator(generators::CurrentAabb { colliders })
     }
 
-    /// Update the acceleration structure on the query pipeline.
+    /// Update the acceleration structure on the query pipeline using a custom collider bounding
+    /// volume generator.
     ///
-    /// See [`updaters`] for available modes.
-    pub fn update_with_mode(&mut self, mode: impl QbvhDataGenerator<ColliderHandle>) {
+    /// See [`generators`] for available generators.
+    pub fn update_with_generator(&mut self, mode: impl QbvhDataGenerator<ColliderHandle>) {
         self.qbvh.clear_and_rebuild(mode, self.dilation_factor);
     }
 

--- a/src/pipeline/query_pipeline/updaters.rs
+++ b/src/pipeline/query_pipeline/updaters.rs
@@ -1,0 +1,99 @@
+//! This module contains structs implementing [`QbvhDataGenerator<ColliderHandle>`].
+//!
+//! These structs are designed to be passed as a parameters to
+//! [`super::QueryPipeline::update_with_mode`] to update the query pipeline.
+
+use parry::partitioning::QbvhDataGenerator;
+
+use crate::math::Real;
+use crate::prelude::{Aabb, ColliderHandle, ColliderSet, RigidBodySet};
+
+/// Designed to be passed as a parameters to
+/// [`super::QueryPipeline::update_with_mode`] to update the query pipeline.
+///
+/// The `RigidBody::predict_position_using_velocity_and_forces * Collider::position_wrt_parent`
+/// is taken into account for the colliders position.
+pub struct SweepTestWithPredictedPosition<'a> {
+    /// The rigid bodies of your simulation.
+    pub bodies: &'a RigidBodySet,
+    /// The colliders of your simulation.
+    pub colliders: &'a ColliderSet,
+    /// The delta time to compute predicted position.
+    /// You probably want to set it to [`crate::dynamics::IntegrationParameter::dt`].
+    pub dt: Real,
+}
+impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithPredictedPosition<'a> {
+    fn size_hint(&self) -> usize {
+        self.colliders.len()
+    }
+
+    #[inline(always)]
+    fn for_each(&mut self, mut f: impl FnMut(ColliderHandle, Aabb)) {
+        for (h, co) in self.colliders.iter_enabled() {
+            if let Some(co_parent) = co.parent {
+                let rb = &self.bodies[co_parent.handle];
+                let predicted_pos = rb
+                    .pos
+                    .integrate_forces_and_velocities(self.dt, &rb.forces, &rb.vels, &rb.mprops);
+
+                let next_position = predicted_pos * co_parent.pos_wrt_parent;
+                f(h, co.shape.compute_swept_aabb(&co.pos, &next_position))
+            } else {
+                f(h, co.shape.compute_aabb(&co.pos))
+            }
+        }
+    }
+}
+
+/// Designed to be passed as a parameters to update the query pipeline,
+/// through [`super::QueryPipeline::update_with_mode`].
+///
+/// The `RigidBody::next_position * Collider::position_wrt_parent` is taken into account for
+/// the colliders positions.
+pub struct SweepTestWithNextPosition<'a> {
+    /// The rigid bodies of your simulation.
+    pub bodies: &'a RigidBodySet,
+    /// The colliders of your simulation.
+    pub colliders: &'a ColliderSet,
+}
+
+impl<'a> QbvhDataGenerator<ColliderHandle> for SweepTestWithNextPosition<'a> {
+    fn size_hint(&self) -> usize {
+        self.colliders.len()
+    }
+
+    #[inline(always)]
+    fn for_each(&mut self, mut f: impl FnMut(ColliderHandle, Aabb)) {
+        for (h, co) in self.colliders.iter_enabled() {
+            if let Some(co_parent) = co.parent {
+                let rb_next_pos = &self.bodies[co_parent.handle].pos.next_position;
+                let next_position = rb_next_pos * co_parent.pos_wrt_parent;
+                f(h, co.shape.compute_swept_aabb(&co.pos, &next_position))
+            } else {
+                f(h, co.shape.compute_aabb(&co.pos))
+            }
+        }
+    }
+}
+
+/// Designed to be passed as a parameters to update the query pipeline,
+/// through [`super::QueryPipeline::update_with_mode`].
+///
+/// The [`super::Collider::position`] is taken into account.
+pub struct CurrentPosition<'a> {
+    /// The colliders of your simulation.
+    pub colliders: &'a ColliderSet,
+}
+
+impl<'a> QbvhDataGenerator<ColliderHandle> for CurrentPosition<'a> {
+    fn size_hint(&self) -> usize {
+        self.colliders.len()
+    }
+
+    #[inline(always)]
+    fn for_each(&mut self, mut f: impl FnMut(ColliderHandle, Aabb)) {
+        for (h, co) in self.colliders.iter_enabled() {
+            f(h, co.shape.compute_aabb(&co.pos))
+        }
+    }
+}


### PR DESCRIPTION
When working on https://github.com/dimforge/rapier.rs/pull/104 ; I noticed an outdated note on the userguide, which was also teasing future features.

<details><summary>Note details</summary>
<p>

at https://rapier.rs/docs/user_guides/rust/scene_queries

> Right now, the query pipeline takes the `IslandManager` and `RigidBodySet` as arguments. These two arguments may look superfluous, especially if the colliders are not attached to rigid-bodies. Another update method that only takes a `ColliderSet` as its only argument will be added in the future.



</p>
</details> 

This PR allows to remove that note, and makes up for a more powerful API.


On its downside, passing a generic is less explicit, I tried my best to guide the user with the documentation.