### PR TITLE
Make Broadphase Serializable to Json

### DIFF
--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -394,7 +394,7 @@ pub struct SolverContactGeneric<N: SimdRealCopy, const LANES: usize> {
     /// This isn’t a bool for optimizations purpose with SIMD.
     pub is_new: N, // 1/1
     /// The index of the manifold contact used to generate this solver contact.
-    pub contact_id: [u32; LANES], // 1/1
+    pub(crate) contact_id: [u32; LANES], // 1/1
     #[cfg(feature = "dim3")]
     pub(crate) padding: [N; 1],
 }


### PR DESCRIPTION
Serde can serialize almost the entire Rapier state to JSON; the only thing that's preventing full JSON-serialization (at least in my implementation) is this hashmap in Broadphase. Rapier already has serialization tools that can serialize hashmaps as vector tuples, so this PR just uses these existing utilities.