### PR TITLE
Release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.26.1 (23 May 2025)
+
+### Added
+
+- Add `RigidBodySet::get_pair_mut` and `ColliderSet::get_pair_mut` to get two mutable rigid-bodies or colliders
+  simultaneously.
+
 ## v0.26.0 (16 May 2025)
 
 ### Modified

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -68,7 +68,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d-f64 = "0.21.0"
+parry2d-f64 = "0.21.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -69,7 +69,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d = "0.21.0"
+parry2d = "0.21.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -71,7 +71,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d-f64 = "0.21.0"
+parry3d-f64 = "0.21.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -73,7 +73,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d = "0.21.0"
+parry3d = "0.21.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -186,6 +186,29 @@ impl RigidBodySet {
         Some(result)
     }
 
+    /// Gets a mutable reference to the two rigid-bodies with the given handles.
+    ///
+    /// If `handle1 == handle2`, only the first returned value will be `Some`.
+    #[cfg(not(feature = "dev-remove-slow-accessors"))]
+    pub fn get_pair_mut(
+        &mut self,
+        handle1: RigidBodyHandle,
+        handle2: RigidBodyHandle,
+    ) -> (Option<&mut RigidBody>, Option<&mut RigidBody>) {
+        if handle1 == handle2 {
+            (self.get_mut(handle1), None)
+        } else {
+            let (mut rb1, mut rb2) = self.bodies.get2_mut(handle1.0, handle2.0);
+            if let Some(rb1) = rb1.as_deref_mut() {
+                self.modified_bodies.push_once(handle1, rb1);
+            }
+            if let Some(rb2) = rb2.as_deref_mut() {
+                self.modified_bodies.push_once(handle2, rb2);
+            }
+            (rb1, rb2)
+        }
+    }
+
     pub(crate) fn get_mut_internal(&mut self, handle: RigidBodyHandle) -> Option<&mut RigidBody> {
         self.bodies.get_mut(handle.0)
     }

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -299,6 +299,29 @@ impl ColliderSet {
         Some(result)
     }
 
+    /// Gets a mutable reference to the two colliders with the given handles.
+    ///
+    /// If `handle1 == handle2`, only the first returned value will be `Some`.
+    #[cfg(not(feature = "dev-remove-slow-accessors"))]
+    pub fn get_pair_mut(
+        &mut self,
+        handle1: ColliderHandle,
+        handle2: ColliderHandle,
+    ) -> (Option<&mut Collider>, Option<&mut Collider>) {
+        if handle1 == handle2 {
+            (self.get_mut(handle1), None)
+        } else {
+            let (mut co1, mut co2) = self.colliders.get2_mut(handle1.0, handle2.0);
+            if let Some(co1) = co1.as_deref_mut() {
+                self.modified_colliders.push_once(handle1, co1);
+            }
+            if let Some(co2) = co2.as_deref_mut() {
+                self.modified_colliders.push_once(handle2, co2);
+            }
+            (co1, co2)
+        }
+    }
+
     pub(crate) fn index_mut_internal(&mut self, handle: ColliderHandle) -> &mut Collider {
         &mut self.colliders[handle.0]
     }


### PR DESCRIPTION
## v0.26.1 (23 May 2025)

### Added

- Add `RigidBodySet::get_pair_mut` and `ColliderSet::get_pair_mut` to get two mutable rigid-bodies or colliders
  simultaneously.
