### PR TITLE
Use workspace lints to control unexpected_cfgs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ members = ["crates/rapier2d", "crates/rapier2d-f64", "crates/rapier_testbed2d", 
     "crates/rapier3d", "crates/rapier3d-f64", "crates/rapier_testbed3d", "crates/rapier_testbed3d-f64", "examples3d", "examples3d-f64", "benchmarks3d", "crates/rapier3d-urdf", "crates/rapier3d-stl"]
 resolver = "2"
 
+[workspace.lints]
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "dim3", "f32", "f64"))',
+    # The `other-backends` feature isn't in the tested3d-f64
+    # but easier to just ignore it here.
+    'cfg(feature, values("other-backends"))',
+] }
+
 [patch.crates-io]
 #wrapped2d = { git = "https://github.com/Bastacyclop/rust_box2d.git" }
 #xurdf = { path = "../xurdf/xurdf" }

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim2", "f64"]
 dim2 = []

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim2", "f32"]
 dim2 = []

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim3", "f64"]
 dim3 = []

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim3", "f32"]
 dim3 = []

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -24,6 +24,9 @@ name = "rapier_testbed2d"
 path = "../../src_testbed/lib.rs"
 required-features = ["dim2"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim2"]
 dim2 = []

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -24,6 +24,9 @@ name = "rapier_testbed2d"
 path = "../../src_testbed/lib.rs"
 required-features = ["dim2"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim2"]
 dim2 = []

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -24,6 +24,9 @@ name = "rapier_testbed3d"
 path = "../../src_testbed/lib.rs"
 required-features = ["dim3"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim3"]
 dim3 = []

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -24,6 +24,9 @@ name = "rapier_testbed3d"
 path = "../../src_testbed/lib.rs"
 required-features = ["dim3"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["dim3"]
 dim3 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)] // TODO: remove this? I find that in the math code using indices adds clarity.
 #![allow(clippy::module_inception)]
-#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 #[cfg(all(feature = "dim2", feature = "f32"))]
 pub extern crate parry2d as parry;

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::too_many_arguments)]
-#![allow(unexpected_cfgs)] // This happens due to the dim2/dim3/f32/f64 cfg.
 
 extern crate nalgebra as na;
 


### PR DESCRIPTION
By using `workspace.lints`, we can configure lints once for everything (and then inherit it into the various crates).

The lint configuration for `unexpected_cfgs` works in 1.80+ and warns otherwise.