### PR TITLE
feat(rapier_testbed): autosave testbed configuration + add support for per-example settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 **/*.csv
 .history
 .vscode/
+*.autosave.json

--- a/benchmarks2d/all_benchmarks2.rs
+++ b/benchmarks2d/all_benchmarks2.rs
@@ -74,11 +74,7 @@ pub fn main() {
         (false, true) => Ordering::Less,
     });
 
-    let i = builders
-        .iter()
-        .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
-        .unwrap_or(0);
-    let testbed = TestbedApp::from_builders(i, builders);
+    let testbed = TestbedApp::from_builders(builders);
 
     testbed.run()
 }

--- a/benchmarks2d/all_benchmarks2.rs
+++ b/benchmarks2d/all_benchmarks2.rs
@@ -3,8 +3,6 @@
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-use inflector::Inflector;
-
 use rapier_testbed2d::{Testbed, TestbedApp};
 use std::cmp::Ordering;
 
@@ -46,11 +44,6 @@ fn demo_name_from_url() -> Option<String> {
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    let demo = demo_name_from_command_line()
-        .or_else(demo_name_from_url)
-        .unwrap_or_default()
-        .to_camel_case();
-
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
         ("Balls", balls2::init_world),
         ("Boxes", boxes2::init_world),

--- a/benchmarks3d/all_benchmarks3.rs
+++ b/benchmarks3d/all_benchmarks3.rs
@@ -84,12 +84,12 @@ pub fn main() {
                 .iter()
                 .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
             {
-                TestbedApp::from_builders(0, vec![builders[i]]).run()
+                TestbedApp::from_builders(vec![builders[i]]).run()
             } else {
                 eprintln!("Invalid example to run provided: '{}'", demo);
             }
         }
-        Command::RunAll => TestbedApp::from_builders(0, builders).run(),
+        Command::RunAll => TestbedApp::from_builders(builders).run(),
         Command::List => {
             for builder in &builders {
                 println!("{}", builder.0.to_camel_case())

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -61,6 +61,7 @@ bevy_pbr = "0.15"
 bevy_sprite = "0.15"
 profiling = "1.0"
 puffin_egui = { version = "0.29", optional = true }
+serde_json = "1"
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -62,6 +62,8 @@ bevy_sprite = "0.15"
 profiling = "1.0"
 puffin_egui = { version = "0.29", optional = true }
 serde_json = "1"
+serde = { version = "1.0.215", features = ["derive"] }
+
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -76,6 +76,7 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_gizmos",
+    "serialize"
 ] }
 
 # Dependencies for WASM only.

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -61,6 +61,8 @@ bevy_pbr = "0.15"
 bevy_sprite = "0.15"
 profiling = "1.0"
 puffin_egui = { version = "0.29", optional = true }
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1"
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -77,6 +77,7 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_gizmos",
+    "serialize"
 ] }
 
 # Dependencies for WASM only.

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -56,6 +56,7 @@ bincode = "1"
 md5 = "0.7"
 Inflector = "0.11"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 bevy_egui = "0.31"
 bevy_ecs = "0.15"
 bevy_core_pipeline = "0.15"

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -77,6 +77,7 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_gizmos",
+    "serialize"
 ] }
 
 # Dependencies for WASM only.
@@ -91,6 +92,7 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_gizmos",
+    "serialize"
 ] }
 #bevy_webgl2 = "0.5"
 

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -57,6 +57,7 @@ bincode = "1"
 md5 = "0.7"
 Inflector = "0.11"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 bevy_egui = "0.31"
 bevy_ecs = "0.15"
 bevy_core_pipeline = "0.15"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -78,6 +78,7 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_render",
     "bevy_pbr",
     "bevy_gizmos",
+    "serialize"
 ] }
 
 # Dependencies for WASM only.

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -14,7 +14,6 @@ enhanced-determinism = ["rapier2d/enhanced-determinism"]
 
 [dependencies]
 rand = "0.8"
-Inflector = "0.11"
 lyon = "0.17"
 usvg = "0.14"
 

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -3,8 +3,6 @@
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-use inflector::Inflector;
-
 use rapier_testbed2d::{Testbed, TestbedApp};
 use std::cmp::Ordering;
 
@@ -45,38 +43,8 @@ mod s2d_pyramid;
 mod sensor2;
 mod trimesh2;
 
-fn demo_name_from_command_line() -> Option<String> {
-    let mut args = std::env::args();
-
-    while let Some(arg) = args.next() {
-        if &arg[..] == "--example" {
-            return args.next();
-        }
-    }
-
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
-fn demo_name_from_url() -> Option<String> {
-    None
-    //    let window = stdweb::web::window();
-    //    let hash = window.location()?.search().ok()?;
-    //    Some(hash[1..].to_string())
-}
-
-#[cfg(not(any(target_arch = "wasm32")))]
-fn demo_name_from_url() -> Option<String> {
-    None
-}
-
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    let demo = demo_name_from_command_line()
-        .or_else(demo_name_from_url)
-        .unwrap_or_default()
-        .to_camel_case();
-
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
         ("Add remove", add_remove2::init_world),
         ("CCD", ccd2::init_world),

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -126,11 +126,7 @@ pub fn main() {
         (false, true) => Ordering::Less,
     });
 
-    let i = builders
-        .iter()
-        .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
-        .unwrap_or(0);
-    let testbed = TestbedApp::from_builders(i, builders);
+    let testbed = TestbedApp::from_builders(builders);
 
     testbed.run()
 }

--- a/examples2d/s2d_pyramid.rs
+++ b/examples2d/s2d_pyramid.rs
@@ -21,7 +21,9 @@ pub fn init_world(testbed: &mut Testbed) {
     /*
      * Create the cubes
      */
