### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## Unreleased
+## v0.24.0 (10 April 2025)
 
 ### Added
 
 - `IntegrationParameters` now implements `PartialEq`.
+
+### Modified
+
+- Update dependencies (including `parry` 0.19).
 
 ## v0.23.1 (05 March 2025)
 

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -68,7 +68,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d-f64 = "0.18.0"
+parry2d-f64 = "0.19.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -69,7 +69,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d = "0.18.0"
+parry2d = "0.19.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -71,7 +71,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d-f64 = "0.18.0"
+parry3d-f64 = "0.19.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-meshloader"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-meshloader"
@@ -29,4 +29,4 @@ thiserror = "2"
 profiling = "1.0"
 mesh-loader = "0.1.12"
 
-rapier3d = { version = "0.23", path = "../rapier3d" }
+rapier3d = { version = "0.24", path = "../rapier3d" }

--- a/crates/rapier3d-meshloader/src/lib.rs
+++ b/crates/rapier3d-meshloader/src/lib.rs
@@ -33,11 +33,11 @@ pub enum MeshLoaderError {
 /// # Parameters
 /// - `path`: the file’s path.
 /// - `converter`: controls how the shapes are computed from the content. In particular, it lets
-///                you specify if the computed [`SharedShape`] is a triangle mesh, its convex hull,
-///                bounding box, etc.
+///   you specify if the computed [`SharedShape`] is a triangle mesh, its convex hull,
+///   bounding box, etc.
 /// - `scale`: the scaling factor applied to the geometry input to the `converter`. This scale will
-///            affect at the geometric level the [`LoadedShape::shape`]. Note that raw mesh value stored
-///            in [`LoadedShape::raw_mesh`] remains unscaled.
+///   affect at the geometric level the [`LoadedShape::shape`]. Note that raw mesh value stored
+///   in [`LoadedShape::raw_mesh`] remains unscaled.
 pub fn load_from_path(
     path: impl AsRef<Path>,
     converter: &MeshConverter,
@@ -63,11 +63,11 @@ pub fn load_from_path(
 /// # Parameters
 /// - `raw_mesh`: the raw mesh.
 /// - `converter`: controls how the shape is computed from the STL content. In particular, it lets
-///                you specify if the computed [`SharedShape`] is a triangle mesh, its convex hull,
-///                bounding box, etc.
+///   you specify if the computed [`SharedShape`] is a triangle mesh, its convex hull,
+///   bounding box, etc.
 /// - `scale`: the scaling factor applied to the geometry input to the `converter`. This scale will
-///            affect at the geometric level the [`LoadedShape::shape`]. Note that raw mesh value stored
-///            in [`LoadedShape::raw_mesh`] remains unscaled.
+///   affect at the geometric level the [`LoadedShape::shape`]. Note that raw mesh value stored
+///   in [`LoadedShape::raw_mesh`] remains unscaled.
 pub fn load_from_raw_mesh(
     raw_mesh: &Mesh,
     converter: &MeshConverter,

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-urdf"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
@@ -31,5 +31,5 @@ anyhow = "1"
 bitflags = "2"
 urdf-rs = "0.9"
 
-rapier3d = { version = "0.23", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.4.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+rapier3d = { version = "0.24", path = "../rapier3d" }
+rapier3d-meshloader = { version = "0.5.0", path = "../rapier3d-meshloader", default-features = false, optional = true }

--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -221,9 +221,9 @@ impl UrdfRobot {
     /// - `path`: the path of the URDF file.
     /// - `options`: customize the creation of rapier objects from the URDF description.
     /// - `mesh_dir`: the base directory containing the meshes referenced by the URDF file. When
-    ///               a mesh reference is found in the URDF file, this `mesh_dir` is appended
-    ///               to the file path. If `mesh_dir` is `None` then the mesh directory is assumed
-    ///               to be the same directory as the one containing the URDF file.
+    ///   a mesh reference is found in the URDF file, this `mesh_dir` is appended
+    ///   to the file path. If `mesh_dir` is `None` then the mesh directory is assumed
+    ///   to be the same directory as the one containing the URDF file.
     pub fn from_file(
         path: impl AsRef<Path>,
         options: UrdfLoaderOptions,
@@ -249,8 +249,8 @@ impl UrdfRobot {
     /// - `str`: the string content of an URDF file.
     /// - `options`: customize the creation of rapier objects from the URDF description.
     /// - `mesh_dir`: the base directory containing the meshes referenced by the URDF file. When
-    ///               a mesh reference is found in the URDF file, this `mesh_dir` is appended
-    ///               to the file path.
+    ///   a mesh reference is found in the URDF file, this `mesh_dir` is appended
+    ///   to the file path.
     pub fn from_str(
         str: &str,
         options: UrdfLoaderOptions,
@@ -272,8 +272,8 @@ impl UrdfRobot {
     /// - `robot`: the robot loaded from an URDF file.
     /// - `options`: customize the creation of rapier objects from the URDF description.
     /// - `mesh_dir`: the base directory containing the meshes referenced by the URDF file. When
-    ///               a mesh reference is found in the URDF file, this `mesh_dir` is appended
-    ///               to the file path.
+    ///   a mesh reference is found in the URDF file, this `mesh_dir` is appended
+    ///   to the file path.
     pub fn from_robot(robot: &Robot, options: UrdfLoaderOptions, mesh_dir: &Path) -> Self {
         let mut name_to_link_id = HashMap::new();
         let mut link_is_root = vec![true; robot.links.len()];

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -73,7 +73,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d = "0.18.0"
+parry3d = "0.19.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -99,5 +99,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.23.0"
+version = "0.24.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -98,5 +98,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.23.0"
+version = "0.24.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -99,5 +99,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.23.0"
+version = "0.24.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -97,5 +97,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.23.0"
+version = "0.24.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/src/pipeline/event_handler.rs
+++ b/src/pipeline/event_handler.rs
@@ -38,8 +38,8 @@ pub trait EventHandler: Send + Sync {
     /// * `bodies` - The set of rigid-bodies.
     /// * `colliders` - The set of colliders.
     /// * `contact_pair` - The current state of contacts between the two colliders. This is set to `None`
-    ///                    if at least one of the collider is a sensor (in which case no contact information
-    ///                    is ever computed).
+    ///   if at least one of the collider is a sensor (in which case no contact information
+    ///   is ever computed).
     fn handle_collision_event(
         &self,
         bodies: &RigidBodySet,


### PR DESCRIPTION
This is a pretty small release. Bumping the minor version because of the dependencies updates.

## v0.24.0 (10 April 2025)

### Added

- `IntegrationParameters` now implements `PartialEq`.

### Modified

- Update dependencies (including `parry` 0.19).