### PR TITLE
Release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.30.0 (03 Oct. 2025)
+
+- Update to parry 0.25 (which involves breaking changes in the `Voxels` API but improves its internal storage to support
+  large voxel maps).
+
 ## v0.29.0 (05 Sept. 2025)
 
 This version contains a significant rework of the internal velocity constraints solver.

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -69,7 +69,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry2d-f64 = "0.24.0"
+parry2d-f64 = "0.25.0"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -70,7 +70,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry2d = "0.24.0"
+parry2d = "0.25.0"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -72,7 +72,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry3d-f64 = "0.24.0"
+parry3d-f64 = "0.25.0"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-meshloader"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-meshloader"
@@ -29,4 +29,4 @@ thiserror = "2"
 profiling = "1.0"
 mesh-loader = "0.1.12"
 
-rapier3d = { version = "0.29.0", path = "../rapier3d" }
+rapier3d = { version = "0.30.0", path = "../rapier3d" }

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-urdf"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
@@ -31,5 +31,5 @@ anyhow = "1"
 bitflags = "2"
 urdf-rs = "0.9"
 
-rapier3d = { version = "0.29.0", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.10.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+rapier3d = { version = "0.30.0", path = "../rapier3d" }
+rapier3d-meshloader = { version = "0.11.0", path = "../rapier3d-meshloader", default-features = false, optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -74,7 +74,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry3d = "0.24.0"
+parry3d = "0.25.0"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -98,5 +98,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.29.0"
+version = "0.30.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -98,5 +98,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.29.0"
+version = "0.30.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -99,5 +99,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.29.0"
+version = "0.30.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
 homepage = "http://rapier.rs"
@@ -97,5 +97,5 @@ bevy = { version = "0.15", default-features = false, features = [
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.29.0"
+version = "0.30.0"
 features = ["serde-serialize", "debug-render", "profiler"]


### PR DESCRIPTION
## v0.30.0 (03 Oct. 2025)

- Update to parry 0.25 (which involves breaking changes in the `Voxels` API but improves its internal storage to support
  large voxel maps).
