### PR TITLE
Release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.22.0 (20 July 2024)
 
 ### Fix
 
@@ -15,6 +15,8 @@
 
 ### Modified
 
+- Update parry to v0.17. Refer to [its changelog](https://github.com/dimforge/parry/blob/master/CHANGELOG.md#v0170) for
+  further details.
 - Divided by two the value of each `QueryFilterFlags` variant so that
   the smallest one is 1 instead of 2 (fixes a bug in rapier.js).
 - `BroadphaseMultiSap` now serializes its `colliders_proxy_ids` as `Vec[(ColliderHandle, BroadPhaseProxyIndex)]`.

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -64,7 +64,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d-f64 = "0.16.0"
+parry2d-f64 = "0.17.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -64,7 +64,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d = "0.16.0"
+parry2d = "0.17.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -67,7 +67,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d-f64 = "0.16.0"
+parry3d-f64 = "0.17.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-stl/Cargo.toml
+++ b/crates/rapier3d-stl/Cargo.toml
@@ -16,4 +16,4 @@ edition = "2021"
 thiserror = "1.0.61"
 stl_io = "0.7"
 
-rapier3d = { version = "0.21", path = "../rapier3d" }
+rapier3d = { version = "0.22", path = "../rapier3d" }

--- a/crates/rapier3d-stl/src/lib.rs
+++ b/crates/rapier3d-stl/src/lib.rs
@@ -90,7 +90,7 @@ pub fn load_from_raw_mesh(
     let mut vertices: Vec<_> = raw_mesh
         .vertices
         .iter()
-        .map(|xyz| Point::new(xyz[0] as Real, xyz[1] as Real, xyz[2] as Real))
+        .map(|xyz| Point::new(xyz[0], xyz[1], xyz[2]))
         .collect();
     vertices
         .iter_mut()

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -22,5 +22,5 @@ bitflags = "2"
 # NOTE: we are not using the (more recent) urdf-rs crate because of https://github.com/openrr/urdf-rs/issues/94
 xurdf = "0.2"
 
-rapier3d = { version = "0.21", path = "../rapier3d" }
+rapier3d = { version = "0.22", path = "../rapier3d" }
 rapier3d-stl = { version = "0.2.0", path = "../rapier3d-stl", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -67,7 +67,7 @@ vec_map = { version = "0.8", optional = true }
 instant = { version = "0.1", features = ["now"], optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d = "0.16.0"
+parry3d = "0.17.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -84,5 +84,5 @@ bevy = { version = "0.13", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.21.0"
+version = "0.22.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -84,5 +84,5 @@ bevy = { version = "0.13", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.21.0"
+version = "0.22.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -81,5 +81,5 @@ bevy = { version = "0.13", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.21.0"
+version = "0.22.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -85,5 +85,5 @@ bevy = { version = "0.13", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.21.0"
+version = "0.22.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::bad_bit_mask)] // otherwise clippy complains because of TestbedStateFlags::NONE which is 0.
+#![allow(clippy::unnecessary_cast)] // allowed for f32 -> f64 cast for the f64 testbed.
 
 use std::env;
 use std::mem;


### PR DESCRIPTION
## v0.22.0 (20 July 2024)

### Fix

- Fix crash when removing a multibody joint, or a rigid-body with a multipody-joint attached to it.
- Fix crash when inserting multibody joints in an arbitrary order (instead of incrementally from root to leaf).
- Fix `BroadphaseMultiSap` not being able to serialize correctly with serde_json.

### Added

- Implement rotation gizmo for Ball 2D shape (as radius line) in Debug renderer if `DebugRenderMode::COLLIDER_SHAPES`
  enabled
- Implement `Debug` for `ColliderSet`, `InteractionGraph`,
  `MultibodyLink`, `MultibodyJointSet`, `Multibody`, `ImpulseJointSet`

### Modified

- Update parry to v0.17. Refer to [its changelog](https://github.com/dimforge/parry/blob/master/CHANGELOG.md#v0170) for
  further details.
- Divided by two the value of each `QueryFilterFlags` variant so that
  the smallest one is 1 instead of 2 (fixes a bug in rapier.js).
- `BroadphaseMultiSap` now serializes its `colliders_proxy_ids` as `Vec[(ColliderHandle, BroadPhaseProxyIndex)]`.
