### PR TITLE
Prefer explicit features for optional deps.

### DIFF
--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -19,17 +19,17 @@ maintenance = { status = "actively-developed" }
 default = ["dim2", "f64"]
 dim2 = []
 f64 = []
-parallel = ["rayon"]
+parallel = ["dep:rayon"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
-simd-is-enabled = ["vec_map"]
+simd-is-enabled = ["dep:vec_map"]
 wasm-bindgen = ["instant/wasm-bindgen"]
-serde-serialize = ["nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde"]
+serde-serialize = ["nalgebra/serde-serialize", "parry2d-f64/serde-serialize", "dep:serde", "bit-vec/serde", "arrayvec/serde"]
 enhanced-determinism = ["simba/libm_force", "parry2d-f64/enhanced-determinism"]
 debug-render = []
-profiler = ["instant"] # Enables the internal profiler.
+profiler = ["dep:instant"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -19,17 +19,17 @@ maintenance = { status = "actively-developed" }
 default = ["dim2", "f32"]
 dim2 = []
 f32 = []
-parallel = ["rayon"]
+parallel = ["dep:rayon"]
 simd-stable = ["simba/wide", "simd-is-enabled"]
 simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
-simd-is-enabled = ["vec_map"]
+simd-is-enabled = ["dep:vec_map"]
 wasm-bindgen = ["instant/wasm-bindgen"]
-serde-serialize = ["nalgebra/serde-serialize", "parry2d/serde-serialize", "serde", "bit-vec/serde", "arrayvec/serde"]
+serde-serialize = ["nalgebra/serde-serialize", "parry2d/serde-serialize", "dep:serde", "bit-vec/serde", "arrayvec/serde"]
 enhanced-determinism = ["simba/libm_force", "parry2d/enhanced-determinism"]
 debug-render = []
-profiler = ["instant"] # Enables the internal profiler.
+profiler = ["dep:instant"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -19,17 +19,17 @@ maintenance = { status = "actively-developed" }
 default = ["dim3", "f64"]
 dim3 = []
 f64 = []
-parallel = ["rayon"]
+parallel = ["dep:rayon"]
 simd-stable = ["parry3d-f64/simd-stable", "simba/wide", "simd-is-enabled"]
 simd-nightly = ["parry3d-f64/simd-nightly", "simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
-simd-is-enabled = ["vec_map"]
+simd-is-enabled = ["dep:vec_map"]
 wasm-bindgen = ["instant/wasm-bindgen"]
-serde-serialize = ["nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "serde", "bit-vec/serde"]
+serde-serialize = ["nalgebra/serde-serialize", "parry3d-f64/serde-serialize", "dep:serde", "bit-vec/serde"]
 enhanced-determinism = ["simba/libm_force", "parry3d-f64/enhanced-determinism"]
 debug-render = []
-profiler = ["instant"] # Enables the internal profiler.
+profiler = ["dep:instant"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-stl = ["rapier3d-stl"]
+stl = ["dep:rapier3d-stl"]
 
 [dependencies]
 log = "0.4"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -19,17 +19,17 @@ maintenance = { status = "actively-developed" }
 default = ["dim3", "f32"]
 dim3 = []
 f32 = []
-parallel = ["rayon"]
+parallel = ["dep:rayon"]
 simd-stable = ["parry3d/simd-stable", "simba/wide", "simd-is-enabled"]
 simd-nightly = ["parry3d/simd-nightly", "simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
-simd-is-enabled = ["vec_map"]
+simd-is-enabled = ["dep:vec_map"]
 wasm-bindgen = ["instant/wasm-bindgen"]
-serde-serialize = ["nalgebra/serde-serialize", "parry3d/serde-serialize", "serde", "bit-vec/serde"]
+serde-serialize = ["nalgebra/serde-serialize", "parry3d/serde-serialize", "dep:serde", "bit-vec/serde"]
 enhanced-determinism = ["simba/libm_force", "parry3d/enhanced-determinism"]
 debug-render = []
-profiler = ["instant"] # Enables the internal profiler.
+profiler = ["dep:instant"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub extern crate parry3d_f64 as parry;
 
 pub extern crate crossbeam;
 pub extern crate nalgebra as na;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-serialize")]
 #[macro_use]
 extern crate serde;
 extern crate num_traits as num;

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -767,7 +767,7 @@ mod test {
         );
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde-serialize")]
     #[test]
     fn rigid_body_removal_snapshot_handle_determinism() {
         let mut colliders = ColliderSet::new();


### PR DESCRIPTION
Implicit features are slated to be removed in a future version of Rust (2024 edition).

Fixing this exposed 2 instances where the wrong feature was being checked for `serde` vs `serde-serialize`.