### PR TITLE
Changed some API to be more library friendly

### DIFF
--- a/examples2d/debug_intersection2.rs
+++ b/examples2d/debug_intersection2.rs
@@ -53,7 +53,7 @@ pub fn init_world(testbed: &mut Testbed) {
         );
 
         for intersection in query_pipeline.intersect_shape(
-            &Isometry::translation(slow_time.cos() * 10.0, slow_time.sin() * 10.0),
+            Isometry::translation(slow_time.cos() * 10.0, slow_time.sin() * 10.0),
             &Ball::new(rad / 2.0),
         ) {
             if let Some(graphics) = graphics.as_deref_mut() {

--- a/examples2d/utils/character.rs
+++ b/examples2d/utils/character.rs
@@ -140,7 +140,7 @@ fn update_kinematic_controller(
     let Some(broad_phase) = phx.broad_phase.downcast_ref::<BroadPhaseBvh>() else {
         return;
     };
-    let query_pipeline = broad_phase.as_query_pipeline_mut(
+    let mut query_pipeline = broad_phase.as_query_pipeline_mut(
         phx.narrow_phase.query_dispatcher(),
         &mut phx.bodies,
         &mut phx.colliders,
@@ -165,7 +165,7 @@ fn update_kinematic_controller(
 
     controller.solve_character_collision_impulses(
         phx.integration_parameters.dt,
-        query_pipeline,
+        &mut query_pipeline,
         &*character_shape,
         character_mass,
         &*collisions,

--- a/examples3d/utils/character.rs
+++ b/examples3d/utils/character.rs
@@ -150,7 +150,7 @@ fn update_kinematic_controller(
     let Some(broad_phase) = phx.broad_phase.downcast_ref::<BroadPhaseBvh>() else {
         return;
     };
-    let query_pipeline = broad_phase.as_query_pipeline_mut(
+    let mut query_pipeline = broad_phase.as_query_pipeline_mut(
         phx.narrow_phase.query_dispatcher(),
         &mut phx.bodies,
         &mut phx.colliders,
@@ -175,7 +175,7 @@ fn update_kinematic_controller(
 
     controller.solve_character_collision_impulses(
         phx.integration_parameters.dt,
-        query_pipeline,
+        &mut query_pipeline,
         &*character_shape,
         character_mass,
         &*collisions,

--- a/src/control/character_controller.rs
+++ b/src/control/character_controller.rs
@@ -423,7 +423,7 @@ impl KinematicCharacterController {
 
         let mut grounded = false;
 
-        'outer: for (_, collider) in queries.intersect_aabb_conservative(&character_aabb) {
+        'outer: for (_, collider) in queries.intersect_aabb_conservative(character_aabb) {
             manifolds.clear();
             let pos12 = character_pos.inv_mul(collider.position());
             let _ = dispatcher.contact_manifolds(
@@ -770,7 +770,7 @@ impl KinematicCharacterController {
     pub fn solve_character_collision_impulses<'a>(
         &self,
         dt: Real,
-        mut queries: QueryPipelineMut,
+        queries: &mut QueryPipelineMut,
         character_shape: &dyn Shape,
         character_mass: Real,
         collisions: impl IntoIterator<Item = &'a CharacterCollision>,
@@ -778,7 +778,7 @@ impl KinematicCharacterController {
         for collision in collisions {
             self.solve_single_character_collision_impulse(
                 dt,
-                &mut queries,
+                queries,
                 character_shape,
                 character_mass,
                 collision,
@@ -813,10 +813,7 @@ impl KinematicCharacterController {
             .compute_aabb(&collision.character_pos)
             .loosened(prediction);
 
-        for (_, collider) in queries
-            .as_ref()
-            .intersect_aabb_conservative(&character_aabb)
-        {
+        for (_, collider) in queries.as_ref().intersect_aabb_conservative(character_aabb) {
             if let Some(parent) = collider.parent {
                 if let Some(body) = queries.bodies.get(parent.handle) {
                     if body.is_dynamic() {

--- a/src/dynamics/ccd/ccd_solver.rs
+++ b/src/dynamics/ccd/ccd_solver.rs
@@ -168,7 +168,7 @@ impl CCDSolver {
                         .shape
                         .compute_swept_aabb(&co1.pos, &predicted_collider_pos1);
 
-                    for (ch2, _) in query_pipeline.intersect_aabb_conservative(&aabb1) {
+                    for (ch2, _) in query_pipeline.intersect_aabb_conservative(aabb1) {
                         if *ch1 == ch2 {
                             // Ignore self-intersection.
                             continue;
@@ -301,7 +301,7 @@ impl CCDSolver {
                         .shape
                         .compute_swept_aabb(&co1.pos, &predicted_collider_pos1);
 
-                    for (ch2, _) in query_pipeline.intersect_aabb_conservative(&aabb1) {
+                    for (ch2, _) in query_pipeline.intersect_aabb_conservative(aabb1) {
                         if *ch1 == ch2 {
                             // Ignore self-intersection.
                             continue;
@@ -433,7 +433,7 @@ impl CCDSolver {
                 let co_next_pos1 = rb1.pos.next_position * co1_parent.pos_wrt_parent;
                 let aabb = co1.shape.compute_swept_aabb(&co1.pos, &co_next_pos1);
 
-                for (ch2, _) in query_pipeline.intersect_aabb_conservative(&aabb) {
+                for (ch2, _) in query_pipeline.intersect_aabb_conservative(aabb) {
                     let co2 = &colliders[ch2];
 
                     let bh1 = co1.parent.map(|p| p.handle);


### PR DESCRIPTION
- Spawned from https://github.com/dimforge/bevy_rapier/pull/671

### Summary

- functions returning iterators are difficult to build on top of those if they capture references.
- QueryPipeline (especially Mut) should be passed as reference as much as possible