### PR TITLE
Color visualization for grounded character controller

### DIFF
--- a/examples2d/character_controller2.rs
+++ b/examples2d/character_controller2.rs
@@ -29,6 +29,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let character_handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::capsule_y(0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
+    testbed.set_initial_body_color(character_handle, [0.8, 0.2, 0.2]);
 
     /*
      * Create the cubes

--- a/examples2d/character_controller2.rs
+++ b/examples2d/character_controller2.rs
@@ -29,7 +29,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let character_handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::capsule_y(0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
-    testbed.set_initial_body_color(character_handle, [0.8, 0.2, 0.2]);
+    testbed.set_initial_body_color(character_handle, [0.8, 0.1, 0.1]);
 
     /*
      * Create the cubes

--- a/examples3d/character_controller3.rs
+++ b/examples3d/character_controller3.rs
@@ -45,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let character_handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::capsule_y(0.3 * scale, 0.15 * scale); // 0.15, 0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
-    testbed.set_initial_body_color(character_handle, [0.8, 0.2, 0.2]);
+    testbed.set_initial_body_color(character_handle, [0.8, 0.1, 0.1]);
 
     /*
      * Create the cubes

--- a/examples3d/character_controller3.rs
+++ b/examples3d/character_controller3.rs
@@ -45,6 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let character_handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::capsule_y(0.3 * scale, 0.15 * scale); // 0.15, 0.3, 0.15);
     colliders.insert_with_parent(collider, character_handle, &mut bodies);
+    testbed.set_initial_body_color(character_handle, [0.8, 0.2, 0.2]);
 
     /*
      * Create the cubes

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -417,7 +417,6 @@ impl TestbedApp {
                 .add_systems(Update, track_mouse_state);
 
             init(&mut app);
-
             app.run();
         }
     }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -807,13 +807,13 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
             if let Some(graphics) = &mut self.graphics {
                 if mvt.grounded {
                     graphics.graphics.set_body_color(
-                        &mut graphics.materials,
+                        graphics.materials,
                         character_handle,
                         [0.1, 0.8, 0.1],
                     );
                 } else {
                     graphics.graphics.set_body_color(
-                        &mut graphics.materials,
+                        graphics.materials,
                         character_handle,
                         [0.8, 0.1, 0.1],
                     );

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -417,6 +417,7 @@ impl TestbedApp {
                 .add_systems(Update, track_mouse_state);
 
             init(&mut app);
+
             app.run();
         }
     }
@@ -803,6 +804,21 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
                 QueryFilter::new().exclude_rigid_body(character_handle),
                 |c| collisions.push(c),
             );
+            if let Some(graphics) = &mut self.graphics {
+                if mvt.grounded {
+                    graphics.graphics.set_body_color(
+                        &mut graphics.materials,
+                        character_handle,
+                        [0.1, 0.8, 0.1],
+                    );
+                } else {
+                    graphics.graphics.set_body_color(
+                        &mut graphics.materials,
+                        character_handle,
+                        [0.8, 0.1, 0.1],
+                    );
+                }
+            }
             controller.solve_character_collision_impulses(
                 phx.integration_parameters.dt,
                 &mut phx.bodies,


### PR DESCRIPTION
It's currently difficult to assess if character controller ground detection works correctly, this adds a visual helper (the capsule turns red when not grounded) to detect it more quickly in the examples.

https://github.com/user-attachments/assets/f0a5b817-4563-46db-a6fe-16d5433d91b3


<details><summary>ground detection analysis</summary>
<p>

when calling `colliders_with_aabb_intersecting_aabb` from within `detect_grounded_status_and_apply_friction`
, it sometimes doesn't get any manifests, resulting in `grounded = false`.

- Honestly, a raycast down is probably less work than fiddling with nudge factor, numerical errors, shape implementations and whatnot 🤔 

- Or maybe just exposing or bumping up the predict ground distance around https://github.com/dimforge/rapier/blob/661c33f64c5a3392f5abb8a200151be8580ec9e5/src/control/character_controller.rs#L400

- I tested it against https://github.com/dimforge/rapier/pull/481, and still have not grounded frames.

</p>
</details> 