### PR TITLE
Workspace lints in each crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,6 @@ members = [
 ]
 resolver = "2"
 
-[workspace.lints]
-rust.unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(feature, values("dim2", "dim3", "f32", "f64"))',
-    # The `other-backends` feature isn't in the tested3d-f64
-    # but easier to just ignore it here.
-    'cfg(feature, values("other-backends"))',
-] }
-
 [patch.crates-io]
 #wrapped2d = { git = "https://github.com/Bastacyclop/rust_box2d.git" }
 #xurdf = { path = "../xurdf/xurdf" }

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -22,7 +22,9 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim3", "f32"))',
+] }
 
 [features]
 default = ["dim2", "f64"]

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -22,7 +22,9 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim3", "f64"))',
+] }
 
 [features]
 default = ["dim2", "f32"]

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -22,7 +22,9 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "f32"))',
+] }
 
 [features]
 default = ["dim3", "f64"]

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -22,7 +22,9 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "f64"))',
+] }
 
 [features]
 default = ["dim3", "f32"]

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -25,7 +25,9 @@ path = "../../src_testbed/lib.rs"
 required-features = ["dim2"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim3", "f32"))',
+] }
 
 [features]
 default = ["dim2"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -25,7 +25,9 @@ path = "../../src_testbed/lib.rs"
 required-features = ["dim2"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim3", "f64"))',
+] }
 
 [features]
 default = ["dim2"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -25,7 +25,12 @@ path = "../../src_testbed/lib.rs"
 required-features = ["dim3"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "f32"))',
+    # The `other-backends` feature isn't in the tested3d-f64
+    # but easier to just ignore it here.
+    'cfg(feature, values("other-backends"))',
+] }
 
 [features]
 default = ["dim3"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -25,7 +25,9 @@ path = "../../src_testbed/lib.rs"
 required-features = ["dim3"]
 
 [lints]
-workspace = true
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(feature, values("dim2", "f64"))',
+] }
 
 [features]
 default = ["dim3"]


### PR DESCRIPTION
- Detected on https://github.com/dimforge/rapier/pull/727/

I realized the copying of cargo.toml incurs a compilation error as they're not part of a workspace anymore while publishing, this pull request sets the lints in each crate.