-    let base_count = 100;
+    const BASE_COUNT_SETTING: &str = "# of basis cubes";
+    let settings = testbed.example_settings_mut();
+    let base_count = settings.get_or_set_u32(BASE_COUNT_SETTING, 100, 2..=200);
 
     let h = 0.5;
     let shift = 1.0 * h;

--- a/examples3d-f64/Cargo.toml
+++ b/examples3d-f64/Cargo.toml
@@ -14,7 +14,6 @@ enhanced-determinism = ["rapier3d-f64/enhanced-determinism"]
 [dependencies]
 rand = "0.8"
 getrandom = { version = "0.2", features = ["js"] }
-Inflector = "0.11"
 wasm-bindgen = "0.2"
 obj-rs = { version = "0.7", default-features = false }
 bincode = "1"

--- a/examples3d-f64/all_examples3-f64.rs
+++ b/examples3d-f64/all_examples3-f64.rs
@@ -58,11 +58,6 @@ pub fn main() {
         (false, true) => Ordering::Less,
     });
 
-    let i = builders
-        .iter()
-        .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
-        .unwrap_or(0);
-
-    let testbed = TestbedApp::from_builders(i, builders);
+    let testbed = TestbedApp::from_builders(builders);
     testbed.run()
 }

--- a/examples3d-f64/all_examples3-f64.rs
+++ b/examples3d-f64/all_examples3-f64.rs
@@ -5,49 +5,13 @@ use wasm_bindgen::prelude::*;
 extern crate rapier3d_f64 as rapier3d;
 extern crate rapier_testbed3d_f64 as rapier_testbed3d;
 
-use inflector::Inflector;
-
 use rapier_testbed3d::{Testbed, TestbedApp};
 use std::cmp::Ordering;
 
 mod debug_serialized3;
 
