### PR TITLE
fix: testbed: keyD removes only dynamic bodies as intended

### DIFF
--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -880,7 +880,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                         .physics
                         .bodies
                         .iter()
-                        .filter(|e| !e.1.is_fixed())
+                        .filter(|e| e.1.is_dynamic())
                         .map(|e| e.0)
                         .collect();
                     let num_to_delete = (dynamic_bodies.len() / 10).max(0);


### PR DESCRIPTION
Currently, the character controller example has all chances to crash if its kinematic character controller is removed with "KeyD".

it's the intended behaviour as hinted by a comment above modified line.