### PR TITLE
Fix CI

### DIFF
--- a/src/data/graph.rs
+++ b/src/data/graph.rs
@@ -517,74 +517,6 @@ impl<N, E> Graph<N, E> {
     }
 }
 
-/// An iterator over either the nodes without edges to them or from them.
-pub struct Externals<'a, N: 'a> {
-    iter: std::iter::Enumerate<std::slice::Iter<'a, Node<N>>>,
-    dir: Direction,
-}
-
-impl<'a, N: 'a> Iterator for Externals<'a, N> {
-    type Item = NodeIndex;
-    fn next(&mut self) -> Option<NodeIndex> {
-        let k = self.dir as usize;
-        loop {
-            match self.iter.next() {
-                None => return None,
-                Some((index, node)) => {
-                    if node.next[k] == EdgeIndex::end() && node.next[1 - k] == EdgeIndex::end() {
-                        return Some(NodeIndex::new(index as u32));
-                    } else {
-                        continue;
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Iterator over the neighbors of a node.
-///
-/// Iterator element type is `NodeIndex`.
-///
-/// Created with [`.neighbors()`][1], [`.neighbors_directed()`][2] or
-/// [`.neighbors_undirected()`][3].
-///
-/// [1]: struct.Graph.html#method.neighbors
-/// [2]: struct.Graph.html#method.neighbors_directed
-/// [3]: struct.Graph.html#method.neighbors_undirected
-pub struct Neighbors<'a, E: 'a> {
-    /// starting node to skip over
-    skip_start: NodeIndex,
-    edges: &'a [Edge<E>],
-    next: [EdgeIndex; 2],
-}
-
-impl<'a, E> Iterator for Neighbors<'a, E> {
-    type Item = NodeIndex;
-
-    fn next(&mut self) -> Option<NodeIndex> {
-        // First any outgoing edges
-        match self.edges.get(self.next[0].index()) {
-            None => {}
-            Some(edge) => {
-                self.next[0] = edge.next[0];
-                return Some(edge.node[1]);
-            }
-        }
-        // Then incoming edges
-        // For an "undirected" iterator (traverse both incoming
-        // and outgoing edge lists), make sure we don't double
-        // count selfloops by skipping them in the incoming list.
-        while let Some(edge) = self.edges.get(self.next[1].index()) {
-            self.next[1] = edge.next[1];
-            if edge.node[0] != self.skip_start {
-                return Some(edge.node[0]);
-            }
-        }
-        None
-    }
-}
-
 struct EdgesWalkerMut<'a, E: 'a> {
     edges: &'a mut [Edge<E>],
     next: EdgeIndex,
@@ -783,32 +715,3 @@ where
         self.index == rhs.index && self.weight == rhs.weight
     }
 }
-
-/// Iterator over all nodes of a graph.
-pub struct NodeReferences<'a, N: 'a> {
-    iter: std::iter::Enumerate<std::slice::Iter<'a, Node<N>>>,
-}
-
-impl<'a, N> Iterator for NodeReferences<'a, N> {
-    type Item = (NodeIndex, &'a N);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|(i, node)| (NodeIndex::new(i as u32), &node.weight))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
-}
-
-impl<'a, N> DoubleEndedIterator for NodeReferences<'a, N> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next_back()
-            .map(|(i, node)| (NodeIndex::new(i as u32), &node.weight))
-    }
-}
-
-impl<'a, N> ExactSizeIterator for NodeReferences<'a, N> {}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,7 +2,6 @@
 
 pub use self::arena::{Arena, Index};
 pub use self::coarena::Coarena;
-pub use graph::{Externals, Neighbors, NodeReferences};
 
 pub mod arena;
 mod coarena;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,7 @@
 
 pub use self::arena::{Arena, Index};
 pub use self::coarena::Coarena;
+pub use graph::{Externals, Neighbors, NodeReferences};
 
 pub mod arena;
 mod coarena;

--- a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
@@ -55,12 +55,13 @@ impl IndexedData for MultibodyJointHandle {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Indexes usable to get a multibody link from a `MultibodyJointSet`.
 ///
-/// ```.skip
+/// ```ignore
 /// // With:
 /// //     multibody_joint_set: MultibodyJointSet
 /// //     multibody_link_id: MultibodyLinkId
 /// let multibody = &multibody_joint_set[multibody_link_id.multibody];
 /// let link = multibody.link(multibody_link_id.id).expect("Link not found.");
+/// ```
 pub struct MultibodyLinkId {
     pub(crate) graph_id: RigidBodyGraphIndex,
     /// The multibody index to be used as `&multibody_joint_set[multibody]` to

--- a/src/geometry/interaction_graph.rs
+++ b/src/geometry/interaction_graph.rs
@@ -66,7 +66,7 @@ impl<N: Copy, E> InteractionGraph<N, E> {
     /// a map between `CollisionObjectSlabHandle` and `ColliderGraphIndex`, then you should update this
     /// map to associate `id` to the handle returned by this method. For example:
     ///
-    /// ```.ignore
+    /// ```ignore
     /// // Let `id` be the graph index of the collision object we want to remove.
     /// if let Some(other_handle) = graph.remove_node(id) {
     ///    // The graph index of `other_handle` changed to `id` due to the removal.


### PR DESCRIPTION
These new warnings come from rust 1.80.

I'd like to take this opportunity to fix unused `NodeReferences`, `Externals` and `Neighbors` ; I imagine they should be exposed, and not straight up deleted.