### PR TITLE
Crash when removing multibody

### DIFF
--- a/src/dynamics/joint/multibody_joint/mod.rs
+++ b/src/dynamics/joint/multibody_joint/mod.rs
@@ -29,37 +29,74 @@ mod test {
 
     #[test]
     fn multibody_joint_remove_and_step() {
-        let mut rnd = oorandom::Rand32::new(1234);
+        let mut bodies = RigidBodySet::new();
+        let mut multibody_joints = MultibodyJointSet::new();
+        let mut colliders = ColliderSet::new();
+        let mut impulse_joints = ImpulseJointSet::new();
+        let mut islands = IslandManager::new();
 
-        for k in 0..10 {
-            let mut bodies = RigidBodySet::new();
-            let mut multibody_joints = MultibodyJointSet::new();
-            let mut colliders = ColliderSet::new();
-            let mut impulse_joints = ImpulseJointSet::new();
-            let mut islands = IslandManager::new();
+        let mut pipeline = PhysicsPipeline::new();
+        let mut bf = BroadPhaseMultiSap::new();
+        let mut nf = NarrowPhase::new();
 
-            let mut pipeline = PhysicsPipeline::new();
-            let mut bf = BroadPhaseMultiSap::new();
-            let mut nf = NarrowPhase::new();
+        let num_links = 2;
+        let mut handles = vec![];
 
-            let num_links = 2;
-            let mut handles = vec![];
+        for _ in 0..num_links {
+            use crate::prelude::RigidBodyBuilder;
 
-            for _ in 0..num_links {
-                use crate::prelude::RigidBodyBuilder;
+            handles.push(bodies.insert(RigidBodyBuilder::dynamic()));
+        }
 
-                handles.push(bodies.insert(RigidBodyBuilder::dynamic()));
-            }
+        #[cfg(feature = "dim2")]
+        let joint = RevoluteJoint::new();
+        #[cfg(feature = "dim3")]
+        let joint = RevoluteJoint::new(na::Vector::x_axis());
 
-            #[cfg(feature = "dim2")]
-            let joint = RevoluteJoint::new();
-            #[cfg(feature = "dim3")]
-            let joint = RevoluteJoint::new(na::Vector::x_axis());
+        for i in 0..num_links - 1 {
+            multibody_joints
+                .insert(handles[i], handles[i + 1], joint, true)
+                .unwrap();
+        }
+        pipeline.step(
+            &Vector::zeros(),
+            &IntegrationParameters::default(),
+            &mut islands,
+            &mut bf,
+            &mut nf,
+            &mut bodies,
+            &mut colliders,
+            &mut impulse_joints,
+            &mut multibody_joints,
+            &mut CCDSolver::new(),
+            None,
+            &(),
+            &(),
+        );
 
-            for i in 0..num_links - 1 {
-                multibody_joints
-                    .insert(handles[i], handles[i + 1], joint, true)
-                    .unwrap();
+        for handle in handles.clone().iter() {
+            bodies.remove(
+                *handle,
+                &mut islands,
+                &mut colliders,
+                &mut impulse_joints,
+                &mut multibody_joints,
+                true,
+            );
+            // Remove from our handles the one we just removed.
+            handles.retain(|value| value != handle);
+            // All handles left should be correctly set up.
+            for handle in handles.iter() {
+                // Note debug #847: rigid_body_link should return none when attempting to remove the last (second) body.
+                if let Some(link) = multibody_joints.rigid_body_link(*handle).copied() {
+                    if multibody_joints
+                        .get_multibody_mut_internal(link.multibody)
+                        .is_none()
+                    {
+                        panic!("multibody_joints should be able to get all links returned from rigid_body_link.");
+                    }
+                    panic!("This test has only 1 link, it should lead to rigid_body_link returning `None` immediately after first removal.");
+                }
             }
             pipeline.step(
                 &Vector::zeros(),
@@ -76,61 +113,6 @@ mod test {
                 &(),
                 &(),
             );
-            match k {
-                0 => {} // Remove in insertion order.
-                1 => {
-                    // Remove from leaf to root.
-                    handles.reverse();
-                }
-                _ => {
-                    // Shuffle the vector a bit.
-                    // (This test checks multiple shuffle arrangements due to k > 2).
-                    for l in 0..num_links {
-                        handles.swap(l, rnd.rand_range(0..num_links as u32) as usize);
-                    }
-                }
-            }
-
-            for handle in handles.clone().iter() {
-                bodies.remove(
-                    *handle,
-                    &mut islands,
-                    &mut colliders,
-                    &mut impulse_joints,
-                    &mut multibody_joints,
-                    true,
-                );
-                // Remove from our handles the one we just removed.
-                handles.retain(|value| value != handle);
-                // All handles left should be correctly set up.
-                for handle in handles.iter() {
-                    // Note debug #847: rigid_body_link should return none when attempting to remove the last (second) body.
-                    if let Some(link) = multibody_joints.rigid_body_link(*handle).copied() {
-                        if multibody_joints
-                            .get_multibody_mut_internal(link.multibody)
-                            .is_none()
-                        {
-                            panic!("multibody_joints should be able to get all links returned from rigid_body_link.");
-                        }
-                        panic!("This test has only 1 link, it should lead to rigid_body_link returning `None` immediately after first removal.");
-                    }
-                }
-                pipeline.step(
-                    &Vector::zeros(),
-                    &IntegrationParameters::default(),
-                    &mut islands,
-                    &mut bf,
-                    &mut nf,
-                    &mut bodies,
-                    &mut colliders,
-                    &mut impulse_joints,
-                    &mut multibody_joints,
-                    &mut CCDSolver::new(),
-                    None,
-                    &(),
-                    &(),
-                );
-            }
         }
     }
 }

--- a/src/dynamics/joint/multibody_joint/mod.rs
+++ b/src/dynamics/joint/multibody_joint/mod.rs
@@ -17,3 +17,106 @@ mod multibody_workspace;
 mod multibody_ik;
 mod multibody_joint;
 mod unit_multibody_joint;
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::{
+        BroadPhaseMultiSap, CCDSolver, ColliderSet, ImpulseJointSet, IntegrationParameters,
+        IslandManager, NarrowPhase, PhysicsPipeline, RigidBodySet,
+    };
+    use crate::prelude::{MultibodyJointSet, RevoluteJoint};
+    use parry::math::Vector;
+
+    #[test]
+    fn multibody_joint_remove_and_step() {
+        let mut rnd = oorandom::Rand32::new(1234);
+
+        for k in 0..10 {
+            let mut bodies = RigidBodySet::new();
+            let mut multibody_joints = MultibodyJointSet::new();
+            let mut colliders = ColliderSet::new();
+            let mut impulse_joints = ImpulseJointSet::new();
+            let mut islands = IslandManager::new();
+
+            let mut pipeline = PhysicsPipeline::new();
+            let mut bf = BroadPhaseMultiSap::new();
+            let mut nf = NarrowPhase::new();
+
+            let num_links = 100;
+            let mut handles = vec![];
+
+            for _ in 0..num_links {
+                use crate::prelude::RigidBodyBuilder;
+
+                handles.push(bodies.insert(RigidBodyBuilder::dynamic()));
+            }
+
+            #[cfg(feature = "dim2")]
+            let joint = RevoluteJoint::new();
+            #[cfg(feature = "dim3")]
+            let joint = RevoluteJoint::new(na::Vector::x_axis());
+
+            for i in 0..num_links - 1 {
+                multibody_joints
+                    .insert(handles[i], handles[i + 1], joint, true)
+                    .unwrap();
+            }
+            pipeline.step(
+                &Vector::zeros(),
+                &IntegrationParameters::default(),
+                &mut islands,
+                &mut bf,
+                &mut nf,
+                &mut bodies,
+                &mut colliders,
+                &mut impulse_joints,
+                &mut multibody_joints,
+                &mut CCDSolver::new(),
+                None,
+                &(),
+                &(),
+            );
+            match k {
+                0 => {} // Remove in insertion order.
+                1 => {
+                    // Remove from leaf to root.
+                    handles.reverse();
+                }
+                _ => {
+                    // Shuffle the vector a bit.
+                    // (This test checks multiple shuffle arrangements due to k > 2).
+                    for l in 0..num_links {
+                        handles.swap(l, rnd.rand_range(0..num_links as u32) as usize);
+                    }
+                }
+            }
+
+            for (i, handle) in handles.iter().enumerate() {
+                dbg!(i);
+                bodies.remove(
+                    *handle,
+                    &mut islands,
+                    &mut colliders,
+                    &mut impulse_joints,
+                    &mut multibody_joints,
+                    true,
+                );
+                pipeline.step(
+                    &Vector::zeros(),
+                    &IntegrationParameters::default(),
+                    &mut islands,
+                    &mut bf,
+                    &mut nf,
+                    &mut bodies,
+                    &mut colliders,
+                    &mut impulse_joints,
+                    &mut multibody_joints,
+                    &mut CCDSolver::new(),
+                    None,
+                    &(),
+                    &(),
+                );
+            }
+        }
+    }
+}

--- a/src/dynamics/joint/multibody_joint/mod.rs
+++ b/src/dynamics/joint/multibody_joint/mod.rs
@@ -91,8 +91,7 @@ mod test {
                 }
             }
 
-            for (i, handle) in handles.clone().iter().enumerate() {
-                dbg!(i, handle);
+            for handle in handles.clone().iter() {
                 bodies.remove(
                     *handle,
                     &mut islands,
@@ -111,9 +110,9 @@ mod test {
                             .get_multibody_mut_internal(link.multibody)
                             .is_none()
                         {
-                            dbg!(handle, link);
                             panic!("multibody_joints should be able to get all links returned from rigid_body_link.");
                         }
+                        panic!("This test has only 1 link, it should lead to rigid_body_link returning `None` immediately after first removal.");
                     }
                 }
                 pipeline.step(

--- a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
@@ -308,7 +308,7 @@ impl MultibodyJointSet {
 
     /// Returns the link of this multibody attached to the given rigid-body.
     ///
-    /// Returns `None` if `rb` isn’t part of any rigid-body.
+    /// Returns `None` if `rb` isn’t part of any multibody.
     pub fn rigid_body_link(&self, rb: RigidBodyHandle) -> Option<&MultibodyLinkId> {
         self.rb2mb.get(rb.0)
     }

--- a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
@@ -241,11 +241,17 @@ impl MultibodyJointSet {
                     if multibody.num_links() == 1 {
                         // We don’t have any multibody_joint attached to this body, remove it.
                         let isolated_link = multibody.link(0).unwrap();
-                        let isolated_graph_id =
-                            self.rb2mb.get(isolated_link.rigid_body.0).unwrap().graph_id;
-                        if let Some(other) = self.connectivity_graph.remove_node(isolated_graph_id)
+                        let isolated_graph_id = self
+                            .rb2mb
+                            .remove(isolated_link.rigid_body.0, Default::default())
+                            .unwrap();
+
+                        if let Some(other) = self
+                            .connectivity_graph
+                            .remove_node(isolated_graph_id.graph_id)
                         {
-                            self.rb2mb.get_mut(other.0).unwrap().graph_id = isolated_graph_id;
+                            self.rb2mb.get_mut(other.0).unwrap().graph_id =
+                                isolated_graph_id.graph_id;
                         }
                     } else {
                         let mb_id = self.multibodies.insert(multibody);

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -848,7 +848,7 @@ impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
                         .collect();
                     colliders.sort_by_key(|co| -(co.len() as isize));
 
-                    let num_to_delete = (colliders.len() / 10).max(0);
+                    let num_to_delete = (colliders.len() / 10).clamp(1, colliders.len());
                     for to_delete in &colliders[..num_to_delete] {
                         if let Some(graphics) = self.graphics.as_mut() {
                             graphics.remove_collider(to_delete[0], &self.harness.physics.colliders);
@@ -871,7 +871,7 @@ impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
                         .filter(|e| e.1.is_dynamic())
                         .map(|e| e.0)
                         .collect();
-                    let num_to_delete = (dynamic_bodies.len() / 10).max(0);
+                    let num_to_delete = (dynamic_bodies.len() / 10).clamp(1, dynamic_bodies.len());
                     for to_delete in &dynamic_bodies[..num_to_delete] {
                         if let Some(graphics) = self.graphics.as_mut() {
                             graphics.remove_body(*to_delete);
@@ -895,7 +895,8 @@ impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
                         .iter()
                         .map(|e| e.0)
                         .collect();
-                    let num_to_delete = (impulse_joints.len() / 10).max(0);
+                    let num_to_delete =
+                        (impulse_joints.len() / 10).max(1).min(impulse_joints.len());
                     for to_delete in &impulse_joints[..num_to_delete] {
                         self.harness.physics.impulse_joints.remove(*to_delete, true);
                     }
@@ -909,7 +910,8 @@ impl Testbed<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
                         .iter()
                         .map(|e| e.0)
                         .collect();
-                    let num_to_delete = (multibody_joints.len() / 10).max(0);
+                    let num_to_delete =
+                        (multibody_joints.len() / 10).clamp(1, multibody_joints.len());
                     for to_delete in &multibody_joints[..num_to_delete] {
                         self.harness
                             .physics


### PR DESCRIPTION
- Following up to https://github.com/dimforge/bevy_rapier/discussions/663 ; This issue seems to come from rapier, so fixing this in rapier before investigating in bevy_rapier is a better approach.

```
thread 'dynamics::joint::multibody_joint::test::multibody_joint_remove_and_step' panicked at crates/rapier2d/../../src/dynamics/solver/velocity_solver.rs:101:22:
called `Option::unwrap()` on a `None` value
```

- Maybe related: https://github.com/dimforge/rapier/pull/672

:warning: I easily make it crash by running `cargo run --bin all_examples3` -> hitting a few times `A` (remove any 10% multibodies) with 2 scenari:
- either the simulation explodes and we have the sap axis panic. (unrelated to this PR)
- or there is a failing unwrap at https://github.com/Vrixyz/rapier/blob/d357433b2da9da12c48264ad3acd2fb6c9411b6d/src/dynamics/solver/contact_constraint/generic_one_body_constraint.rs#L67
  - should the `MultibodyJointSet`  remove recursively the `rb2mb` when it detects a removal leading to empty link?
  - something like: ( :warning: not working either)
```diff
diff --git a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
index 3dd3e36..aac7538 100644
--- a/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_joint_set.rs
@@ -250,8 +250,13 @@ impl MultibodyJointSet {
                             .connectivity_graph
                             .remove_node(isolated_graph_id.graph_id)
                         {
-                            self.rb2mb.get_mut(other.0).unwrap().graph_id =
-                                isolated_graph_id.graph_id;
+                            let other_mb_id = self.rb2mb.get_mut(other.0).unwrap();
+                            other_mb_id.graph_id = isolated_graph_id.graph_id;
+                            let other_mb_id = other_mb_id.clone();
+                            let other_mb = self.multibodies.get(other_mb_id.multibody.0).unwrap();
+                            if other_mb.num_links() == 1 {
+                                self.remove(MultibodyJointHandle(other_mb_id.multibody.0), wake_up);
+                            }
                         }
                     } else {
                         let mb_id = self.multibodies.insert(multibody);
```