### PR TITLE
Fix issue where set_enabled had no effect

### DIFF
--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -831,6 +831,10 @@ impl NarrowPhase {
                     // No update needed for these colliders.
                     return;
                 }
+                if !co1.is_enabled() || !co2.is_enabled() {
+                    pair.clear();
+                    break 'emit_events;
+                }
                 if co1.parent.map(|p| p.handle) == co2.parent.map(|p| p.handle) && co1.parent.is_some()
                 {
                     // Same parents. Ignore collisions.


### PR DESCRIPTION
This PR fixes an issue where calling `set_enabled(false)` had no effect. There may be a more appropriate solution to this issue, and feedback from maintainers is needed.

Related issues:
1. [dimforge/bevy_rapier#680](https://github.com/dimforge/bevy_rapier/pull/680)  
2. https://github.com/dimforge/bevy_rapier/pull/678#issuecomment-3397808035
3. [dimforge/rapier.js#344](https://github.com/dimforge/rapier.js/issues/344)

Reproduction:
Steps to reproduce the issue are clearly described in the [Update to Bevy 0.17.2 PR](https://github.com/dimforge/bevy_rapier/pull/680).
