### PR TITLE
Make `MeshConverter` enum derive `Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- `MeshConverter` now implements `Copy`.
+
 ## v0.24.0 (10 April 2025)
 
 ### Added

--- a/src/geometry/mesh_converter.rs
+++ b/src/geometry/mesh_converter.rs
@@ -23,8 +23,7 @@ pub enum MeshConverterError {
 }
 
 /// Determines how meshes (generally when loaded from a file) are converted into Rapier colliders.
-// TODO: implement Copy once we add a Copy implementation for VHACDParameters.
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum MeshConverter {
     /// The mesh is loaded as-is without any particular processing.
     #[default]


### PR DESCRIPTION
Now that `VHACDParameters` is `Copy` in parry 0.19, this can now be fixed here.