-fn demo_name_from_command_line() -> Option<String> {
-    let mut args = std::env::args();
-
-    while let Some(arg) = args.next() {
-        if &arg[..] == "--example" {
-            return args.next();
-        }
-    }
-
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
-fn demo_name_from_url() -> Option<String> {
-    None
-    //    let window = stdweb::web::window();
-    //    let hash = window.location()?.search().ok()?;
-    //    if hash.len() > 0 {
-    //        Some(hash[1..].to_string())
-    //    } else {
-    //        None
-    //    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn demo_name_from_url() -> Option<String> {
-    None
-}
-
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    let demo = demo_name_from_command_line()
-        .or_else(demo_name_from_url)
-        .unwrap_or_default()
-        .to_camel_case();
-
     let mut builders: Vec<(_, fn(&mut Testbed))> =
         vec![("(Debug) serialized", debug_serialized3::init_world)];
 

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -15,7 +15,6 @@ enhanced-determinism = ["rapier3d/enhanced-determinism"]
 [dependencies]
 rand = "0.8"
 getrandom = { version = "0.2", features = ["js"] }
-Inflector = "0.11"
 wasm-bindgen = "0.2"
 obj-rs = { version = "0.7", default-features = false }
 serde = "1"

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -3,8 +3,6 @@
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-use inflector::Inflector;
-
 use rapier_testbed3d::{Testbed, TestbedApp};
 use std::cmp::Ordering;
 
@@ -59,42 +57,8 @@ mod urdf3;
 mod vehicle_controller3;
 mod vehicle_joints3;
 
-fn demo_name_from_command_line() -> Option<String> {
-    let mut args = std::env::args();
-
-    while let Some(arg) = args.next() {
-        if &arg[..] == "--example" {
-            return args.next();
-        }
-    }
-
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
-fn demo_name_from_url() -> Option<String> {
-    None
-    //    let window = stdweb::web::window();
-    //    let hash = window.location()?.search().ok()?;
-    //    if hash.len() > 0 {
-    //        Some(hash[1..].to_string())
-    //    } else {
-    //        None
-    //    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn demo_name_from_url() -> Option<String> {
-    None
-}
-
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
 pub fn main() {
-    let demo = demo_name_from_command_line()
-        .or_else(demo_name_from_url)
-        .unwrap_or_default()
-        .to_camel_case();
-
     let mut builders: Vec<(_, fn(&mut Testbed))> = vec![
         ("Character controller", character_controller3::init_world),
         ("Fountain", fountain3::init_world),

--- a/examples3d/all_examples3.rs
+++ b/examples3d/all_examples3.rs
@@ -173,11 +173,6 @@ pub fn main() {
         (false, true) => Ordering::Less,
     });
 
-    let i = builders
-        .iter()
-        .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
-        .unwrap_or(0);
-
-    let testbed = TestbedApp::from_builders(i, builders);
+    let testbed = TestbedApp::from_builders(builders);
     testbed.run()
 }

--- a/examples3d/all_examples3_wasm.rs
+++ b/examples3d/all_examples3_wasm.rs
@@ -124,11 +124,6 @@ pub fn main() {
         (false, true) => Ordering::Less,
     });
 
-    let i = builders
-        .iter()
-        .position(|builder| builder.0.to_camel_case().as_str() == demo.as_str())
-        .unwrap_or(0);
-
-    let testbed = TestbedApp::from_builders(i, builders);
+    let testbed = TestbedApp::from_builders(builders);
     testbed.run()
 }

--- a/examples3d/all_examples3_wasm.rs
+++ b/examples3d/all_examples3_wasm.rs
@@ -3,8 +3,6 @@
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-use inflector::Inflector;
-
 use rapier_testbed3d::{Testbed, TestbedApp};
 use std::cmp::Ordering;
 

--- a/src_testbed/camera2d.rs
+++ b/src_testbed/camera2d.rs
@@ -9,7 +9,7 @@ use bevy::render::camera::Camera;
 
 const LINE_TO_PIXEL_RATIO: f32 = 0.1;
 
-#[derive(Component)]
+#[derive(Component, PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OrbitCamera {
     pub zoom: f32,
     pub center: Vec3,

--- a/src_testbed/camera3d.rs
+++ b/src_testbed/camera3d.rs
@@ -11,7 +11,7 @@ use std::ops::RangeInclusive;
 
 const LINE_TO_PIXEL_RATIO: f32 = 0.1;
 
-#[derive(Component)]
+#[derive(Component, PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OrbitCamera {
     pub x: f32,
     pub y: f32,

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -16,6 +16,7 @@ use rapier::math::{Isometry, Real, Vector};
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg32;
 use std::collections::HashMap;
+use crate::testbed::TestbedStateFlags;
 
 #[cfg(feature = "dim2")]
 pub type BevyMaterial = bevy_sprite::ColorMaterial;
