### PR TITLE
Use `bitflags!` consistently.

### DIFF
--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -75,9 +75,7 @@ impl Default for InteractionGroups {
     }
 }
 
-use bitflags::bitflags;
-
-bitflags! {
+bitflags::bitflags! {
     /// A bit mask identifying groups for interaction.
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -3,9 +3,6 @@
 
 extern crate nalgebra as na;
 
-#[macro_use]
-extern crate bitflags;
-
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -74,7 +74,7 @@ fn usage(exe_name: &str) {
     info!("    --pause - do not start the simulation right away.");
 }
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
     pub struct TestbedStateFlags: u32 {
         const NONE = 0;
@@ -91,7 +91,7 @@ bitflags! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub struct TestbedActionFlags: u32 {
         const RESET_WORLD_GRAPHICS = 1 << 0;


### PR DESCRIPTION
This removes an `extern crate` and a `use` so that we always call it via `bitflags::bitflags!` everywhere.