### PR TITLE
fix(ccd): honor filter_contact_pair PhysicsHook during CCD (closes #754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Fixed
+
+- Continuous Collision Detection now consults the user's `PhysicsHooks::filter_contact_pair`
+  hook, matching narrow-phase semantics. Previously, CCD would clamp a fast-moving body's
+  motion at a predicted impact with a pair the user had filtered out. Closes #754.
+
+### Modified
+
+- **Breaking (CCD solver direct callers only):** `CCDSolver::find_first_impact` and
+  `CCDSolver::predict_impacts_at_next_positions` now take an extra `hooks: &dyn PhysicsHooks`
+  argument. `PhysicsPipeline::step` callers are unaffected.
+
 ## v0.31.0 (09 Jan. 2026)
 
 ### Modified

--- a/src/dynamics/ccd/ccd_solver.rs
+++ b/src/dynamics/ccd/ccd_solver.rs
@@ -1,13 +1,51 @@
 use super::TOIEntry;
 use crate::alloc_prelude::*;
 use crate::dynamics::{IntegrationParameters, IslandManager, RigidBodyHandle, RigidBodySet};
-use crate::geometry::{BroadPhaseBvh, ColliderParent, ColliderSet, CollisionEvent, NarrowPhase};
+use crate::geometry::{
+    BroadPhaseBvh, Collider, ColliderHandle, ColliderParent, ColliderSet, CollisionEvent,
+    NarrowPhase,
+};
 use crate::math::Real;
 use crate::parry::utils::SortedPair;
-use crate::pipeline::{EventHandler, QueryFilter};
+use crate::pipeline::{ActiveHooks, EventHandler, PairFilterContext, PhysicsHooks, QueryFilter};
 use crate::prelude::{ActiveEvents, CollisionEventFlags};
 use alloc::collections::BinaryHeap;
 use parry::utils::hashmap::HashMap;
+
+/// Returns `true` if the user's `filter_contact_pair` hook rejected this
+/// pair. Mirrors the narrow-phase filter call in `NarrowPhase::compute_contacts`
+/// so CCD respects the same user-level contact filtering (see issue #754).
+///
+/// Note: the narrow phase may invoke this hook for sensor pairs too (it
+/// uses `solver_flags` to decide downstream). The CCD sweep sites skip
+/// sensors before calling this helper, which is intentional — CCD only
+/// resolves contact TOIs, and sensor intersections are reported elsewhere.
+#[inline]
+fn pair_filtered_out_by_hooks(
+    hooks: &dyn PhysicsHooks,
+    bodies: &RigidBodySet,
+    colliders: &ColliderSet,
+    co1: &Collider,
+    co2: &Collider,
+    ch1: ColliderHandle,
+    ch2: ColliderHandle,
+    bh1: Option<RigidBodyHandle>,
+    bh2: Option<RigidBodyHandle>,
+) -> bool {
+    let active_hooks = co1.flags.active_hooks | co2.flags.active_hooks;
+    if !active_hooks.contains(ActiveHooks::FILTER_CONTACT_PAIRS) {
+        return false;
+    }
+    let context = PairFilterContext {
+        bodies,
+        colliders,
+        rigid_body1: bh1,
+        rigid_body2: bh2,
+        collider1: ch1,
+        collider2: ch2,
+    };
+    hooks.filter_contact_pair(&context).is_none()
+}
 
 pub enum PredictedImpacts {
     Impacts(HashMap<RigidBodyHandle, Real>),
@@ -117,6 +155,7 @@ impl CCDSolver {
         colliders: &ColliderSet,
         broad_phase: &mut BroadPhaseBvh,
         narrow_phase: &NarrowPhase,
+        hooks: &dyn PhysicsHooks,
     ) -> Option<Real> {
         // Update the query pipeline with the colliders’ predicted positions.
         for (handle, co) in colliders.iter_enabled() {
@@ -199,6 +238,12 @@ impl CCDSolver {
                                 continue;
                             }
 
+                            if pair_filtered_out_by_hooks(
+                                hooks, bodies, colliders, co1, co2, *ch1, ch2, bh1, bh2,
+                            ) {
+                                continue;
+                            }
+
                             let smallest_dist = narrow_phase
                                 .contact_pair(*ch1, ch2)
                                 .and_then(|p| p.find_deepest_contact())
@@ -242,6 +287,7 @@ impl CCDSolver {
         colliders: &ColliderSet,
         broad_phase: &mut BroadPhaseBvh,
         narrow_phase: &NarrowPhase,
+        hooks: &dyn PhysicsHooks,
         events: &dyn EventHandler,
     ) -> PredictedImpacts {
         let dt = params.dt;
@@ -322,6 +368,12 @@ impl CCDSolver {
                             if bh1 == bh2
                                 || !co1.flags.collision_groups.test(co2.flags.collision_groups)
                             {
+                                continue;
+                            }
+
+                            if pair_filtered_out_by_hooks(
+                                hooks, bodies, colliders, co1, co2, *ch1, ch2, bh1, bh2,
+                            ) {
                                 continue;
                             }
 
@@ -439,6 +491,12 @@ impl CCDSolver {
 
                     // Ignore self-intersection and apply groups filter.
                     if bh1 == bh2 || !co1.flags.collision_groups.test(co2.flags.collision_groups) {
+                        continue;
+                    }
+
+                    if pair_filtered_out_by_hooks(
+                        hooks, bodies, colliders, co1, co2, *ch1, ch2, bh1, bh2,
+                    ) {
                         continue;
                     }
 

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -374,6 +374,7 @@ impl PhysicsPipeline {
         broad_phase: &mut BroadPhaseBvh,
         narrow_phase: &NarrowPhase,
         ccd_solver: &mut CCDSolver,
+        hooks: &dyn PhysicsHooks,
         events: &dyn EventHandler,
     ) {
         self.counters.ccd.toi_computation_time.start();
@@ -385,6 +386,7 @@ impl PhysicsPipeline {
             colliders,
             broad_phase,
             narrow_phase,
+            hooks,
             events,
         );
         ccd_solver.clamp_motions(integration_parameters.dt, bodies, &impacts);
@@ -638,6 +640,7 @@ impl PhysicsPipeline {
                         colliders,
                         broad_phase,
                         narrow_phase,
+                        hooks,
                     )
                 } else {
                     None
@@ -709,6 +712,7 @@ impl PhysicsPipeline {
                         broad_phase,
                         narrow_phase,
                         ccd_solver,
+                        hooks,
                         events,
                     );
                 }
@@ -952,6 +956,100 @@ mod test {
         assert_eq!(h1a, h1b);
         assert_eq!(h2a, h2b);
         assert_eq!(h3a, h3b);
+    }
+
+    // Regression test for https://github.com/dimforge/rapier/issues/754 —
+    // CCD must consult `filter_contact_pair` just like the narrow phase, so
+    // pairs the user filtered out don't clamp a fast CCD body's motion.
+    #[test]
+    #[cfg(feature = "dim3")]
+    fn ccd_respects_filter_contact_pair_hook() {
+        use crate::pipeline::{ActiveHooks, PairFilterContext, PhysicsHooks};
+        use crate::prelude::{ColliderHandle, SolverFlags};
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        struct RejectAllHooks {
+            calls: AtomicUsize,
+        }
+        impl PhysicsHooks for RejectAllHooks {
+            fn filter_contact_pair(&self, _: &PairFilterContext) -> Option<SolverFlags> {
+                self.calls.fetch_add(1, Ordering::Relaxed);
+                None // reject every pair
+            }
+        }
+
+        let mut pipeline = PhysicsPipeline::new();
+        let integration_parameters = IntegrationParameters::default();
+        let mut broad_phase = BroadPhaseBvh::new();
+        let mut narrow_phase = NarrowPhase::new();
+        let mut bodies = RigidBodySet::new();
+        let mut colliders = ColliderSet::new();
+        let mut ccd = CCDSolver::new();
+        let mut impulse_joints = ImpulseJointSet::new();
+        let mut multibody_joints = MultibodyJointSet::new();
+        let mut islands = IslandManager::new();
+        let hooks = RejectAllHooks { calls: AtomicUsize::new(0) };
+        let event_handler = ();
+
+        // Body A: fast-moving, CCD-enabled.
+        let body_a = RigidBodyBuilder::dynamic()
+            .translation(Vector::new(-5.0, 0.0, 0.0))
+            .linvel(Vector::new(200.0, 0.0, 0.0))
+            .ccd_enabled(true)
+            .build();
+        let a_handle = bodies.insert(body_a);
+        let _: ColliderHandle = colliders.insert_with_parent(
+            ColliderBuilder::ball(0.5)
+                .active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS)
+                .build(),
+            a_handle,
+            &mut bodies,
+        );
+
+        // Body B: stationary, CCD-enabled, at origin.
+        let body_b = RigidBodyBuilder::dynamic().ccd_enabled(true).build();
+        let b_handle = bodies.insert(body_b);
+        let _: ColliderHandle = colliders.insert_with_parent(
+            ColliderBuilder::ball(0.5)
+                .active_hooks(ActiveHooks::FILTER_CONTACT_PAIRS)
+                .build(),
+            b_handle,
+            &mut bodies,
+        );
+
+        for _ in 0..5 {
+            pipeline.step(
+                Vector::ZERO,
+                &integration_parameters,
+                &mut islands,
+                &mut broad_phase,
+                &mut narrow_phase,
+                &mut bodies,
+                &mut colliders,
+                &mut impulse_joints,
+                &mut multibody_joints,
+                &mut ccd,
+                &hooks,
+                &event_handler,
+            );
+        }
+
+        // Hook must be called at least once (from CCD, since they never
+        // reach narrow-phase contact in a single step at 200 m/s × 1/60s).
+        assert!(
+            hooks.calls.load(Ordering::Relaxed) > 0,
+            "filter_contact_pair was never called",
+        );
+
+        // Without the fix: CCD clamps A's motion at the predicted impact
+        // with B (hook ignored). A stalls near B.
+        // With the fix: A flies straight through at 200 m/s for 5 steps of
+        // dt=1/60s ≈ 16.67 units, so it ends near +11.67.
+        let a_pos = bodies[a_handle].translation().x;
+        assert!(
+            a_pos > 10.0,
+            "body A should have passed through filtered body B, but x={a_pos}",
+        );
     }
 
     #[test]

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -988,7 +988,9 @@ mod test {
         let mut impulse_joints = ImpulseJointSet::new();
         let mut multibody_joints = MultibodyJointSet::new();
         let mut islands = IslandManager::new();
-        let hooks = RejectAllHooks { calls: AtomicUsize::new(0) };
+        let hooks = RejectAllHooks {
+            calls: AtomicUsize::new(0),
+        };
         let event_handler = ();
 
         // Body A: fast-moving, CCD-enabled.


### PR DESCRIPTION
## What

Makes Continuous Collision Detection consult the user's `PhysicsHooks::filter_contact_pair` hook, matching narrow-phase semantics. Previously, CCD would clamp a fast-moving body's motion at a predicted impact with a pair the user had filtered out, leading to the bug described in #754.

## Why

Per the issue, *"filtering in rapier is done in narrow phase only, for contacts and intersections (bodies and areas). The problem is in case of CCD we don't do any of these filterings."* When a user enables CCD on an object and also installs a `filter_contact_pair` hook to suppress certain collisions, the hook is bypassed during CCD's time-of-impact sweeps — so the fast body still gets motion-clamped on a pair the user told the engine to ignore.

## How

- New private helper `pair_filtered_out_by_hooks` in `src/dynamics/ccd/ccd_solver.rs` that mirrors the filter call in `NarrowPhase::compute_contacts` (checks `ActiveHooks::FILTER_CONTACT_PAIRS` on either collider, builds a `PairFilterContext`, returns `true` on `None`).
- Called at all three pair-evaluation sites in the CCD solver:
  - `find_first_impact` (substep splitting)
  - `predict_impacts_at_next_positions` first-sweep loop (initial TOI collection)
  - `predict_impacts_at_next_positions` resweep loop (after freezing bodies)
- `hooks: &dyn PhysicsHooks` is threaded through the two public `CCDSolver` methods and through `PhysicsPipeline::run_ccd_motion_clamping`.

## Breaking change

`CCDSolver::find_first_impact` and `CCDSolver::predict_impacts_at_next_positions` now take an extra `hooks: &dyn PhysicsHooks` argument. `PhysicsPipeline::step` callers are **unaffected** — only code that drives the CCD solver directly (uncommon) needs to pass the hooks argument.

If you'd prefer a non-breaking additive approach (e.g., keep the current signatures and add `*_with_hooks` variants that take the extra param), I'm happy to restructure — I went with the breaking approach because rapier already makes breaking changes between minor versions and it keeps the surface clean.

## Test

Added `pipeline::physics_pipeline::test::ccd_respects_filter_contact_pair_hook` (3D) that:
1. Creates a 200 m/s CCD body and a stationary CCD body directly in its path
2. Installs a hook that rejects the pair
3. Steps 5 times
4. Asserts (a) the hook was called from CCD (since narrow phase never sees the pair at these speeds), and (b) the fast body flew through to `x > 10` rather than clamping near the stationary body (which happens without the fix at `x ≈ -0.77`).

Empirically verified on a downstream project that the same scenario fails before this patch and passes after.

## CHANGELOG

Added an `Unreleased` section with the fix and the breaking-change note.

## Notes for review

- **Sensor asymmetry**: the narrow phase invokes `filter_contact_pair` for sensor pairs too (and uses `solver_flags` to decide what to do downstream). CCD's sweep sites skip sensors *before* calling this helper, which is intentional — CCD only resolves contact TOIs, and sensor intersection events are reported elsewhere. Called out in the helper's doc comment.
- **Double-filter per step**: a filtered pair may get `filter_contact_pair` called up to 3× per step now (once per CCD sweep + narrow phase). Narrow phase already calls per-pair per-step; I don't expect the CCD sweeps to dominate in practice since CCD is only engaged for fast bodies.