### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-## Unreleased
+## v0.21.0 (23 June 2024)
 
 ### Fix
 
-- Fix `NaN` values appearing in bodies translation and rotation after a simulation step with a delta time equal to 0 ([#660](https://github.com/dimforge/rapier/pull/660)).
+- Fix `NaN` values appearing in bodies translation and rotation after a simulation step with a delta time equal to
+  0 ([#660](https://github.com/dimforge/rapier/pull/660)).
+- Fix crash in the SAP broad-phase when teleporting an object.
 
 ### Modified
 
+- Update to `nalgebra` 0.33 and `parry` 0.16.
 - `solve_character_collision_impulses` collisions parameter is now an iterator over references.
 
 ## v0.20.0 (9 June 2024)

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier3d-stl/Cargo.toml
+++ b/crates/rapier3d-stl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-stl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-stl"
@@ -16,4 +16,4 @@ edition = "2021"
 thiserror = "1.0.61"
 stl_io = "0.7"
 
-rapier3d = { version = "0.20", path = "../rapier3d" }
+rapier3d = { version = "0.21", path = "../rapier3d" }

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-urdf"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
@@ -22,5 +22,5 @@ bitflags = "2"
 # NOTE: we are not using the (more recent) urdf-rs crate because of https://github.com/openrr/urdf-rs/issues/94
 xurdf = "0.2"
 
-rapier3d = { version = "0.20", path = "../rapier3d" }
-rapier3d-stl = { version = "0.1.0", path = "../rapier3d-stl", optional = true }
+rapier3d = { version = "0.21", path = "../rapier3d" }
+rapier3d-stl = { version = "0.2.0", path = "../rapier3d-stl", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_asset", "
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.20.0"
+version = "0.21.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -59,5 +59,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_sprite", 
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.20.0"
+version = "0.21.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -58,5 +58,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.20.0"
+version = "0.21.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.org"
@@ -62,5 +62,5 @@ bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.20.0"
+version = "0.21.0"
 features = ["serde-serialize", "debug-render", "profiler"]


### PR DESCRIPTION
## v0.21.0 (23 June 2024)

### Fix

- Fix `NaN` values appearing in bodies translation and rotation after a simulation step with a delta time equal to
  0 ([#660](https://github.com/dimforge/rapier/pull/660)).
- Fix crash in the SAP broad-phase when teleporting an object.

### Modified

- Update to `nalgebra` 0.33 and `parry` 0.16.
- `solve_character_collision_impulses` collisions parameter is now an iterator over references.
