### PR TITLE
chore: add publish script for urdf and stl + unify all releases by de…

### DIFF
--- a/.github/workflows/rapier-ci-build.yml
+++ b/.github/workflows/rapier-ci-build.yml
@@ -97,3 +97,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: check typos
         uses: crate-ci/typos@v1.23.2
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - name: publish dry-run
+        run: ./publish-all.sh

--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -490,7 +490,7 @@ fn urdf_to_rigid_body(options: &UrdfLoaderOptions, inertial: &Inertial) -> Rigid
 
 fn urdf_to_collider(
     options: &UrdfLoaderOptions,
-    _mesh_dir: &Path, // NOTO: this isn’t used if there is no extrenal mesh feature enabled (like stl).
+    _mesh_dir: &Path, // NOTO: this isn’t used if there is no external mesh feature enabled (like stl).
     geometry: &Geometry,
     origin: &Pose,
 ) -> Option<Collider> {

--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -32,10 +32,7 @@ use rapier3d::{
         JointAxis, MassProperties, MultibodyJointHandle, MultibodyJointSet, RigidBody,
         RigidBodyBuilder, RigidBodyHandle, RigidBodySet, RigidBodyType,
     },
-    geometry::{
-        Collider, ColliderBuilder, ColliderHandle, ColliderSet, MeshConverter, SharedShape,
-        TriMeshFlags,
-    },
+    geometry::{Collider, ColliderBuilder, ColliderHandle, ColliderSet, SharedShape, TriMeshFlags},
     math::{Isometry, Point, Real, Vector},
     na,
 };
