### PR TITLE
add getter for `contact_id` field of `SolverContact`

### DIFF
--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -327,6 +327,11 @@ impl SolverContact {
             self.restitution >= 1.0
         }
     }
+
+    /// The index of the manifold contact used to generate this solver contact.
+    pub fn contact_id(&self) -> u8 {
+        self.contact_id
+    }
 }
 
 impl Default for ContactManifoldData {


### PR DESCRIPTION
Adds a simple getter for the `contact_id` field of `SolverContact`. (Alternatively, could set that field to `pub` instead of `pub(crate)`.)

My use case is that I need to access the _local_ coords of a contact relative to each collider involved in the contact. To get that data, I need the `contact_id` to look up the entry in `contact_pair.manifolds[i].points` that corresponds to a specific `SolverContact`, because the `SolverContact` only has the world space position of the contact point. Example:

```
     narrow_phase
    .contact_pairs_with(this_handle)
    .filter(|contact_pair| {
        // filter out pairs that are not active
        contact_pair.has_any_active_contact
    })
    .flat_map(move |contact_pair| {
      
        let manifold = &contact_pair.manifolds[0];

        manifold.data.solver_contacts.iter().map(move |contact| {
            let contact_point = manifold.points[contact.contact_id() as usize];
            (
                contact_point.local_p1,
                contact_point.local_p2,
                manifold.local_n1,
                contact_point.dist,
                manifold.data.rigid_body2,
                contact_pair.collider2,
            )
        }
    })
```



Near as I can tell, there is not any existing shortcut API for accessing the _local_ coords that I need. But that's ok as long as we can get this id; however there is no way of accessing the id either.

Since this is just a simple getter, and doesn't e.g. allow mutation of this id, I think this should be a trivial, non-risky way of satisfying my use case. (But then again I'm not sure why this field wasn't `pub` in the first place, so there may be some detail I'm not aware of.)

Please LMK if any changes are needed! Thanks!