### PR TITLE
fix: Fixed typo in castShape functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,7 @@ without affecting performance of the other parts of the simulation.
 - The method `QueryFilter::exclude_dynamic` is now a static method (the `self` argument was removed).
 - The `QueryPipeline::cast_shape` method has a new argument `stop_at_penertation`. If set to `false`, the linear
   shape-cast won’t immediately stop if the shape is penetrating another shape at its starting point **and** its
-  trajectory is such that it’s on a path to exist that penetration state.
+  trajectory is such that it’s on a path to exit that penetration state.
 - The `InteractionGroups` is now a set of explicit bit flags instead of a raw `u32`.
 - The world-space mass properties of rigid-bodies are now updated automatically whenever the user changes their
   position.

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -602,7 +602,7 @@ impl QueryPipeline {
     ///   limits the distance traveled by the shape to `shapeVel.norm() * maxToi`.
     /// * `stop_at_penetration` - If set to `false`, the linear shape-cast won’t immediately stop if
     ///   the shape is penetrating another shape at its starting point **and** its trajectory is such
-    ///   that it’s on a path to exist that penetration state.
+    ///   that it’s on a path to exit that penetration state.
     /// * `filter`: set of rules used to determine which collider is taken into account by this scene query.
     pub fn cast_shape(
         &self,


### PR DESCRIPTION
Similar change to https://github.com/dimforge/rapier.js/pull/280.