@@ -493,7 +490,7 @@ fn urdf_to_rigid_body(options: &UrdfLoaderOptions, inertial: &Inertial) -> Rigid
 
 fn urdf_to_collider(
     options: &UrdfLoaderOptions,
-    mesh_dir: &Path,
+    _mesh_dir: &Path, // NOTO: this isn’t used if there is no extrenal mesh feature enabled (like stl).
     geometry: &Geometry,
     origin: &Pose,
 ) -> Option<Collider> {
@@ -514,17 +511,18 @@ fn urdf_to_collider(
         Geometry::Sphere { radius } => SharedShape::ball(*radius as Real),
         Geometry::Mesh { filename, scale } => {
             let path: &Path = filename.as_ref();
-            let scale = scale
+            let _scale = scale
                 .map(|s| Vector::new(s.x as Real, s.y as Real, s.z as Real))
                 .unwrap_or_else(|| Vector::<Real>::repeat(1.0));
             match path.extension().and_then(|ext| ext.to_str()) {
                 #[cfg(feature = "stl")]
                 Some("stl") | Some("STL") => {
-                    let full_path = mesh_dir.join(filename);
+                    use rapier3d::geometry::MeshConverter;
+                    let full_path = _mesh_dir.join(filename);
                     match rapier3d_stl::load_from_path(
                         full_path,
                         MeshConverter::TriMeshWithFlags(options.trimesh_flags),
-                        scale,
+                        _scale,
                     ) {
                         Ok(stl_shape) => {
                             shape_transform = stl_shape.pose;

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+if [[ "$PUBLISH_MODE" == 1 ]]
+then
+    ./scripts/publish-rapier.sh
+    ./scripts/publish-testbeds.sh
+    ./scripts/publish-extra-formats.sh
+else
+    echo "Running in dry mode, re-run with \`PUBLISH_MODE=1 publish-all.sh\` to actually publish."
+
+    DRY_RUN="--dry-run" ./scripts/publish-rapier.sh
+    DRY_RUN="--dry-run" ./scripts/publish-testbeds.sh
+    DRY_RUN="--dry-run" ./scripts/publish-extra-formats.sh
+fi

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -2,13 +2,13 @@
 
 if [[ "$PUBLISH_MODE" == 1 ]]
 then
-    ./scripts/publish-rapier.sh
-    ./scripts/publish-testbeds.sh
+    ./scripts/publish-rapier.sh &&
+    ./scripts/publish-testbeds.sh &&
     ./scripts/publish-extra-formats.sh
 else
     echo "Running in dry mode, re-run with \`PUBLISH_MODE=1 publish-all.sh\` to actually publish."
 
-    DRY_RUN="--dry-run" ./scripts/publish-rapier.sh
-    DRY_RUN="--dry-run" ./scripts/publish-testbeds.sh
+    DRY_RUN="--dry-run" ./scripts/publish-rapier.sh &&
+    DRY_RUN="--dry-run" ./scripts/publish-testbeds.sh &&
     DRY_RUN="--dry-run" ./scripts/publish-extra-formats.sh
 fi

--- a/scripts/publish-extra-formats.sh
+++ b/scripts/publish-extra-formats.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 currdir=$(pwd)
 

--- a/scripts/publish-extra-formats.sh
+++ b/scripts/publish-extra-formats.sh
@@ -3,9 +3,9 @@
 currdir=$(pwd)
 
 ### Publish rapier3d-stl.
-cd "crates/rapier3d-stl" && cargo publish $DRY_RUN
-cd "$currdir" || exit
+cd "crates/rapier3d-stl" && cargo publish $DRY_RUN || exit 1
+cd "$currdir" || exit 2
 
 ### Publish rapier3d-urdf.
-cd "crates/rapier3d-urdf" && cargo publish $DRY_RUN
-cd "$currdir" || exit
+cd "crates/rapier3d-urdf" && cargo publish $DRY_RUN || exit 1
+cd "$currdir" || exit 2

--- a/scripts/publish-extra-formats.sh
+++ b/scripts/publish-extra-formats.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+currdir=$(pwd)
+
+### Publish rapier3d-stl.
+cd "crates/rapier3d-stl" && cargo publish $DRY_RUN
+cd "$currdir" || exit
+
+### Publish rapier3d-urdf.
+cd "crates/rapier3d-urdf" && cargo publish $DRY_RUN
+cd "$currdir" || exit

--- a/scripts/publish-rapier.sh
+++ b/scripts/publish-rapier.sh
@@ -10,26 +10,26 @@ cp -r LICENSE README.md "$tmp"/.
 ### Publish the 2D version.
 sed 's#\.\./\.\./src#src#g' crates/rapier2d/Cargo.toml > "$tmp"/Cargo.toml
 currdir=$(pwd)
-cd "$tmp" && cargo publish $DRY_RUN
-cd "$currdir" || exit
+cd "$tmp" && cargo publish $DRY_RUN || exit 1
+cd "$currdir" || exit 2
 
 
 ### Publish the 3D version.
 sed 's#\.\./\.\./src#src#g' crates/rapier3d/Cargo.toml > "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
-cd "$tmp" && cargo publish $DRY_RUN
-cd "$currdir" || exit
+cd "$tmp" && cargo publish $DRY_RUN || exit 1
+cd "$currdir" || exit 2
 
 ### Publish the 2D f64 version.
 sed 's#\.\./\.\./src#src#g' crates/rapier2d-f64/Cargo.toml > "$tmp"/Cargo.toml
 currdir=$(pwd)
-cd "$tmp" && cargo publish $DRY_RUN
-cd "$currdir" || exit
+cd "$tmp" && cargo publish $DRY_RUN || exit 1
+cd "$currdir" || exit 2
 
 
 ### Publish the 3D f64 version.
 sed 's#\.\./\.\./src#src#g' crates/rapier3d-f64/Cargo.toml > "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
-cd "$tmp" && cargo publish $DRY_RUN
+cd "$tmp" && cargo publish $DRY_RUN || exit 1
 
 rm -rf "$tmp"

--- a/scripts/publish-rapier.sh
+++ b/scripts/publish-rapier.sh
@@ -10,26 +10,26 @@ cp -r LICENSE README.md "$tmp"/.
 ### Publish the 2D version.
 sed 's#\.\./\.\./src#src#g' crates/rapier2d/Cargo.toml > "$tmp"/Cargo.toml
 currdir=$(pwd)
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 cd "$currdir" || exit
 
 
 ### Publish the 3D version.
 sed 's#\.\./\.\./src#src#g' crates/rapier3d/Cargo.toml > "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 cd "$currdir" || exit
 
 ### Publish the 2D f64 version.
 sed 's#\.\./\.\./src#src#g' crates/rapier2d-f64/Cargo.toml > "$tmp"/Cargo.toml
 currdir=$(pwd)
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 cd "$currdir" || exit
 
 
 ### Publish the 3D f64 version.
 sed 's#\.\./\.\./src#src#g' crates/rapier3d-f64/Cargo.toml > "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 
 rm -rf "$tmp"

--- a/scripts/publish-rapier.sh
+++ b/scripts/publish-rapier.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 tmp=$(mktemp -d)
 

--- a/scripts/publish-testbeds.sh
+++ b/scripts/publish-testbeds.sh
@@ -13,7 +13,7 @@ cp -r LICENSE README.md "$tmp"/.
 gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed2d/Cargo.toml > "$tmp"/Cargo.toml
 gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
 currdir=$(pwd)
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 cd "$currdir" || exit
 
 
@@ -21,6 +21,6 @@ cd "$currdir" || exit
 gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed3d/Cargo.toml > "$tmp"/Cargo.toml
 gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
-cd "$tmp" && cargo publish
+cd "$tmp" && cargo publish $DRY_RUN
 
 rm -rf "$tmp"

--- a/scripts/publish-testbeds.sh
+++ b/scripts/publish-testbeds.sh
@@ -1,4 +1,12 @@
-#! /bin/bash
+#!/bin/bash
+
+gsed -v >> /dev/null
+if [ $? == 0 ]; then
+    gsed=gsed
+else
+    # Hopefully installed sed is the gnu one.
+    gsed=sed
+fi
 
 tmp=$(mktemp -d)
 
@@ -10,16 +18,16 @@ cp -r crates "$tmp"/.
 cp -r LICENSE README.md "$tmp"/.
 
 ### Publish the 2D version.
-gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed2d/Cargo.toml > "$tmp"/Cargo.toml
-gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
+$gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed2d/Cargo.toml > "$tmp"/Cargo.toml
+$gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
 currdir=$(pwd)
 cd "$tmp" && cargo publish $DRY_RUN
 cd "$currdir" || exit
 
 
 ### Publish the 3D version.
-gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed3d/Cargo.toml > "$tmp"/Cargo.toml
-gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
+$gsed 's#\.\./\.\./src#src#g' crates/rapier_testbed3d/Cargo.toml > "$tmp"/Cargo.toml
+$gsed -i 's#\.\./rapier#./crates/rapier#g' "$tmp"/Cargo.toml
 cp -r LICENSE README.md "$tmp"/.
 cd "$tmp" && cargo publish $DRY_RUN
 


### PR DESCRIPTION
- related to #720.
- Adds a script to publish urdf and stl
- default publish script publishes all crates, as they all depend on rapier, it's our most common usage.
- default behaviour for the root publish script is to run a dry-run, for being careful about it, and allow easier testing.
- :warning: This needs https://github.com/dimforge/rapier/pull/728 in order to build (I added a CI step to validate it fails, which will get green after that other PR)