### PR TITLE
Remove check for `target_arch = "asmjs"`

### DIFF
--- a/examples3d/all_examples3_wasm.rs
+++ b/examples3d/all_examples3_wasm.rs
@@ -51,7 +51,7 @@ fn demo_name_from_command_line() -> Option<String> {
     None
 }
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(target_arch = "wasm32")]
 fn demo_name_from_url() -> Option<String> {
     None
     //    let window = stdweb::web::window();
@@ -63,7 +63,7 @@ fn demo_name_from_url() -> Option<String> {
     //    }
 }
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+#[cfg(not(target_arch = "wasm32"))]
 fn demo_name_from_url() -> Option<String> {
     None
 }


### PR DESCRIPTION
This is long obsolete and was removed from Rust itself in https://github.com/rust-lang/rust/pull/117338