### PR TITLE
Fix NaN resulting from non-clamped input to simd_asin in angular motor solver

### DIFF
--- a/src/dynamics/solver/joint_constraint/joint_constraint_builder.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint_builder.rs
@@ -756,7 +756,7 @@ impl<N: SimdRealCopy> JointTwoBodyConstraintHelper<N> {
             #[cfg(feature = "dim2")]
             let ang_dist = self.ang_err.angle();
             #[cfg(feature = "dim3")]
-            let ang_dist = self.ang_err.imag()[_motor_axis].simd_asin() * N::splat(2.0);
+            let ang_dist = self.ang_err.imag()[_motor_axis].simd_clamp(-1.0, 1.0).simd_asin() * N::splat(2.0);
             let target_ang = motor_params.target_pos;
             rhs_wo_bias += utils::smallest_abs_diff_between_angles(ang_dist, target_ang)
                 * motor_params.erp_inv_dt;


### PR DESCRIPTION
Fixes a significant NaN issue caused by a non-clamped input to `simd_asin` in `joint_constraint_builder.rs`.

Beforehand, as seen below, slight imprecision in the imaginary component of the error quaternion could cause a value out of bounds to be passed into  `simd_asin`, causing a NaN that further propagates to the body. This occurs very frequently with moving nested revolute joints.

Logged data from the code during debugging showcasing the issue:
```
ang error [1.0000001, -1.6205013e-5, -1.5124679e-6, 9.6172094e-5]
ang dist NaN
```