### PR TITLE
feat: added geometric combine rule and examples

### DIFF
--- a/examples2d/restitution2.rs
+++ b/examples2d/restitution2.rs
@@ -18,7 +18,9 @@ pub fn init_world(testbed: &mut Testbed) {
 
     let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height]);
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height).restitution(1.0);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height)
+        .restitution(1.0)
+        .restitution_combine_rule(CoefficientCombineRule::GeometricMean);
     colliders.insert_with_parent(collider, handle, &mut bodies);
 
     let num = 10;
@@ -30,7 +32,9 @@ pub fn init_world(testbed: &mut Testbed) {
             let rigid_body =
                 RigidBodyBuilder::dynamic().translation(vector![x * 2.0, 10.0 * (j as f32 + 1.0)]);
             let handle = bodies.insert(rigid_body);
-            let collider = ColliderBuilder::ball(rad).restitution((i as f32) / (num as f32));
+            let collider = ColliderBuilder::ball(rad)
+                .restitution((i as f32) / (num as f32))
+                .restitution_combine_rule(CoefficientCombineRule::GeometricMean);
             colliders.insert_with_parent(collider, handle, &mut bodies);
         }
     }

--- a/examples3d/restitution3.rs
+++ b/examples3d/restitution3.rs
@@ -18,7 +18,9 @@ pub fn init_world(testbed: &mut Testbed) {
 
     let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0]);
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 2.0).restitution(1.0);
+    let collider = ColliderBuilder::cuboid(ground_size, ground_height, 2.0)
+        .restitution(1.0)
+        .restitution_combine_rule(CoefficientCombineRule::GeometricMean);
     colliders.insert_with_parent(collider, handle, &mut bodies);
 
     let num = 10;
@@ -33,7 +35,9 @@ pub fn init_world(testbed: &mut Testbed) {
                 0.0
             ]);
             let handle = bodies.insert(rigid_body);
-            let collider = ColliderBuilder::ball(rad).restitution((i as f32) / (num as f32));
+            let collider = ColliderBuilder::ball(rad)
+                .restitution((i as f32) / (num as f32))
+                .restitution_combine_rule(CoefficientCombineRule::GeometricMean);
             colliders.insert_with_parent(collider, handle, &mut bodies);
         }
     }

--- a/src/dynamics/coefficient_combine_rule.rs
+++ b/src/dynamics/coefficient_combine_rule.rs
@@ -19,6 +19,8 @@ pub enum CoefficientCombineRule {
     Multiply = 2,
     /// The greatest coefficient is chosen.
     Max = 3,
+    /// The two coefficients are multiplied then the square root is taken.
+    GeometricMean = 4,
 }
 
 impl CoefficientCombineRule {
@@ -35,6 +37,7 @@ impl CoefficientCombineRule {
             CoefficientCombineRule::Min => coeff1.min(coeff2),
             CoefficientCombineRule::Multiply => coeff1 * coeff2,
             CoefficientCombineRule::Max => coeff1.max(coeff2),
+            CoefficientCombineRule::GeometricMean => (coeff1 * coeff2).sqrt(),
         }
     }
 }


### PR DESCRIPTION
Closes issue #685. I'm getting some crashes on an example I haven't touched - Multibody joints 3d crashes under the parallel,simd-stable feature set with `Matrix slicing out of bounds.`

Should I open a new issue for this separately?

Otherwise, I think this is the expected implementation of this feature. If this is all good I'll try tackle a harder issue next!