### PR TITLE
Fix web_time usage for Timer

### DIFF
--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -3,12 +3,16 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "profiler")]
+use web_time::Instant;
+
 /// A timer.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Timer {
     time: Duration,
     #[allow(dead_code)] // The field isn’t used if the `profiler` feature isn’t enabled.
-    start: Option<std::time::Instant>,
+    #[cfg(feature = "profiler")]
+    start: Option<Instant>,
 }
 
 impl Timer {
@@ -16,6 +20,7 @@ impl Timer {
     pub fn new() -> Self {
         Timer {
             time: Duration::from_secs(0),
+            #[cfg(feature = "profiler")]
             start: None,
         }
     }
@@ -30,7 +35,7 @@ impl Timer {
         #[cfg(feature = "profiler")]
         {
             self.time = Duration::from_secs(0);
-            self.start = Some(web_time::Instant::now());
+            self.start = Some(Instant::now());
         }
     }
 
@@ -39,7 +44,7 @@ impl Timer {
         #[cfg(feature = "profiler")]
         {
             if let Some(start) = self.start {
-                self.time += web_time::Instant::now().duration_since(start);
+                self.time += Instant::now().duration_since(start);
             }
             self.start = None;
         }
@@ -49,7 +54,7 @@ impl Timer {
     pub fn resume(&mut self) {
         #[cfg(feature = "profiler")]
         {
-            self.start = Some(web_time::Instant::now());
+            self.start = Some(Instant::now());
         }
     }
 

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -10,7 +10,6 @@ use web_time::Instant;
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Timer {
     time: Duration,
-    #[allow(dead_code)] // The field isn’t used if the `profiler` feature isn’t enabled.
     #[cfg(feature = "profiler")]
     start: Option<Instant>,
 }


### PR DESCRIPTION
rapier3d failed to compile for wasm32 with the `profiler` feature flag enabled.
This PR fixes it, making the `profiler` flag work as expected across any target_arch.