### PR TITLE
Expose ColliderSet::{take_modified, take_removed}

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,7 +2,7 @@
 
 pub use self::arena::{Arena, Index};
 pub use self::coarena::Coarena;
-pub(crate) use self::modified_objects::{HasModifiedFlag, ModifiedObjects};
+pub use self::modified_objects::{HasModifiedFlag, ModifiedObjects};
 
 pub mod arena;
 mod coarena;

--- a/src/data/modified_objects.rs
+++ b/src/data/modified_objects.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 /// be done for internal engine usage (like the physics pipeline).
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
-pub(crate) struct ModifiedObjects<Handle, Object>(Vec<Handle>, PhantomData<Object>);
+pub struct ModifiedObjects<Handle, Object>(Vec<Handle>, PhantomData<Object>);
 
 impl<Handle, Object> Default for ModifiedObjects<Handle, Object> {
     fn default() -> Self {
@@ -17,8 +17,11 @@ impl<Handle, Object> Default for ModifiedObjects<Handle, Object> {
     }
 }
 
-pub(crate) trait HasModifiedFlag {
+/// Objects that internally track a flag indicating whether they've been modified
+pub trait HasModifiedFlag {
+    /// Whether the object has been modified
     fn has_modified_flag(&self) -> bool;
+    /// Mark object as modified
     fn set_modified_flag(&mut self);
 }
 
@@ -30,6 +33,7 @@ impl<Handle, Object> Deref for ModifiedObjects<Handle, Object> {
 }
 
 impl<Handle, Object: HasModifiedFlag> ModifiedObjects<Handle, Object> {
+    /// Preallocate memory for `capacity` handles
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Vec::with_capacity(capacity), PhantomData)
     }

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -5,7 +5,8 @@ use crate::geometry::{Collider, ColliderChanges, ColliderHandle, ColliderParent}
 use crate::math::Isometry;
 use std::ops::{Index, IndexMut};
 
-pub(crate) type ModifiedColliders = ModifiedObjects<ColliderHandle, Collider>;
+/// A set of modified colliders
+pub type ModifiedColliders = ModifiedObjects<ColliderHandle, Collider>;
 
 impl HasModifiedFlag for Collider {
     #[inline]
@@ -71,7 +72,16 @@ impl ColliderSet {
         }
     }
 
-    pub(crate) fn take_modified(&mut self) -> ModifiedColliders {
+    /// Fetch the set of colliders modified since the last call to
+    /// `take_modified`
+    ///
+    /// Provides a value that can be passed to the `modified_colliders` argument
+    /// of [`BroadPhaseBvh::update`](crate::geometry::BroadPhaseBvh::update).
+    ///
+    /// Should not be used if this [`ColliderSet`] will be used with a
+    /// [`PhysicsPipeline`](crate::pipeline::PhysicsPipeline), which handles
+    /// broadphase updates automatically.
+    pub fn take_modified(&mut self) -> ModifiedColliders {
         std::mem::take(&mut self.modified_colliders)
     }
 
@@ -79,7 +89,15 @@ impl ColliderSet {
         self.modified_colliders = modified;
     }
 
-    pub(crate) fn take_removed(&mut self) -> Vec<ColliderHandle> {
+    /// Fetch the set of colliders removed since the last call to `take_removed`
+    ///
+    /// Provides a value that can be passed to the `removed_colliders` argument
+    /// of [`BroadPhaseBvh::update`](crate::geometry::BroadPhaseBvh::update).
+    ///
+    /// Should not be used if this [`ColliderSet`] will be used with a
+    /// [`PhysicsPipeline`](crate::pipeline::PhysicsPipeline), which handles
+    /// broadphase updates automatically.
+    pub fn take_removed(&mut self) -> Vec<ColliderHandle> {
         std::mem::take(&mut self.removed_colliders)
     }
 

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -4,7 +4,7 @@ pub use self::broad_phase_bvh::{BroadPhaseBvh, BvhOptimizationStrategy};
 pub use self::broad_phase_pair_event::{BroadPhasePairEvent, ColliderPair};
 pub use self::collider::{Collider, ColliderBuilder};
 pub use self::collider_components::*;
-pub use self::collider_set::ColliderSet;
+pub use self::collider_set::{ColliderSet, ModifiedColliders};
 pub use self::contact_pair::{
     ContactData, ContactManifoldData, ContactPair, IntersectionPair, SimdSolverContact,
     SolverContact, SolverFlags,
@@ -211,7 +211,6 @@ impl ContactForceEvent {
     }
 }
 
-pub(crate) use self::collider_set::ModifiedColliders;
 pub(crate) use self::narrow_phase::ContactManifoldIndex;
 pub use parry::shape::*;
 


### PR DESCRIPTION
These are practically necessary when working without a PhysicsPipeline.

A larger change could avoid exposing `ModifiedObjects`, but it seems like it might be useful as well.

Alternatively, `BroadPhaseBvh::update` could be modified to pull this data from the `ColliderSet` itself. In that case the public interface could be narrowed to a method on `ColliderSet` to clear the modified/removed sets, but this would make it impossible for a user to inject their own modified/removed handles. I'm not sure if that's useful.