@@ -362,9 +363,11 @@ impl GraphicsManager {
 
     pub fn draw(
         &mut self,
+        flags: TestbedStateFlags,
         _bodies: &RigidBodySet,
         colliders: &ColliderSet,
         components: &mut Query<&mut Transform>,
+        visibilities: &mut Query<&mut Visibility>,
         _materials: &mut Assets<BevyMaterial>,
     ) {
         for (_, ns) in self.b2sn.iter_mut() {
@@ -385,6 +388,14 @@ impl GraphicsManager {
                 //         n.set_color(materials, point![0.0, 1.0, 0.0]);
                 //     }
                 // }
+
+                if let Ok(mut vis) = visibilities.get_mut(n.entity) {
+                    if flags.contains(TestbedStateFlags::DRAW_SURFACES) {
+                        *vis = Visibility::Inherited;
+                    } else {
+                        *vis = Visibility::Hidden;
+                    }
+                }
 
                 n.update(colliders, components, &self.gfx_shift);
             }

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -13,10 +13,10 @@ use rapier::math::{Isometry, Real, Vector};
 //#[cfg(feature = "dim2")]
 //use crate::objects::polyline::Polyline;
 // use crate::objects::mesh::Mesh;
+use crate::testbed::TestbedStateFlags;
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg32;
 use std::collections::HashMap;
-use crate::testbed::TestbedStateFlags;
 
 #[cfg(feature = "dim2")]
 pub type BevyMaterial = bevy_sprite::ColorMaterial;

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -25,6 +25,8 @@ mod physx_backend;
 mod plugin;
 mod testbed;
 mod ui;
+mod settings;
+mod save;
 
 #[cfg(feature = "dim2")]
 pub mod math {

--- a/src_testbed/lib.rs
+++ b/src_testbed/lib.rs
@@ -23,10 +23,10 @@ pub mod physics;
 #[cfg(all(feature = "dim3", feature = "other-backends"))]
 mod physx_backend;
 mod plugin;
+mod save;
+mod settings;
 mod testbed;
 mod ui;
-mod settings;
-mod save;
 
 #[cfg(feature = "dim2")]
 pub mod math {

--- a/src_testbed/save.rs
+++ b/src_testbed/save.rs
@@ -1,10 +1,10 @@
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "dim2")]
+use crate::camera2d::OrbitCamera;
+#[cfg(feature = "dim3")]
+use crate::camera3d::OrbitCamera;
 use crate::settings::ExampleSettings;
 use crate::testbed::{RapierSolverType, RunMode, TestbedStateFlags};
-#[cfg(feature = "dim2")]
-use crate::camera2d::{OrbitCamera};
-#[cfg(feature = "dim3")]
-use crate::camera3d::{OrbitCamera};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
 pub struct SerializableTestbedState {

--- a/src_testbed/save.rs
+++ b/src_testbed/save.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 use crate::settings::ExampleSettings;
 use crate::testbed::{RapierSolverType, RunMode, TestbedStateFlags};
+#[cfg(feature = "dim2")]
+use crate::camera2d::{OrbitCamera};
+#[cfg(feature = "dim3")]
+use crate::camera3d::{OrbitCamera};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
 pub struct SerializableTestbedState {
@@ -11,4 +15,20 @@ pub struct SerializableTestbedState {
     pub example_settings: ExampleSettings,
     pub solver_type: RapierSolverType,
     pub physx_use_two_friction_directions: bool,
+    pub camera: OrbitCamera,
+}
+
+#[cfg(feature = "dim2")]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+pub struct SerializableCameraState {
+    pub zoom: f32,
+    pub center: na::Point2<f32>,
+}
+
+#[cfg(feature = "dim3")]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+pub struct SerializableCameraState {
+    pub distance: f32,
+    pub position: na::Point3<f32>,
+    pub center: na::Point3<f32>,
 }

--- a/src_testbed/save.rs
+++ b/src_testbed/save.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+use crate::settings::ExampleSettings;
+use crate::testbed::{RapierSolverType, RunMode, TestbedStateFlags};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
+pub struct SerializableTestbedState {
+    pub running: RunMode,
+    pub flags: TestbedStateFlags,
+    pub selected_example: usize,
+    pub selected_backend: usize,
+    pub example_settings: ExampleSettings,
+    pub solver_type: RapierSolverType,
+    pub physx_use_two_friction_directions: bool,
+}

--- a/src_testbed/settings.rs
+++ b/src_testbed/settings.rs
@@ -3,8 +3,14 @@ use std::ops::RangeInclusive;
 
 #[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum SettingValue {
-    U32 { value: u32, range: RangeInclusive<u32> },
-    F32 { value: f32, range: RangeInclusive<f32> }
+    U32 {
+        value: u32,
+        range: RangeInclusive<u32>,
+    },
+    F32 {
+        value: f32,
+        range: RangeInclusive<f32>,
+    },
 }
 
 #[derive(Default, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -30,12 +36,24 @@ impl ExampleSettings {
     }
 
     pub fn set_u32(&mut self, key: &str, value: u32, range: RangeInclusive<u32>) {
-        self.values.insert(key.to_string(), SettingValue::U32 { value, range });
+        self.values
+            .insert(key.to_string(), SettingValue::U32 { value, range });
     }
 
-    pub fn get_or_set_u32(&mut self, key: &'static str, default: u32, range: RangeInclusive<u32>) -> u32 {
-        let to_insert = SettingValue::U32 { value: default, range };
-        let entry = self.values.entry(key.to_string()).or_insert(to_insert.clone());
+    pub fn get_or_set_u32(
+        &mut self,
+        key: &'static str,
+        default: u32,
+        range: RangeInclusive<u32>,
+    ) -> u32 {
+        let to_insert = SettingValue::U32 {
+            value: default,
+            range,
+        };
+        let entry = self
+            .values
+            .entry(key.to_string())
+            .or_insert(to_insert.clone());
         match entry {
             SettingValue::U32 { value, .. } => *value,
             _ => {
@@ -47,12 +65,21 @@ impl ExampleSettings {
     }
 
     pub fn set_f32(&mut self, key: &str, value: f32, range: RangeInclusive<f32>) {
-        self.values.insert(key.to_string(), SettingValue::F32 { value, range });
+        self.values
+            .insert(key.to_string(), SettingValue::F32 { value, range });
     }
 
-    pub fn get_or_set_f32(&mut self, key: &'static str, value: f32, range: RangeInclusive<f32>) -> f32 {
+    pub fn get_or_set_f32(
+        &mut self,
+        key: &'static str,
+        value: f32,
+        range: RangeInclusive<f32>,
+    ) -> f32 {
         let to_insert = SettingValue::F32 { value, range };
-        let entry = self.values.entry(key.to_string()).or_insert(to_insert.clone());
+        let entry = self
+            .values
+            .entry(key.to_string())
+            .or_insert(to_insert.clone());
         match entry {
             SettingValue::F32 { value, .. } => *value,
             _ => {
@@ -66,14 +93,14 @@ impl ExampleSettings {
     pub fn get_u32(&self, key: &'static str) -> Option<u32> {
         match self.values.get(key)? {
             SettingValue::U32 { value, .. } => Some(*value),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn get_f32(&self, key: &'static str) -> Option<f32> {
         match self.values.get(key)? {
             SettingValue::F32 { value, .. } => Some(*value),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/src_testbed/settings.rs
+++ b/src_testbed/settings.rs
@@ -1,0 +1,52 @@
+use std::collections::HashMap;
+
+#[derive(Copy, Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub enum SettingValue {
+    U32(u32),
+    F32(f32)
+}
+
+#[derive(Default, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ExampleSettings {
+    values: HashMap<String, SettingValue>,
+}
+
+impl ExampleSettings {
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&String, &mut SettingValue)> {
+        self.values.iter_mut()
+    }
+
+    pub fn set_u32(&mut self, key: &str, value: u32) {
+        self.values.insert(key.to_string(), SettingValue::U32(value));
+    }
+
+    pub fn set_f32(&mut self, key: &str, value: f32) {
+        self.values.insert(key.to_string(), SettingValue::F32(value));
+    }
+
+    pub fn get_u32(&self, key: &'static str) -> Option<u32> {
+        match self.values.get(key)? {
+            SettingValue::U32(value) => Some(*value),
+            _ => None
+        }
+    }
+
+    pub fn get_f32(&self, key: &'static str) -> Option<f32> {
+        match self.values.get(key)? {
+            SettingValue::F32(value) => Some(*value),
+            _ => None
+        }
+    }
+}

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::bad_bit_mask)] // otherwise clippy complains because of TestbedStateFlags::NONE which is 0.
 #![allow(clippy::unnecessary_cast)] // allowed for f32 -> f64 cast for the f64 testbed.
 
-use bevy::log;
 use bevy::prelude::*;
-use std::collections::HashMap;
 use std::env;
 use std::mem;
 use std::num::NonZeroUsize;
@@ -225,7 +223,7 @@ impl TestbedApp {
         #[cfg(all(feature = "dim3", feature = "other-backends"))]
         backend_names.push("physx (two friction dir)");
 
-        let mut state = TestbedState {
+        let state = TestbedState {
             running: RunMode::Running,
             draw_colls: false,
             highlighted_body: None,

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::bad_bit_mask)] // otherwise clippy complains because of TestbedStateFlags::NONE which is 0.
 #![allow(clippy::unnecessary_cast)] // allowed for f32 -> f64 cast for the f64 testbed.
 
+use bevy::log;
+use bevy::prelude::*;
 use std::collections::HashMap;
 use std::env;
 use std::mem;
 use std::num::NonZeroUsize;
-use bevy::log;
-use bevy::prelude::*;
 
 use crate::debug_render::{DebugRenderPipelineResource, RapierDebugRenderPlugin};
 use crate::graphics::BevyMaterialComponent;
@@ -110,7 +110,6 @@ pub enum RapierSolverType {
 
 pub type SimulationBuilders = Vec<(&'static str, fn(&mut Testbed))>;
 
-
 #[derive(Resource)]
 pub struct TestbedState {
     pub running: RunMode,
@@ -151,7 +150,7 @@ impl TestbedState {
             example_settings: self.example_settings.clone(),
             solver_type: self.solver_type,
             physx_use_two_friction_directions: self.physx_use_two_friction_directions,
-            camera
+            camera,
         }
     }
 
@@ -1216,9 +1215,9 @@ fn egui_focus(mut ui_context: EguiContexts, mut cameras: Query<&mut OrbitCamera>
 }
 
 use crate::mouse::{track_mouse_state, MainCamera, SceneMouse};
-use bevy::window::PrimaryWindow;
 use crate::save::SerializableTestbedState;
-use crate::settings::{ ExampleSettings};
+use crate::settings::ExampleSettings;
+use bevy::window::PrimaryWindow;
 
 #[allow(clippy::type_complexity)]
 fn update_testbed(
@@ -1326,19 +1325,18 @@ fn update_testbed(
                 .set(TestbedActionFlags::EXAMPLE_CHANGED, true);
         }
 
-
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let app_started = state
-                .action_flags
-                .contains(TestbedActionFlags::APP_STARTED);
+            let app_started = state.action_flags.contains(TestbedActionFlags::APP_STARTED);
 
             if app_started {
                 state
                     .action_flags
                     .set(TestbedActionFlags::APP_STARTED, false);
-                if let Some(saved_state) = std::fs::read(save_file_path()).ok()
-                    .and_then(|data| serde_json::from_slice::<SerializableTestbedState>(&data).ok()) {
+                if let Some(saved_state) = std::fs::read(save_file_path())
+                    .ok()
+                    .and_then(|data| serde_json::from_slice::<SerializableTestbedState>(&data).ok())
+                {
                     state.apply_saved_data(saved_state, &mut cameras.single_mut().2);
                     state.camera_locked = true;
                 }

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -25,7 +25,7 @@ pub fn update_ui(
 ) {
     #[cfg(feature = "profiler_ui")]
     {
-        profiler_ui(ui_context, state, harness, debug_render);
+        profiler_ui(ui_context);
     }
 
     example_settings_ui(ui_context, state);
@@ -475,15 +475,11 @@ fn example_settings_ui(ui_context: &mut EguiContexts, state: &mut TestbedState) 
                 }
                 SettingValue::U32 { value, range } => {
                     ui.horizontal(|ui| {
-                        if ui.button("<").clicked() {
-                            if *value > *range.start() {
-                                *value -= 1;
-                            }
+                        if ui.button("<").clicked() && *value > *range.start() {
+                            *value -= 1;
                         }
-                        if ui.button(">").clicked() {
-                            if *value <= *range.end() {
-                                *value += 1;
-                            }
+                        if ui.button(">").clicked() && *value <= *range.end() {
+                            *value += 1;
                         }
 
                         ui.add(Slider::new(value, range.clone()).text(name));
@@ -502,12 +498,7 @@ fn example_settings_ui(ui_context: &mut EguiContexts, state: &mut TestbedState) 
 }
 
 #[cfg(feature = "profiler_ui")]
-fn profiler_ui(
-    ui_context: &mut EguiContexts,
-    state: &mut TestbedState,
-    harness: &mut Harness,
-    debug_render: &mut DebugRenderPipelineResource,
-) {
+fn profiler_ui(ui_context: &mut EguiContexts) {
     let window = egui::Window::new("Profiling");
     let window = window.default_open(false);
 

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -15,6 +15,7 @@ use bevy_egui::egui::{Slider, Ui};
 use bevy_egui::{egui, EguiContexts};
 use rapier::dynamics::IntegrationParameters;
 use web_time::Instant;
+use crate::settings::SettingValue;
 
 pub fn update_ui(
     ui_context: &mut EguiContexts,
@@ -24,38 +25,10 @@ pub fn update_ui(
 ) {
     #[cfg(feature = "profiler_ui")]
     {
-        let window = egui::Window::new("Profiling");
-        let window = window.default_open(false);
-
-        #[cfg(feature = "unstable-puffin-pr-235")]
-        {
-            use std::sync::Once;
-            static START: Once = Once::new();
-
-            fn set_default_rapier_filter() {
-                let mut profile_ui = puffin_egui::PROFILE_UI.lock();
-                profile_ui
-                    .profiler_ui
-                    .flamegraph_options
-                    .scope_name_filter
-                    .set_filter("Harness::step_with_graphics".to_string());
-            }
-            START.call_once(|| {
-                set_default_rapier_filter();
-            });
-            window.show(ui_context.ctx_mut(), |ui| {
-                if ui.button("🔍 Rapier filter").clicked() {
-                    set_default_rapier_filter();
-                }
-                puffin_egui::profiler_ui(ui);
-            });
-        }
-
-        #[cfg(not(feature = "unstable-puffin-pr-235"))]
-        window.show(ui_context.ctx_mut(), |ui| {
-            puffin_egui::profiler_ui(ui);
-        });
+        profiler_ui(ui_context, state, harness, debug_render);
     }
+
+    example_settings_ui(ui_context, state);
 
     egui::Window::new("Parameters").show(ui_context.ctx_mut(), |ui| {
         if state.backend_names.len() > 1 && !state.example_names.is_empty() {
@@ -264,14 +237,17 @@ pub fn update_ui(
         integration_parameters.set_inv_dt(frequency as Real);
 
         let mut sleep = state.flags.contains(TestbedStateFlags::SLEEP);
+        let mut draw_surfaces = state.flags.contains(TestbedStateFlags::DRAW_SURFACES);
         // let mut contact_points = state.flags.contains(TestbedStateFlags::CONTACT_POINTS);
         // let mut wireframe = state.flags.contains(TestbedStateFlags::WIREFRAME);
         ui.checkbox(&mut sleep, "sleep enabled");
         // ui.checkbox(&mut contact_points, "draw contacts");
         // ui.checkbox(&mut wireframe, "draw wireframes");
+        ui.checkbox(&mut draw_surfaces, "surface render enabled");
         ui.checkbox(&mut debug_render.enabled, "debug render enabled");
 
         state.flags.set(TestbedStateFlags::SLEEP, sleep);
+        state.flags.set(TestbedStateFlags::DRAW_SURFACES, draw_surfaces);
         // state
         //     .flags
         //     .set(TestbedStateFlags::CONTACT_POINTS, contact_points);
@@ -480,4 +456,87 @@ Hashes at frame: {}
         js.len() as f32 / 1000.0,
         format!("{:?}", hash_joints).split_at(10).0,
     )
+}
+
+fn example_settings_ui(
+    ui_context: &mut EguiContexts,
+    state: &mut TestbedState,) {
+    if state.example_settings.is_empty() {
+        // Don’t show any window if there is no settings for the
+        // example.
+        return;
+    }
+
+    egui::Window::new("Example settings").show(ui_context.ctx_mut(), |ui| {
+        let mut any_changed = false;
+        for (name, value) in state.example_settings.iter_mut() {
+            let prev_value = *value;
+            match value {
+                SettingValue::F32(x) => {
+                    ui.add(Slider::new(x, 0.0..=10.0).text(name));
+                }
+                SettingValue::U32(x) => {
+                    ui.horizontal(|ui| {
+                        if ui.button("<").clicked() {
+                            if *x > 0 {
+                                *x -= 1;
+                            }
+                        }
+                        ui.add(Slider::new(x, 0..=2000).step_by(1.0));
+                        if ui.button(">").clicked()  {
+                            *x += 1;
+                        }
+                        ui.label(name);
+                    });
+                }
+            }
+
+            any_changed = any_changed || *value != prev_value;
+        }
+
+        if any_changed {
+            // The value changed, request a restart.
+            state.action_flags.set(TestbedActionFlags::RESTART, true);
+        }
+    });
+}
+
+#[cfg(feature = "profiler_ui")]
+fn profiler_ui(
+    ui_context: &mut EguiContexts,
+    state: &mut TestbedState,
+    harness: &mut Harness,
+    debug_render: &mut DebugRenderPipelineResource,
+) {
+    let window = egui::Window::new("Profiling");
+    let window = window.default_open(false);
+
+    #[cfg(feature = "unstable-puffin-pr-235")]
+    {
+        use std::sync::Once;
+        static START: Once = Once::new();
+
+        fn set_default_rapier_filter() {
+            let mut profile_ui = puffin_egui::PROFILE_UI.lock();
+            profile_ui
+                .profiler_ui
+                .flamegraph_options
+                .scope_name_filter
+                .set_filter("Harness::step_with_graphics".to_string());
+        }
+        START.call_once(|| {
+            set_default_rapier_filter();
+        });
+        window.show(ui_context.ctx_mut(), |ui| {
+            if ui.button("🔍 Rapier filter").clicked() {
+                set_default_rapier_filter();
+            }
+            puffin_egui::profiler_ui(ui);
+        });
+    }
+
+    #[cfg(not(feature = "unstable-puffin-pr-235"))]
+    window.show(ui_context.ctx_mut(), |ui| {
+        puffin_egui::profiler_ui(ui);
+    });
 }

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -10,12 +10,12 @@ use crate::testbed::{
     PHYSX_BACKEND_PATCH_FRICTION, PHYSX_BACKEND_TWO_FRICTION_DIR,
 };
 
+use crate::settings::SettingValue;
 use crate::PhysicsState;
 use bevy_egui::egui::{Slider, Ui};
 use bevy_egui::{egui, EguiContexts};
 use rapier::dynamics::IntegrationParameters;
 use web_time::Instant;
-use crate::settings::SettingValue;
 
 pub fn update_ui(
     ui_context: &mut EguiContexts,
@@ -458,9 +458,7 @@ Hashes at frame: {}
     )
 }
 
-fn example_settings_ui(
-    ui_context: &mut EguiContexts,
-    state: &mut TestbedState,) {
+fn example_settings_ui(ui_context: &mut EguiContexts, state: &mut TestbedState) {
     if state.example_settings.is_empty() {
         // Don’t show any window if there is no settings for the
         // example.
@@ -483,7 +481,7 @@ fn example_settings_ui(
                             }
                         }
                         ui.add(Slider::new(value, range.clone()));
-                        if ui.button(">").clicked()  {
+                        if ui.button(">").clicked() {
                             if *value < range.max().unwrap_or(u32::MAX) {
                                 *value += 1;
                             }

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -476,17 +476,17 @@ fn example_settings_ui(ui_context: &mut EguiContexts, state: &mut TestbedState) 
                 SettingValue::U32 { value, range } => {
                     ui.horizontal(|ui| {
                         if ui.button("<").clicked() {
-                            if *value > range.min().unwrap_or(0) {
+                            if *value > *range.start() {
                                 *value -= 1;
                             }
                         }
-                        ui.add(Slider::new(value, range.clone()));
                         if ui.button(">").clicked() {
-                            if *value < range.max().unwrap_or(u32::MAX) {
+                            if *value <= *range.end() {
                                 *value += 1;
                             }
                         }
-                        ui.label(name);
+
+                        ui.add(Slider::new(value, range.clone()).text(name));
                     });
                 }
             }

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -470,21 +470,23 @@ fn example_settings_ui(
     egui::Window::new("Example settings").show(ui_context.ctx_mut(), |ui| {
         let mut any_changed = false;
         for (name, value) in state.example_settings.iter_mut() {
-            let prev_value = *value;
+            let prev_value = value.clone();
             match value {
-                SettingValue::F32(x) => {
-                    ui.add(Slider::new(x, 0.0..=10.0).text(name));
+                SettingValue::F32 { value, range } => {
+                    ui.add(Slider::new(value, range.clone()).text(name));
                 }
-                SettingValue::U32(x) => {
+                SettingValue::U32 { value, range } => {
                     ui.horizontal(|ui| {
                         if ui.button("<").clicked() {
-                            if *x > 0 {
-                                *x -= 1;
+                            if *value > range.min().unwrap_or(0) {
+                                *value -= 1;
                             }
                         }
-                        ui.add(Slider::new(x, 0..=2000).step_by(1.0));
+                        ui.add(Slider::new(value, range.clone()));
                         if ui.button(">").clicked()  {
-                            *x += 1;
+                            if *value < range.max().unwrap_or(u32::MAX) {
+                                *value += 1;
+                            }
                         }
                         ui.label(name);
                     });


### PR DESCRIPTION
Improve the ergonomics of the rapier testbed by:
- Automatically saving the example selection, camera position, example settings, etc. and restore them when starting the testbed app again.
- Add support for per-example settings. For example in the video below, the number of cubes in the pyramid can be controlled (this the only example modified to use that new feature for now):

https://github.com/user-attachments/assets/eefc7356-39c1-428c-870c-0cbeba57a2e0

