### PR TITLE
Remove commented out reference to array-macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ pub extern crate nalgebra as na;
 #[macro_use]
 extern crate serde;
 extern crate num_traits as num;
-// #[macro_use]
-// extern crate array_macro;
 
 #[cfg(feature = "parallel")]
 pub use rayon;


### PR DESCRIPTION
This has been commented out since the first public release of Rapier in 2020.