### PR TITLE
Replace crossbeam channel with std::sync::mpsc

### DIFF
--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -73,7 +73,6 @@ parry2d-f64 = "0.22.0-beta.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }
-crossbeam = "0.8"
 arrayvec = "0.7"
 bit-vec = "0.8"
 rustc-hash = "2"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -74,7 +74,6 @@ parry2d = "0.22.0-beta.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }
-crossbeam = "0.8"
 arrayvec = "0.7"
 bit-vec = "0.8"
 rustc-hash = "2"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -76,7 +76,6 @@ parry3d-f64 = "0.22.0-beta.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }
-crossbeam = "0.8"
 arrayvec = "0.7"
 bit-vec = "0.8"
 rustc-hash = "2"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -78,7 +78,6 @@ parry3d = "0.22.0-beta.1"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }
-crossbeam = "0.8"
 arrayvec = "0.7"
 bit-vec = "0.8"
 rustc-hash = "2"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -50,7 +50,6 @@ web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
 wrapped2d = { version = "0.4", optional = true }
-crossbeam = "0.8"
 bincode = "1"
 Inflector = "0.11"
 md5 = "0.7"

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -50,7 +50,6 @@ web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
 wrapped2d = { version = "0.4", optional = true }
-crossbeam = "0.8"
 bincode = "1"
 Inflector = "0.11"
 md5 = "0.7"

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -51,7 +51,6 @@ rand_pcg = "0.3"
 web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
-crossbeam = "0.8"
 bincode = "1"
 md5 = "0.7"
 Inflector = "0.11"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -52,7 +52,6 @@ glam = { version = "0.27", optional = true } # For Physx
 num_cpus = { version = "1", optional = true }
 physx = { version = "0.19", features = ["glam"], optional = true }
 physx-sys = { version = "0.11", optional = true }
-crossbeam = "0.8"
 bincode = "1"
 md5 = "0.7"
 Inflector = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ pub extern crate parry3d as parry;
 #[cfg(all(feature = "dim3", feature = "f64"))]
 pub extern crate parry3d_f64 as parry;
 
-pub extern crate crossbeam;
 pub extern crate nalgebra as na;
 #[cfg(feature = "serde-serialize")]
 #[macro_use]

--- a/src/pipeline/event_handler.rs
+++ b/src/pipeline/event_handler.rs
@@ -1,7 +1,7 @@
 use crate::dynamics::RigidBodySet;
 use crate::geometry::{ColliderSet, CollisionEvent, ContactForceEvent, ContactPair};
 use crate::math::Real;
-use crossbeam::channel::Sender;
+use std::sync::mpsc::Sender;
 
 bitflags::bitflags! {
     #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
@@ -90,14 +90,14 @@ impl EventHandler for () {
     }
 }
 
-/// A collision event handler that collects events into a crossbeam channel.
+/// A collision event handler that collects events into a channel.
 pub struct ChannelEventCollector {
     collision_event_sender: Sender<CollisionEvent>,
     contact_force_event_sender: Sender<ContactForceEvent>,
 }
 
 impl ChannelEventCollector {
-    /// Initialize a new collision event handler from crossbeam channel senders.
+    /// Initialize a new collision event handler from channel senders.
     pub fn new(
         collision_event_sender: Sender<CollisionEvent>,
         contact_force_event_sender: Sender<ContactForceEvent>,

--- a/src_testbed/harness/mod.rs
+++ b/src_testbed/harness/mod.rs
@@ -118,8 +118,8 @@ type Callbacks =
 #[allow(dead_code)]
 impl Harness {
     pub fn new_empty() -> Self {
-        let collision_event_channel = crossbeam::channel::unbounded();
-        let contact_force_event_channel = crossbeam::channel::unbounded();
+        let collision_event_channel = std::sync::mpsc::channel();
+        let contact_force_event_channel = std::sync::mpsc::channel();
         let event_handler =
             ChannelEventCollector::new(collision_event_channel.0, contact_force_event_channel.0);
         let events = PhysicsEvents {

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -1,4 +1,4 @@
-use crossbeam::channel::Receiver;
+use std::sync::mpsc::Receiver;
 use rapier::dynamics::{
     CCDSolver, ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointSet,
     RigidBodySet,

--- a/src_testbed/physics/mod.rs
+++ b/src_testbed/physics/mod.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc::Receiver;
 use rapier::dynamics::{
     CCDSolver, ImpulseJointSet, IntegrationParameters, IslandManager, MultibodyJointSet,
     RigidBodySet,
@@ -8,6 +7,7 @@ use rapier::geometry::{
 };
 use rapier::math::{Real, Vector};
 use rapier::pipeline::{PhysicsHooks, PhysicsPipeline};
+use std::sync::mpsc::Receiver;
 
 pub struct PhysicsSnapshot {
     timestep_id: usize,


### PR DESCRIPTION
Replaced all uses of `crossbeam::channel` with `std::sync::mpsc` to reduce the dependency footprint.

## Changes
- Modified channel imports from `crossbeam::channel::{Sender, Receiver}` to `std::sync::mpsc::{Sender, Receiver}`
- Changed `crossbeam::channel::unbounded()` to `std::sync::mpsc::channel()`
- Removed `crossbeam = "0.8"` dependency from 8 Cargo.toml files
- Removed `pub extern crate crossbeam;` from src/lib.rs
- Updated doc comments to remove crossbeam mentions

As discussed in #828, crossbeam is only used for its channel implementation. Since std::sync::mpsc provides equivalent functionality for this use case, we can use the standard library instead.

Fixes #828