### PR TITLE
Release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## Unreleased
+## v0.30.1 (17 Oct. 2025)
 
 - Kinematic rigid-bodies will no longer fall asleep if they have a nonzero velocity, even if that velocity is very
   small. The rationale is that, since that velocity is chosen by the user, they really want the platform to move even
   if the speed is low.
 - Fix bug where kinematic bodies would ignore the `wake_up` flag passed to `set_linear_velocity` and
   `set_angular_velocity`.
+- Add serde derives to `PdController`, `PidController` and `DynamicRaycastVehicle` controllers.
 
 ## v0.30.0 (03 Oct. 2025)
 

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d-f64"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -69,7 +69,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry2d-f64 = "0.25.0"
+parry2d-f64 = "0.25.1"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier2d"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "2-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier2d"
@@ -70,7 +70,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry2d = "0.25.0"
+parry2d = "0.25.1"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d-f64"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -72,7 +72,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry3d-f64 = "0.25.0"
+parry3d-f64 = "0.25.1"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapier3d"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 description = "3-dimensional physics engine in Rust."
 documentation = "https://docs.rs/rapier3d"
@@ -74,7 +74,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.34"
-parry3d = "0.25.0"
+parry3d = "0.25.1"
 simba = "0.9.1"
 approx = "0.5"
 rayon = { version = "1", optional = true }


### PR DESCRIPTION
## v0.30.1 (17 Oct. 2025)

- Kinematic rigid-bodies will no longer fall asleep if they have a nonzero velocity, even if that velocity is very
  small. The rationale is that, since that velocity is chosen by the user, they really want the platform to move even
  if the speed is low.
- Fix bug where kinematic bodies would ignore the `wake_up` flag passed to `set_linear_velocity` and
  `set_angular_velocity`.
- Add serde derives to `PdController`, `PidController` and `DynamicRaycastVehicle` controllers.