### PR TITLE
Release d0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.26.0 (16 May 2025)
+
+### Modified
+
+- Update to parry 0.21.0. This changes the initialization of `Voxels` colliders by removing the primitive geometry
+  argument. This also fixes intersection checks with voxels, and force calculation between voxels and other
+  voxels or compound shapes.
+
 ## v0.25.1 (02 May 2025)
 
 ### Modified

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -68,7 +68,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d-f64 = "0.20.1"
+parry2d-f64 = "0.21.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -69,7 +69,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d = "0.20.1"
+parry2d = "0.21.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -71,7 +71,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d-f64 = "0.20.1"
+parry3d-f64 = "0.21.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-meshloader"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-meshloader"
@@ -29,4 +29,4 @@ thiserror = "2"
 profiling = "1.0"
 mesh-loader = "0.1.12"
 
-rapier3d = { version = "0.25", path = "../rapier3d" }
+rapier3d = { version = "0.26", path = "../rapier3d" }

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-urdf"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
@@ -31,5 +31,5 @@ anyhow = "1"
 bitflags = "2"
 urdf-rs = "0.9"
 
-rapier3d = { version = "0.25", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.6.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+rapier3d = { version = "0.26", path = "../rapier3d" }
+rapier3d-meshloader = { version = "0.7.0", path = "../rapier3d-meshloader", default-features = false, optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -73,7 +73,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d = "0.20.1"
+parry3d = "0.21.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -99,5 +99,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.25.1"
+version = "0.26.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -99,5 +99,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.25.1"
+version = "0.26.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -100,5 +100,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.25.1"
+version = "0.26.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -98,5 +98,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.25.1"
+version = "0.26.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/examples2d/voxels2.rs
+++ b/examples2d/voxels2.rs
@@ -11,11 +11,6 @@ pub fn init_world(testbed: &mut Testbed) {
     // TODO: make the testbed support custom enums (or at least a list of option from strings and
     //       associated constants).
     let settings = testbed.example_settings_mut();
-    let geometry_mode = settings.get_or_set_string(
-        "Voxels mode",
-        0,
-        vec!["PseudoCube".to_string(), "PseudoBall".to_string()],
-    );
     let falling_objects = settings.get_or_set_string(
         "Falling objects",
         3, // Defaults to Mixed.
@@ -29,12 +24,6 @@ pub fn init_world(testbed: &mut Testbed) {
     let voxel_size_y = settings.get_or_set_f32("Voxel size y", 1.0, 0.5..=2.0);
     let voxel_size = Vector::new(1.0, voxel_size_y);
     let test_ccd = settings.get_or_set_bool("Test CCD", false);
-
-    let primitive_geometry = if geometry_mode == 0 {
-        VoxelPrimitiveGeometry::PseudoCube
-    } else {
-        VoxelPrimitiveGeometry::PseudoBall
-    };
 
     /*
      * World
@@ -93,13 +82,7 @@ pub fn init_world(testbed: &mut Testbed) {
         .map(|i| [i, (i + 1) % polyline.len() as u32])
         .collect();
     let rb = bodies.insert(RigidBodyBuilder::fixed().translation(vector![-20.0, -10.0]));
-    let shape = SharedShape::voxelized_mesh(
-        primitive_geometry,
-        &polyline,
-        &indices,
-        0.2,
-        FillMode::default(),
-    );
+    let shape = SharedShape::voxelized_mesh(&polyline, &indices, 0.2, FillMode::default());
 
     colliders.insert_with_parent(ColliderBuilder::new(shape), rb, &mut bodies);
 
@@ -112,11 +95,7 @@ pub fn init_world(testbed: &mut Testbed) {
             point![(i as f32 - 125.0) * voxel_size.x / 2.0, y * voxel_size.y]
         })
         .collect();
-    colliders.insert(ColliderBuilder::voxels_from_points(
-        primitive_geometry,
-        voxel_size,
-        &voxels,
-    ));
+    colliders.insert(ColliderBuilder::voxels_from_points(voxel_size, &voxels));
 
     /*
      * Set up the testbed.

--- a/examples3d/voxels3.rs
+++ b/examples3d/voxels3.rs
@@ -14,11 +14,6 @@ pub fn init_world(testbed: &mut Testbed) {
 
     let settings = testbed.example_settings_mut();
 
-    let geometry_mode = settings.get_or_set_string(
-        "Voxels mode",
-        0,
-        vec!["PseudoCube".to_string(), "PseudoBall".to_string()],
-    );
     let falling_objects = settings.get_or_set_string(
         "Falling objects",
         5, // Defaults to Mixed.
@@ -39,12 +34,6 @@ pub fn init_world(testbed: &mut Testbed) {
     // TODO: give a better placement to the objs.
     // settings.get_or_set_bool("Load .obj", false);
     let load_obj = false;
-
-    let primitive_geometry = if geometry_mode == 0 {
-        VoxelPrimitiveGeometry::PseudoCube
-    } else {
-        VoxelPrimitiveGeometry::PseudoBall
-    };
 
     /*
      * World
@@ -112,13 +101,8 @@ pub fn init_world(testbed: &mut Testbed) {
                     .map(|idx| [idx[0] as u32, idx[1] as u32, idx[2] as u32])
                     .collect();
 
-                let decomposed_shape = SharedShape::voxelized_mesh(
-                    primitive_geometry,
-                    &vertices,
-                    &indices,
-                    0.1,
-                    FillMode::default(),
-                );
+                let decomposed_shape =
+                    SharedShape::voxelized_mesh(&vertices, &indices, 0.1, FillMode::default());
 
                 shapes.push(decomposed_shape);
 
@@ -160,8 +144,7 @@ pub fn init_world(testbed: &mut Testbed) {
             }
         }
     }
-    let collider =
-        ColliderBuilder::voxels_from_points(primitive_geometry, voxel_size, &samples).build();
+    let collider = ColliderBuilder::voxels_from_points(voxel_size, &samples).build();
     let floor_aabb = collider.compute_aabb();
     colliders.insert(collider);
 

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -738,7 +738,6 @@ impl RigidBodyVelocity {
 impl std::ops::Mul<Real> for RigidBodyVelocity {
     type Output = Self;
 
-    #[must_use]
     fn mul(self, rhs: Real) -> Self {
         RigidBodyVelocity {
             linvel: self.linvel * rhs,
@@ -750,7 +749,6 @@ impl std::ops::Mul<Real> for RigidBodyVelocity {
 impl std::ops::Add<RigidBodyVelocity> for RigidBodyVelocity {
     type Output = Self;
 
-    #[must_use]
     fn add(self, rhs: Self) -> Self {
         RigidBodyVelocity {
             linvel: self.linvel + rhs.linvel,
@@ -769,7 +767,6 @@ impl std::ops::AddAssign<RigidBodyVelocity> for RigidBodyVelocity {
 impl std::ops::Sub<RigidBodyVelocity> for RigidBodyVelocity {
     type Output = Self;
 
-    #[must_use]
     fn sub(self, rhs: Self) -> Self {
         RigidBodyVelocity {
             linvel: self.linvel - rhs.linvel,

--- a/src/geometry/broad_phase_qbvh.rs
+++ b/src/geometry/broad_phase_qbvh.rs
@@ -33,10 +33,10 @@ impl BroadPhaseQbvh {
 impl BroadPhase for BroadPhaseQbvh {
     fn update(
         &mut self,
-        dt: Real,
+        _dt: Real,
         prediction_distance: Real,
         colliders: &mut ColliderSet,
-        bodies: &RigidBodySet,
+        _bodies: &RigidBodySet,
         modified_colliders: &[ColliderHandle],
         removed_colliders: &[ColliderHandle],
         events: &mut Vec<BroadPhasePairEvent>,

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -12,7 +12,7 @@ use crate::pipeline::{ActiveEvents, ActiveHooks};
 use crate::prelude::ColliderEnabled;
 use na::Unit;
 use parry::bounding_volume::{Aabb, BoundingVolume};
-use parry::shape::{Shape, TriMeshBuilderError, TriMeshFlags, VoxelPrimitiveGeometry};
+use parry::shape::{Shape, TriMeshBuilderError, TriMeshFlags};
 use parry::transformation::voxelization::FillMode;
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -580,45 +580,28 @@ impl ColliderBuilder {
     ///
     /// For initializing a voxels shape from points in space, see [`Self::voxels_from_points`].
     /// For initializing a voxels shape from a mesh to voxelize, see [`Self::voxelized_mesh`].
-    pub fn voxels(
-        primitive_geometry: VoxelPrimitiveGeometry,
-        voxel_size: Vector<Real>,
-        voxels: &[Point<i32>],
-    ) -> Self {
-        Self::new(SharedShape::voxels(primitive_geometry, voxel_size, voxels))
+    pub fn voxels(voxel_size: Vector<Real>, voxels: &[Point<i32>]) -> Self {
+        Self::new(SharedShape::voxels(voxel_size, voxels))
     }
 
     /// Initializes a collider made of voxels.
     ///
     /// Each voxel has the size `voxel_size` and contains at least one point from `centers`.
     /// The `primitive_geometry` controls the behavior of collision detection at voxels boundaries.
-    pub fn voxels_from_points(
-        primitive_geometry: VoxelPrimitiveGeometry,
-        voxel_size: Vector<Real>,
-        points: &[Point<Real>],
-    ) -> Self {
-        Self::new(SharedShape::voxels_from_points(
-            primitive_geometry,
-            voxel_size,
-            points,
-        ))
+    pub fn voxels_from_points(voxel_size: Vector<Real>, points: &[Point<Real>]) -> Self {
+        Self::new(SharedShape::voxels_from_points(voxel_size, points))
     }
 
     /// Initializes a voxels obtained from the decomposition of the given trimesh (in 3D)
     /// or polyline (in 2D) into voxelized convex parts.
     pub fn voxelized_mesh(
-        primitive_geometry: VoxelPrimitiveGeometry,
         vertices: &[Point<Real>],
         indices: &[[u32; DIM]],
         voxel_size: Real,
         fill_mode: FillMode,
     ) -> Self {
         Self::new(SharedShape::voxelized_mesh(
-            primitive_geometry,
-            vertices,
-            indices,
-            voxel_size,
-            fill_mode,
+            vertices, indices, voxel_size, fill_mode,
         ))
     }
 

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -17,7 +17,7 @@ pub use self::narrow_phase::NarrowPhase;
 
 pub use parry::bounding_volume::BoundingVolume;
 pub use parry::query::{PointQuery, PointQueryWithLocation, RayCast, TrackedContact};
-pub use parry::shape::{SharedShape, VoxelPrimitiveGeometry, VoxelState, VoxelType, Voxels};
+pub use parry::shape::{SharedShape, VoxelState, VoxelType, Voxels};
 
 use crate::math::{Real, Vector};
 

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -255,7 +255,7 @@ impl GraphicsManager {
             }
         }
 
-        self.b2color.insert(handle, color.into());
+        self.b2color.insert(handle, color);
 
         color
     }

--- a/src_testbed/harness/mod.rs
+++ b/src_testbed/harness/mod.rs
@@ -179,7 +179,7 @@ impl Harness {
         self.physics.hooks = Box::new(hooks);
 
         self.physics.islands = IslandManager::new();
-        self.physics.broad_phase = DefaultBroadPhase::new();
+        self.physics.broad_phase = DefaultBroadPhase::default();
         self.physics.narrow_phase = NarrowPhase::new();
         self.state.timestep_id = 0;
         self.state.time = 0.0;

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -113,7 +113,7 @@ impl PhysicsState {
     pub fn new() -> Self {
         Self {
             islands: IslandManager::new(),
-            broad_phase: DefaultBroadPhase::new(),
+            broad_phase: DefaultBroadPhase::default(),
             narrow_phase: NarrowPhase::new(),
             bodies: RigidBodySet::new(),
             colliders: ColliderSet::new(),

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -178,11 +178,12 @@ struct OtherBackends {
 }
 struct Plugins(Vec<Box<dyn TestbedPlugin>>);
 
-pub struct TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> {
+pub struct TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k> {
     graphics: &'a mut GraphicsManager,
     commands: &'a mut Commands<'d, 'e>,
     meshes: &'a mut Assets<Mesh>,
     materials: &'a mut Assets<BevyMaterial>,
+    material_handles: &'a mut Query<'i, 'j, &'k mut BevyMaterialComponent>,
     components: &'a mut Query<'b, 'f, &'c mut Transform>,
     #[allow(dead_code)] // Dead in 2D but not in 3D.
     camera_transform: GlobalTransform,
@@ -192,8 +193,8 @@ pub struct TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> {
     mouse: &'a SceneMouse,
 }
 
-pub struct Testbed<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> {
-    graphics: Option<TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h>>,
+pub struct Testbed<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k> {
+    graphics: Option<TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k>>,
     harness: &'a mut Harness,
     state: &'a mut TestbedState,
     #[cfg(feature = "other-backends")]
@@ -508,9 +509,10 @@ impl TestbedApp {
     }
 }
 
-impl<'g, 'h> TestbedGraphics<'_, '_, '_, '_, '_, '_, 'g, 'h> {
+impl<'g, 'h> TestbedGraphics<'_, '_, '_, '_, '_, '_, 'g, 'h, '_, '_, '_> {
     pub fn set_body_color(&mut self, body: RigidBodyHandle, color: [f32; 3]) {
-        self.graphics.set_body_color(self.materials, body, color);
+        self.graphics
+            .set_body_color(self.materials, self.material_handles, body, color);
     }
 
     pub fn ui_context_mut(&mut self) -> &mut EguiContexts<'g, 'h> {
@@ -585,7 +587,7 @@ impl<'g, 'h> TestbedGraphics<'_, '_, '_, '_, '_, '_, 'g, 'h> {
     }
 }
 
-impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_> {
+impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
     pub fn set_number_of_steps_per_frame(&mut self, nsteps: usize) {
         self.state.nsteps = nsteps
     }
@@ -1131,6 +1133,7 @@ fn update_testbed(
             commands: &mut commands,
             meshes: &mut *meshes,
             materials: &mut *materials,
+            material_handles: &mut material_handles,
             components: &mut gfx_components,
             camera_transform: *cameras.single().1,
             camera: &mut cameras.single_mut().2,
@@ -1246,6 +1249,7 @@ fn update_testbed(
                 commands: &mut commands,
                 meshes: &mut *meshes,
                 materials: &mut *materials,
+                material_handles: &mut material_handles,
                 components: &mut gfx_components,
                 camera_transform: *cameras.single().1,
                 camera: &mut cameras.single_mut().2,
@@ -1421,6 +1425,7 @@ fn update_testbed(
                     commands: &mut commands,
                     meshes: &mut *meshes,
                     materials: &mut *materials,
+                    material_handles: &mut material_handles,
                     components: &mut gfx_components,
                     camera_transform: *cameras.single().1,
                     camera: &mut cameras.single_mut().2,


### PR DESCRIPTION
## v0.26.0 (16 May 2025)

### Modified

- Update to parry 0.21.0. This changes the initialization of `Voxels` colliders by removing the primitive geometry argument.
- This also fixes intersection checks with voxels, and force calculation between voxels and other voxels or compound shapes.