### PR TITLE
Fix shape modification not updating graphics in testbed

### DIFF
--- a/examples3d/debug_shape_modification3.rs
+++ b/examples3d/debug_shape_modification3.rs
@@ -39,15 +39,15 @@ pub fn init_world(testbed: &mut Testbed) {
      * Colliders without bodies
      */
     let shape_size = 3.0;
-    let static_collider = ColliderBuilder::ball(shape_size)
-        .translation(vector![-15.0, shape_size, 18.0]);
+    let static_collider =
+        ColliderBuilder::ball(shape_size).translation(vector![-15.0, shape_size, 18.0]);
     colliders.insert(static_collider);
 
-    let shapes = vec![
+    let shapes = [
         SharedShape::ball(shape_size),
         SharedShape::cuboid(shape_size, shape_size, shape_size),
         SharedShape::cone(shape_size, shape_size),
-        SharedShape::cylinder(shape_size, shape_size)
+        SharedShape::cylinder(shape_size, shape_size),
     ];
     let mut shape_idx = 0;
     let shapeshifting_collider = ColliderBuilder::new(shapes[shape_idx].clone())
@@ -72,11 +72,14 @@ pub fn init_world(testbed: &mut Testbed) {
             pos = *ball.position();
         }
 
-        let shapeshifting_coll = physics.colliders.get_mut(shapeshifting_coll_handle).unwrap();
+        let shapeshifting_coll = physics
+            .colliders
+            .get_mut(shapeshifting_coll_handle)
+            .unwrap();
         if step % 50 == 0 {
             shape_idx = (shape_idx + 1) % 4;
             shapeshifting_coll.set_shape(shapes[shape_idx].clone())
-        } 
+        }
 
         if step == 100 {
             ball.set_linvel(linvel, true);

--- a/examples3d/debug_shape_modification3.rs
+++ b/examples3d/debug_shape_modification3.rs
@@ -41,7 +41,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut step = 0;
     let snapped_frame = 51;
 
-    testbed.add_callback(move |_, physics, _, _| {
+    testbed.add_callback(move |mut gfx, physics, _, _| {
         step += 1;
 
         // Snap the ball velocity or restore it.
@@ -62,6 +62,10 @@ pub fn init_world(testbed: &mut Testbed) {
 
         let ball_coll = physics.colliders.get_mut(ball_coll_handle).unwrap();
         ball_coll.set_shape(SharedShape::ball(ball_rad * step as f32 * 2.0));
+        if let Some(gfx) = &mut gfx {
+            gfx.remove_collider(ball_coll_handle, &physics.colliders);
+            gfx.add_collider(ball_coll_handle, &physics.colliders);
+        }
     });
 
     /*

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -82,14 +82,18 @@ impl GraphicsManager {
         collider: ColliderHandle,
     ) {
         let body = body.unwrap_or(RigidBodyHandle::invalid());
-        if let Some(sns) = self.b2sn.get_mut(&body) {
-            for sn in sns.iter_mut() {
+        if let Some(sns) = self.b2sn.remove(&body) {
+            let mut new_sn = vec![];
+            for sn in sns.into_iter() {
                 if let Some(sn_c) = sn.collider {
                     if sn_c == collider {
                         commands.entity(sn.entity).despawn();
+                    } else {
+                        new_sn.push(sn);
                     }
                 }
             }
+            self.b2sn.insert(body, new_sn);
         }
     }
 

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -83,17 +83,17 @@ impl GraphicsManager {
     ) {
         let body = body.unwrap_or(RigidBodyHandle::invalid());
         if let Some(sns) = self.b2sn.remove(&body) {
-            let mut new_sn = vec![];
+            let mut new_sns = vec![];
             for sn in sns.into_iter() {
                 if let Some(sn_c) = sn.collider {
                     if sn_c == collider {
                         commands.entity(sn.entity).despawn();
                     } else {
-                        new_sn.push(sn);
+                        new_sns.push(sn);
                     }
                 }
             }
-            self.b2sn.insert(body, new_sn);
+            self.b2sn.insert(body, new_sns);
         }
     }
 

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -82,18 +82,17 @@ impl GraphicsManager {
         collider: ColliderHandle,
     ) {
         let body = body.unwrap_or(RigidBodyHandle::invalid());
-        if let Some(sns) = self.b2sn.remove(&body) {
-            let mut new_sns = vec![];
-            for sn in sns.into_iter() {
+        if let Some(sns) = self.b2sn.get_mut(&body) {
+            sns.retain(|sn| {
                 if let Some(sn_c) = sn.collider {
                     if sn_c == collider {
                         commands.entity(sn.entity).despawn();
-                    } else {
-                        new_sns.push(sn);
+                        return false;
                     }
                 }
-            }
-            self.b2sn.insert(body, new_sns);
+
+                true
+            });
         }
     }
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -492,13 +492,6 @@ impl TestbedGraphics<'_, '_, '_, '_, '_, '_> {
         )
     }
 
-    pub fn remove_collider(&mut self, handle: ColliderHandle, colliders: &ColliderSet) {
-        if let Some(parent_handle) = colliders.get(handle).map(|c| c.parent()) {
-            self.graphics
-                .remove_collider_nodes(&mut *self.commands, parent_handle, handle)
-        }
-    }
-
     pub fn remove_body(&mut self, handle: RigidBodyHandle) {
         self.graphics.remove_body_nodes(&mut *self.commands, handle)
     }
@@ -511,6 +504,18 @@ impl TestbedGraphics<'_, '_, '_, '_, '_, '_> {
             handle,
             colliders,
         )
+    }
+
+    pub fn remove_collider(&mut self, handle: ColliderHandle, colliders: &ColliderSet) {
+        if let Some(parent_handle) = colliders.get(handle).map(|c| c.parent()) {
+            self.graphics
+                .remove_collider_nodes(&mut *self.commands, parent_handle, handle)
+        }
+    }
+
+    pub fn update_collider(&mut self, handle: ColliderHandle, colliders: &ColliderSet) {
+        self.remove_collider(handle, colliders);
+        self.add_collider(handle, colliders);
     }
 
     pub fn keys(&self) -> &ButtonInput<KeyCode> {


### PR DESCRIPTION
This PR is for a fix for the `GraphicsManager::remove_collider_nodes` function in the testbed. The problem was that the entity was despawned but not removed from `GraphicsManager::b2sn`, creating an invalid state. See [this thread](https://discord.com/channels/507548572338880513/1246940826332958801) for the discussion.

`TestbedApp::add_callback` still requires a manual refresh with `gfx.add_collider` if the user wants to see the 3D entity update correctly.

```rust
if let Some(gfx) = &mut gfx {
    gfx.remove_collider(ball_coll_handle, &physics.colliders);
    gfx.add_collider(ball_coll_handle, &physics.colliders);
}
```

`debug_shape_modification3` before:

![before](https://github.com/user-attachments/assets/4636744a-3cda-47f4-90b4-b4263aae5bc5)

`debug_shape_modification3` after:

![after](https://github.com/user-attachments/assets/54fcf511-73b1-4d44-a35c-d6a25976e6f9)