### PR TITLE
Release rapier3d-meshloader v0.4.0

### DIFF
--- a/crates/rapier3d-meshloader/CHANGELOG.md
+++ b/crates/rapier3d-meshloader/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.0
 
 Renamed the crate from `rapier3d-stl` to `rapier3d-meshloader`, to better reflect its support for multiple formats.
 

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-meshloader"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-meshloader"

--- a/crates/rapier3d-urdf/CHANGELOG.md
+++ b/crates/rapier3d-urdf/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.0
 
 ### Modified
 

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-urdf"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
@@ -32,4 +32,4 @@ bitflags = "2"
 urdf-rs = "0.9"
 
 rapier3d = { version = "0.23", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.3.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+rapier3d-meshloader = { version = "0.4.0", path = "../rapier3d-meshloader", default-features = false, optional = true }


### PR DESCRIPTION
The currently published version (0.3.0) still relies on rapier 0.22 instead of 0.23.