### PR TITLE
fix character controller is_grounded 

### DIFF
--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -397,7 +397,7 @@ impl KinematicCharacterController {
     }
 
     fn predict_ground(&self, up_extends: Real) -> Real {
-        self.offset.eval(up_extends) * 1.1
+        self.offset.eval(up_extends) * 1.2
     }
 
     fn detect_grounded_status_and_apply_friction(


### PR DESCRIPTION
- in https://github.com/dimforge/rapier/pull/446 ; there had been a lot of experimentation on that offset. this `1.1` has been kept since the creation of the character controller.
- I think that 1.1 is not enough, I'm not sure exactly why there's number approximation this high, but manual testing results in better behaviour (no red controller from https://github.com/dimforge/rapier/pull/705), and automatic testing still passes.

## Some numbers

offset is `CharacterLength::Relative(0.01)`, then the height of the `CharacterController` in the exampple is `0.3`, resulting in an exxaggerated  offset (for aabb computation) of  `0.0033`. The nudge factor being `0.0001` shouldn´t impact that, but we're still in small numbers game. I think overshooting a bit won´t hurt much, especially if it fixes `is_grounded` reliability.

## TODO?
I think I can make a test about ground prediction (make a character walking on a trimesh for some time, verify it's always grounded), but I fear this test might not always catch such bug.

## Alternatives

We can consider exposing this offset multiplier, or the whole AABB used.