### PR TITLE
clippy: Fix `clippy::lazy_doc_continuation` lints

### DIFF
--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -15,7 +15,7 @@
 //! these elements are very welcome!
 //!
 //! - Mesh file types other than `stl` are not supported yet. Contributions are welcome. You my check the `rapier3d-stl`
-//! repository for an example of mesh loader.
+//!   repository for an example of mesh loader.
 //! - When inserting joints as multibody joints, they will be reset to their neutral position (all coordinates = 0).
 //! - The following fields are currently ignored:
 //!     - `Joint::dynamics`

--- a/src/geometry/broad_phase_multi_sap/broad_phase_multi_sap.rs
+++ b/src/geometry/broad_phase_multi_sap/broad_phase_multi_sap.rs
@@ -57,6 +57,7 @@ use parry::utils::hashmap::HashMap;
 ///   of the layer `n + 1`.
 /// - When an Aabb in the region of the layer `n + 1` intersects the Aabb corresponding to one of the
 ///   regions at the smaller layer `n`, we add that Aabb to that smaller region.
+///
 /// So in the end it means that a given Aabb will be inserted into all the region it intersects at
 /// the layer `n`. And it will also be inserted into all the regions it intersects at the smaller layers
 /// (the layers `< n`), but only for the regions that already exist (so we don't have to discretize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! Rapier has some unique features for collaborative applications:
 //! - The ability to snapshot the state of the physics engine, and restore it later.
 //! - The ability to run a perfectly deterministic simulation on different machine, as long as they
-//! are compliant with the IEEE 754-2008 floating point standard.
+//!   are compliant with the IEEE 754-2008 floating point standard.
 //!
 //! User documentation for Rapier is on [the official Rapier site](https://rapier.rs/docs/).
 


### PR DESCRIPTION
These will be enabled in Rust 1.80 by default.