### PR TITLE
Improve capacity handling for `ColliderSet`, `RigidBodySet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - The region key has been replaced by an i64 in the f64 version of rapier, increasing the range before panics occur.
 - Fix `BroadphaseMultiSap` not being able to serialize correctly with serde_json.
 
+### Added
+
+- `RigidBodySet` and `ColliderSet` have a new constructor `with_capacity`.
+
 ### Modified
 
 - `InteractionGroups` default value for `memberships` is now `GROUP_1` (#706)

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -43,6 +43,14 @@ impl RigidBodySet {
         }
     }
 
+    /// Create a new set of rigid bodies, with an initial capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        RigidBodySet {
+            bodies: Arena::with_capacity(capacity),
+            modified_bodies: Vec::with_capacity(capacity),
+        }
+    }
+
     pub(crate) fn take_modified(&mut self) -> Vec<RigidBodyHandle> {
         std::mem::take(&mut self.modified_bodies)
     }

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -23,6 +23,17 @@ impl ColliderSet {
         }
     }
 
+    /// Create a new set of colliders, with an initial capacity
+    /// for the set of colliders as well as the tracking of
+    /// modified colliders.
+    pub fn with_capacity(capacity: usize) -> Self {
+        ColliderSet {
+            colliders: Arena::with_capacity(capacity),
+            modified_colliders: Vec::with_capacity(capacity),
+            removed_colliders: Vec::new(),
+        }
+    }
+
     pub(crate) fn take_modified(&mut self) -> Vec<ColliderHandle> {
         std::mem::take(&mut self.modified_colliders)
     }


### PR DESCRIPTION
These allow an application to reduce the cost of reallocation when they know that a large number of colliders or rigid bodies will be created.