### PR TITLE
fix: character controller: walls less likely to trigger ground detection

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -519,7 +519,7 @@ impl KinematicCharacterController {
     ) -> bool {
         let normal = -(character_pos * manifold.local_n1);
 
-        if normal.dot(&self.up) >= 1.0e-5 {
+        if normal.dot(&self.up) >= 1.0e-3 {
             let prediction = self.predict_ground(dims.y);
             for contact in &manifold.points {
                 if contact.dist <= prediction {

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -519,6 +519,8 @@ impl KinematicCharacterController {
     ) -> bool {
         let normal = -(character_pos * manifold.local_n1);
 
+        // For the controller to be grounded, the angle between the contact normal and the up vector
+        // has to be smaller than acos(1.0e-3) = 89.94 degrees.
         if normal.dot(&self.up) >= 1.0e-3 {
             let prediction = self.predict_ground(dims.y);
             for contact in &manifold.points {


### PR DESCRIPTION
## Context

While trying out https://github.com/dimforge/bevy_rapier/pull/476 ; I noticed I could jump when hitting walls (particularly on the junction of 2 walls).

### Bug analysis
When printing the normal dot value, I had this value in air: `1.7037166e-5` (hitting a wall perfectly perpendicular)

The current epsilon being `1.0e-5` ; [this dot check](https://github.com/Vrixyz/rapier/blob/c88e1eaf1b225e36188befab31bb24e7a2c4c69c/src/control/character_controller.rs#L522) is `true`, then `is_grounded` is `true`, and the character can jump in the example from https://github.com/dimforge/bevy_rapier/pull/476.

## Solution decription

I think it makes sense to relax this epsilon ; alternatively we could:
- reuse the slope authorized for the character
- or really pump that value, and/or normalize it
- make it configurable

But that first fix is probably an easy sufficient fix ?

I'm wondering if this has anything to do with scaled transforms ?