### PR TITLE
testbed: Remove use of missing log feature

### DIFF
--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -3,10 +3,6 @@
 
 extern crate nalgebra as na;
 
-#[cfg(feature = "log")]
-#[macro_use]
-extern crate log;
-
 pub use crate::graphics::{BevyMaterial, GraphicsManager};
 pub use crate::harness::plugin::HarnessPlugin;
 pub use crate::physics::PhysicsState;

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -56,22 +56,12 @@ pub enum RunMode {
     Step,
 }
 
-#[cfg(not(feature = "log"))]
 fn usage(exe_name: &str) {
     println!("Usage: {} [OPTION] ", exe_name);
     println!();
     println!("Options:");
     println!("    --help  - prints this help message and exits.");
     println!("    --pause - do not start the simulation right away.");
-}
-
-#[cfg(feature = "log")]
-fn usage(exe_name: &str) {
-    info!("Usage: {} [OPTION] ", exe_name);
-    info!("");
-    info!("Options:");
-    info!("    --help  - prints this help message and exits.");
-    info!("    --pause - do not start the simulation right away.");
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
This code has been here but not used for a long time. There's no log feature (or dependency) within the testbed crates.