### PR TITLE
Release Rapier 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.20.0 (9 June 2024)
 
 This release introduces two new crates:
 

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier3d-stl/Cargo.toml
+++ b/crates/rapier3d-stl/Cargo.toml
@@ -16,4 +16,4 @@ edition = "2021"
 thiserror = "1.0.61"
 stl_io = "0.7"
 
-rapier3d = { version = "0.19", path = "../rapier3d" }
+rapier3d = { version = "0.20", path = "../rapier3d" }

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -22,5 +22,5 @@ bitflags = "2"
 # NOTE: we are not using the (more recent) urdf-rs crate because of https://github.com/openrr/urdf-rs/issues/94
 xurdf = "0.2"
 
-rapier3d = { version = "0.19", path = "../rapier3d" }
+rapier3d = { version = "0.20", path = "../rapier3d" }
 rapier3d-stl = { version = "0.1.0", path = "../rapier3d-stl", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_asset", "
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.19.0"
+version = "0.20.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_sprite", 
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.19.0"
+version = "0.20.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -58,5 +58,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.19.0"
+version = "0.20.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -62,5 +62,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.19.0"
+version = "0.20.0"
 features = ["serde-serialize", "debug-render", "profiler"]


### PR DESCRIPTION
## v0.20.0 (9 June 2024)

This release introduces two new crates:

- `rapier3d-urdf` for loading URDF files into rapier3d. This will load the rigid-bodies,
  colliders, and joints.
- `rapier3d-stl` for loading an STL file as a collision shape.

### Added

- Add `Multibody::inverse_kinematics`, `Multibody::inverse_kinematics_delta`,
  and `::inverse_kinematics_delta_with_jacobian`
  for running inverse kinematics on a multibody to align one its links pose to the given prescribed pose.
- Add `InverseKinematicsOption` to customize some behaviors of the inverse-kinematics solver.
- Add `Multibody::body_jacobian` to get the jacobian of a specific link.
- Add `Multibody::update_rigid_bodies` to update rigid-bodies based on the multibody links poses.
- Add `Multibody::forward_kinematics_single_link` to run forward-kinematics to compute the new pose and jacobian of a
  single link without mutating the multibody. This can take an optional displacement on generalized coordinates that are
  taken into account during transform propagation.
- Implement `Debug` for `ColliderBuilder`.
- Add `Collider::converted_trimesh` and `MeshConverter` for building a collider with a shape computed from a mesh’s
  index and vertex buffers. That computed shape can currently be a `TriMesh`, a `Cuboid` (covering the mesh’s AABB or
  OBB), a convex hull, or a convex decomposition.
- Implement `Default` for `RigidBodyBuilder`. This is equivalent to `RigidBodyBuilder::dynamic()`.
- Implement `Default` for `ColliderBuilder`. This is equivalent to `ColliderBuilder::ball(0.5)`.
- Add `RevoluteJoint::angle` to compute the joint’s angle given the rotation of its attached rigid-bodies.

### Modified

- Renamed `JointAxesMask::X/Y/Z` to `::LIN_X/LIN_Y/LIN_Z`; and renamed `JointAxisMask::X/Y/Z` to `::LinX/LinY/LynZ` to
  make it clear it is not to be used as angular axes (the angular axis are `JointAxesMask::ANG_X/ANG_Y/AngZ` and
  `JointAxisMask::AngX/AngY/AngZ`).
- The contact constraints regularization parameters have been changed from `erp/damping_ratio` to
  `natural_frequency/damping_ratio`. This helps define them in a timestep-length independent way. The new variables
  are named `IntegrationParameters::contact_natural_frequency` and `IntegrationParameters::contact_damping_ratio`.
- The `IntegrationParameters::normalized_max_penetration_correction` has been replaced
  by `::normalized_max_corrective_velocity`
  to make the parameter more timestep-length independent. It is now set to a non-infinite value to eliminate aggressive
  "popping effects".
- The `Multibody::forward_kinematics` method will no longer automatically update the poses of the `RigidBody` associated
  to each joint. Instead `Multibody::update_rigid_bodies` has to be called explicitly.
- The `Multibody::forward_kinematics` method will automatically adjust the multibody’s degrees of freedom if the root
  rigid-body changed type (between dynamic and non-dynamic). It can also optionally apply the root’s rigid-body pose
  instead of the root link’s pose (useful for example if you modified the root rigid-body pose externally and wanted
  to propagate it to the multibody).
- Remove an internal special-case for contact constraints on fast contacts. The doesn’t seem necessary with the substep
  solver.
- Remove `RigidBody::add_collider`. This was an implementation detail previously needed by `bevy_rapier`. To attach
  a collider to a rigid-body, use `ColliderSet::insert_with_parent` or `ColliderSet::set_parent`.
- Rename `JointAxis::X/Y/Z` to `::LinX/LinY/LinZ` to avoid confusing it with `::AngX/AngY/AngZ`.
- Rename `JointAxesMask::X/Y/Z` to `::LIN_X/LIN_Y/LIN_Z` to avoid confusing it with `::ANG_X/ANG_Y/ANG_Z`.
- The function `RigidBody::add_collider` is now private. It was only public because it was needed for some internal
  `bevy_rapier` plumbings, but it is no longer useful. Adding a collider must always go througthe `ColliderSet`.
- `CharacterController::solve_character_collision_impulses` now takes multiple `CharacterCollision` as parameter:
  this change will allow further internal optimizations.
- `QueryPipeline::update` now doesn't need the `RigidBodySet` as parameter.
- Removed `QueryPipelineMode`.
- `QueryPipeline::update_with_mode` was renamed to `::update_with_generator` and now takes
  `impl QbvhDataGenerator<ColliderHandle>` as parameter see [`QueryPipeline::updaters`] module for more information.
