### PR TITLE
feat: add GeometricMean coefficient combine rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.31.0 (09 Jan. 2026)
 
+### Added
+
+- `CoefficientCombineRule::GeometricMean` - Computes the geometric mean of two coefficients using `sqrt(coeff1 * coeff2)`.
+
 ### Modified
 
 - **Breaking:** Migrate math types from nalgebra to glam (via parry). The main type aliases are now:


### PR DESCRIPTION
Closes #685

Fresh implementation since #826 has merge conflicts.

Adds `CoefficientCombineRule::GeometricMean` which computes `sqrt(coeff1 * coeff2)`.

This provides a more physically realistic way to combine friction/restitution coefficients:
- For values 0.1 and 0.9: Average gives 0.5, GeometricMean gives 0.3
- If one value is 0 (perfectly inelastic), result is 0 (not a bounce)
- Equal values unchanged: sqrt(0.8 × 0.8) = 0.8

Uses `.abs()` before sqrt to handle negative coefficients defensively (consistent with Min rule).

Includes unit tests for basic usage, edge cases (zero, negative, same values), priority, and ordering.