### PR TITLE
fix: less invasive `solve_character_collision_impulses` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix `NaN` values appearing in bodies translation and rotation after a simulation step with a delta time equal to 0 ([#660](https://github.com/dimforge/rapier/pull/660)).
 
+### Modified
+
+- `solve_character_collision_impulses` collisions parameter is now an iterator over references.
+
 ## v0.20.0 (9 June 2024)
 
 This release introduces two new crates:

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -788,7 +788,7 @@ impl KinematicCharacterController {
     /// impulses to the rigid-bodies surrounding the character shape at the time of the collisions.
     /// Note that the impulse calculation is only approximate as it is not based on a global
     /// constraints resolution scheme.
-    pub fn solve_character_collision_impulses(
+    pub fn solve_character_collision_impulses<'a>(
         &self,
         dt: Real,
         bodies: &mut RigidBodySet,
@@ -796,7 +796,7 @@ impl KinematicCharacterController {
         queries: &QueryPipeline,
         character_shape: &dyn Shape,
         character_mass: Real,
-        collisions: impl IntoIterator<Item = CharacterCollision>,
+        collisions: impl IntoIterator<Item = &'a CharacterCollision>,
         filter: QueryFilter,
     ) {
         for collision in collisions {
@@ -807,7 +807,7 @@ impl KinematicCharacterController {
                 queries,
                 character_shape,
                 character_mass,
-                &collision,
+                collision,
                 filter,
             );
         }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -818,7 +818,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                 &phx.query_pipeline,
                 character_collider.shape(),
                 character_mass,
-                collisions,
+                &*collisions,
                 QueryFilter::new().exclude_rigid_body(character_handle),
             );
 


### PR DESCRIPTION
in `solve_character_collision_impulses`, Taking ownership of the `CharacterCollision` is not necessary, it's a problem if we're storing the `CharacterCollision`s in another struct, such as https://github.com/dimforge/bevy_rapier/pull/523.

This pull request would help avoid a copy of the `CharacterCollision`.

Using a reference is compatible with an owned `Vec` and also conveys the information that elements are only read.