### PR TITLE
Use a reserved "Default" layer for memberships in `InteractionGroups`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The region key has been replaced by an i64 in the f64 version of rapier, increasing the range before panics occur.
 
+### Modified
+
+- `InteractionGroups` default value for `memberships` is now `GROUP_1` (#706)
+
 ## v0.22.0 (20 July 2024)
 
 ### Fix

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -72,7 +72,7 @@ impl InteractionGroups {
 impl Default for InteractionGroups {
     fn default() -> Self {
         Self {
-            memberships: Group::DEFAULT,
+            memberships: Group::GROUP_1,
             filter: Group::ALL,
         }
     }
@@ -83,70 +83,70 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
     pub struct Group: u32 {
-        /// The default group.
-        const DEFAULT = 1 << 0;
-        /// The group n°1.
-        const GROUP_1 = 1 << 1;
+        /// The group n°1, the default group.
+        const GROUP_1 = 1 << 0;
         /// The group n°2.
-        const GROUP_2 = 1 << 2;
+        const GROUP_2 = 1 << 1;
         /// The group n°3.
-        const GROUP_3 = 1 << 3;
+        const GROUP_3 = 1 << 2;
         /// The group n°4.
-        const GROUP_4 = 1 << 4;
+        const GROUP_4 = 1 << 3;
         /// The group n°5.
-        const GROUP_5 = 1 << 5;
+        const GROUP_5 = 1 << 4;
         /// The group n°6.
-        const GROUP_6 = 1 << 6;
+        const GROUP_6 = 1 << 5;
         /// The group n°7.
-        const GROUP_7 = 1 << 7;
+        const GROUP_7 = 1 << 6;
         /// The group n°8.
-        const GROUP_8 = 1 << 8;
+        const GROUP_8 = 1 << 7;
         /// The group n°9.
-        const GROUP_9 = 1 << 9;
+        const GROUP_9 = 1 << 8;
         /// The group n°10.
-        const GROUP_10 = 1 << 10;
+        const GROUP_10 = 1 << 9;
         /// The group n°11.
-        const GROUP_11 = 1 << 11;
+        const GROUP_11 = 1 << 10;
         /// The group n°12.
-        const GROUP_12 = 1 << 12;
+        const GROUP_12 = 1 << 11;
         /// The group n°13.
-        const GROUP_13 = 1 << 13;
+        const GROUP_13 = 1 << 12;
         /// The group n°14.
-        const GROUP_14 = 1 << 14;
+        const GROUP_14 = 1 << 13;
         /// The group n°15.
-        const GROUP_15 = 1 << 15;
+        const GROUP_15 = 1 << 14;
         /// The group n°16.
-        const GROUP_16 = 1 << 16;
+        const GROUP_16 = 1 << 15;
         /// The group n°17.
-        const GROUP_17 = 1 << 17;
+        const GROUP_17 = 1 << 16;
         /// The group n°18.
-        const GROUP_18 = 1 << 18;
+        const GROUP_18 = 1 << 17;
         /// The group n°19.
-        const GROUP_19 = 1 << 19;
+        const GROUP_19 = 1 << 18;
         /// The group n°20.
-        const GROUP_20 = 1 << 20;
+        const GROUP_20 = 1 << 19;
         /// The group n°21.
-        const GROUP_21 = 1 << 21;
+        const GROUP_21 = 1 << 20;
         /// The group n°22.
-        const GROUP_22 = 1 << 22;
+        const GROUP_22 = 1 << 21;
         /// The group n°23.
-        const GROUP_23 = 1 << 23;
+        const GROUP_23 = 1 << 22;
         /// The group n°24.
-        const GROUP_24 = 1 << 24;
+        const GROUP_24 = 1 << 23;
         /// The group n°25.
-        const GROUP_25 = 1 << 25;
+        const GROUP_25 = 1 << 24;
         /// The group n°26.
-        const GROUP_26 = 1 << 26;
+        const GROUP_26 = 1 << 25;
         /// The group n°27.
-        const GROUP_27 = 1 << 27;
+        const GROUP_27 = 1 << 26;
         /// The group n°28.
-        const GROUP_28 = 1 << 28;
+        const GROUP_28 = 1 << 27;
         /// The group n°29.
-        const GROUP_29 = 1 << 29;
+        const GROUP_29 = 1 << 28;
         /// The group n°30.
-        const GROUP_30 = 1 << 30;
+        const GROUP_30 = 1 << 29;
         /// The group n°31.
-        const GROUP_31 = 1 << 31;
+        const GROUP_31 = 1 << 30;
+        /// The group n°32.
+        const GROUP_32 = 1 << 31;
 
         /// All of the groups.
         const ALL = u32::MAX;

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -71,7 +71,10 @@ impl InteractionGroups {
 
 impl Default for InteractionGroups {
     fn default() -> Self {
-        Self::all()
+        Self {
+            memberships: Group::DEFAULT,
+            filter: Group::ALL,
+        }
     }
 }
 
@@ -80,70 +83,70 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
     pub struct Group: u32 {
+        /// The default group.
+        const DEFAULT = 1 << 0;
         /// The group n°1.
-        const GROUP_1 = 1 << 0;
+        const GROUP_1 = 1 << 1;
         /// The group n°2.
-        const GROUP_2 = 1 << 1;
+        const GROUP_2 = 1 << 2;
         /// The group n°3.
-        const GROUP_3 = 1 << 2;
+        const GROUP_3 = 1 << 3;
         /// The group n°4.
-        const GROUP_4 = 1 << 3;
+        const GROUP_4 = 1 << 4;
         /// The group n°5.
-        const GROUP_5 = 1 << 4;
+        const GROUP_5 = 1 << 5;
         /// The group n°6.
-        const GROUP_6 = 1 << 5;
+        const GROUP_6 = 1 << 6;
         /// The group n°7.
-        const GROUP_7 = 1 << 6;
+        const GROUP_7 = 1 << 7;
         /// The group n°8.
-        const GROUP_8 = 1 << 7;
+        const GROUP_8 = 1 << 8;
         /// The group n°9.
-        const GROUP_9 = 1 << 8;
+        const GROUP_9 = 1 << 9;
         /// The group n°10.
-        const GROUP_10 = 1 << 9;
+        const GROUP_10 = 1 << 10;
         /// The group n°11.
-        const GROUP_11 = 1 << 10;
+        const GROUP_11 = 1 << 11;
         /// The group n°12.
-        const GROUP_12 = 1 << 11;
+        const GROUP_12 = 1 << 12;
         /// The group n°13.
-        const GROUP_13 = 1 << 12;
+        const GROUP_13 = 1 << 13;
         /// The group n°14.
-        const GROUP_14 = 1 << 13;
+        const GROUP_14 = 1 << 14;
         /// The group n°15.
-        const GROUP_15 = 1 << 14;
+        const GROUP_15 = 1 << 15;
         /// The group n°16.
-        const GROUP_16 = 1 << 15;
+        const GROUP_16 = 1 << 16;
         /// The group n°17.
-        const GROUP_17 = 1 << 16;
+        const GROUP_17 = 1 << 17;
         /// The group n°18.
-        const GROUP_18 = 1 << 17;
+        const GROUP_18 = 1 << 18;
         /// The group n°19.
-        const GROUP_19 = 1 << 18;
+        const GROUP_19 = 1 << 19;
         /// The group n°20.
-        const GROUP_20 = 1 << 19;
+        const GROUP_20 = 1 << 20;
         /// The group n°21.
-        const GROUP_21 = 1 << 20;
+        const GROUP_21 = 1 << 21;
         /// The group n°22.
-        const GROUP_22 = 1 << 21;
+        const GROUP_22 = 1 << 22;
         /// The group n°23.
-        const GROUP_23 = 1 << 22;
+        const GROUP_23 = 1 << 23;
         /// The group n°24.
-        const GROUP_24 = 1 << 23;
+        const GROUP_24 = 1 << 24;
         /// The group n°25.
-        const GROUP_25 = 1 << 24;
+        const GROUP_25 = 1 << 25;
         /// The group n°26.
-        const GROUP_26 = 1 << 25;
+        const GROUP_26 = 1 << 26;
         /// The group n°27.
-        const GROUP_27 = 1 << 26;
+        const GROUP_27 = 1 << 27;
         /// The group n°28.
-        const GROUP_28 = 1 << 27;
+        const GROUP_28 = 1 << 28;
         /// The group n°29.
-        const GROUP_29 = 1 << 28;
+        const GROUP_29 = 1 << 29;
         /// The group n°30.
-        const GROUP_30 = 1 << 29;
+        const GROUP_30 = 1 << 30;
         /// The group n°31.
-        const GROUP_31 = 1 << 30;
-        /// The group n°32.
-        const GROUP_32 = 1 << 31;
+        const GROUP_31 = 1 << 31;
 
         /// All of the groups.
         const ALL = u32::MAX;

--- a/src/geometry/interaction_groups.rs
+++ b/src/geometry/interaction_groups.rs
@@ -83,7 +83,7 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
     pub struct Group: u32 {
-        /// The group n°1, the default group.
+        /// The group n°1.
         const GROUP_1 = 1 << 0;
         /// The group n°2.
         const GROUP_2 = 1 << 1;


### PR DESCRIPTION
Currently the default is to being a member of all groups with a filter/interaction with everything.

I believe this is a bit backwards and makes special interactions between groups harder to understand/deal with without flipping all of your logic to be a "non-membership" or by modifying the interaction groups of every object in your simulation.

This is more in line with what Box2d (one membership, all filter) and Godot (one membership, one filter) do currently, ~however there are counterexamples like Unity (all membership, all filter) and the current default.~ Unity is actually one membership/all filter as well since they do not allow multiple groups to be selected, however they allow configuring the default interactions/filters.

There is also an argument of all filter vs one filter as the default, but I do not believe it matters as much as the membership.