### PR TITLE
Fix intradoc link to fix CI.

### DIFF
--- a/src/pipeline/debug_render_pipeline/debug_render_style.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_style.rs
@@ -48,7 +48,7 @@ pub struct DebugRenderStyle {
     pub contact_normal_color: DebugColor,
     /// The length of the contact normals.
     pub contact_normal_length: Real,
-    /// The color of the colliders' [`Aabb`]s.
+    /// The color of the colliders' [`Aabb`](crate::geometry::Aabb)s.
     pub collider_aabb_color: DebugColor,
 }
 


### PR DESCRIPTION
@Vrixyz This happened when you modified one of my PRs to add links for the `Aabb` and the `cargo doc` improvements weren't in place yet to pick it up at that time. (Using merge queues would improve this...)