### PR TITLE
ci: Enable same features as docs.rs in cargo doc

### DIFF
--- a/.github/workflows/rapier-ci-build.yml
+++ b/.github/workflows/rapier-ci-build.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cargo doc
-        run: cargo doc -p rapier3d -p rapier2d -p rapier3d-stl -p rapier3d-urdf
+        run: cargo doc --features parallel,simd-stable,serde-serialize,debug-render -p rapier3d -p rapier2d -p rapier3d-stl -p rapier3d-urdf
   build-native:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This is my version of what's in #694 for CI, but only that, and using the same set of features that docs.rs uses.