### PR TITLE
Rotation gizmo for Ball 2d collider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- Implement rotation gizmo for Ball 2D shape (as radius line) in Debug renderer if `DebugRenderMode::COLLIDER_SHAPES` enabled
+
 ## v0.21.0 (23 June 2024)
 
 ### Fix

--- a/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
@@ -369,6 +369,13 @@ impl DebugRenderPipeline {
                     &Vector::repeat(s.radius * 2.0),
                     color,
                     true,
+                );
+                // Draw a radius line to visualize rotation
+                backend.draw_line(
+                    object,
+                    pos * Point::new(s.radius * 0.2, 0.0),
+                    pos * Point::new(s.radius * 0.8, 0.0),
+                    color,
                 )
             }
             TypedShape::Cuboid(s) => {


### PR DESCRIPTION
add radius line in debug mode for Ball 2d collider in order to visualize rotations

Closes #657 