### PR TITLE
fix aliasing UB, layout UB, and incorrect initialization UB

### DIFF
--- a/src/data/graph.rs
+++ b/src/data/graph.rs
@@ -146,12 +146,10 @@ fn index_twice<T>(arr: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
     } else if a == b {
         Pair::One(&mut arr[max(a, b)])
     } else {
-        // safe because a, b are in bounds and distinct
-        unsafe {
-            let ar = &mut *(arr.get_unchecked_mut(a) as *mut _);
-            let br = &mut *(arr.get_unchecked_mut(b) as *mut _);
-            Pair::Both(ar, br)
-        }
+        // can't panic because a, b are in bounds and distinct
+        let [ar,br] = arr.get_disjoint_mut([a,b]).unwrap();
+        Pair::Both(ar, br)
+        
     }
 }
 

--- a/src/data/graph.rs
+++ b/src/data/graph.rs
@@ -147,9 +147,8 @@ fn index_twice<T>(arr: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
         Pair::One(&mut arr[max(a, b)])
     } else {
         // can't panic because a, b are in bounds and distinct
-        let [ar,br] = arr.get_disjoint_mut([a,b]).unwrap();
+        let [ar, br] = arr.get_disjoint_mut([a, b]).unwrap();
         Pair::Both(ar, br)
-        
     }
 }
 

--- a/src/dynamics/joint/multibody_joint/multibody.rs
+++ b/src/dynamics/joint/multibody_joint/multibody.rs
@@ -30,6 +30,11 @@ impl Force {
     }
 
     fn as_vector(&self) -> &SVector<Real, SPATIAL_DIM> {
+        // SAFETY : this is safe because :
+        // - Force is repr(C)
+        // - Vector is repr(C)
+        // - AngVector is repr(C) or Real
+        // - total size in Reals is SPATIAL_DIM
         unsafe { core::mem::transmute(self) }
     }
 }

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -504,6 +504,7 @@ impl RigidBodyMassProps {
 
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Copy, PartialEq)]
+#[repr(C)]
 /// The velocities of this rigid-body.
 pub struct RigidBodyVelocity<T: ScalarType> {
     /// The linear velocity of the rigid-body.
@@ -593,6 +594,11 @@ impl RigidBodyVelocity<Real> {
     #[inline]
     #[cfg(feature = "dim2")]
     pub fn as_vector(&self) -> &na::Vector3<Real> {
+        // SAFETY : this is safe because :
+        // - RigidBodyVelocity is repr(C)
+        // - the vector types used are repr(C)
+        // - the only non vector type is Real
+        // - total size in Reals is 3
         unsafe { core::mem::transmute(self) }
     }
 
@@ -602,6 +608,11 @@ impl RigidBodyVelocity<Real> {
     #[inline]
     #[cfg(feature = "dim2")]
     pub fn as_vector_mut(&mut self) -> &mut na::Vector3<Real> {
+        // SAFETY : this is safe because :
+        // - RigidBodyVelocity is repr(C)
+        // - the vector types used are repr(C)
+        // - the only non vector type is Real
+        // - total size in Reals is 3
         unsafe { core::mem::transmute(self) }
     }
 
@@ -611,6 +622,11 @@ impl RigidBodyVelocity<Real> {
     #[inline]
     #[cfg(feature = "dim3")]
     pub fn as_vector(&self) -> &na::Vector6<Real> {
+        // SAFETY : this is safe because :
+        // - RigidBodyVelocity is repr(C)
+        // - the vector types used are repr(C)
+        // - the only non vector type is Real
+        // - total size in Reals is 6
         unsafe { core::mem::transmute(self) }
     }
 
@@ -620,6 +636,11 @@ impl RigidBodyVelocity<Real> {
     #[inline]
     #[cfg(feature = "dim3")]
     pub fn as_vector_mut(&mut self) -> &mut na::Vector6<Real> {
+        // SAFETY : this is safe because :
+        // - RigidBodyVelocity is repr(C)
+        // - the vector types used are repr(C)
+        // - the only non vector type is Real
+        // - total size in Reals is 6
         unsafe { core::mem::transmute(self) }
     }
 

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -34,7 +34,7 @@ mod velocity_solver;
 
 // TODO: SAFETY: restrict with bytemuck::Zeroable to make this safe.
 pub unsafe fn reset_buffer<T>(buffer: &mut Vec<T>, len: usize) {
-    buffer.clear();   
+    buffer.clear();
 
-    buffer.resize_with(len, || unsafe { core::mem::zeroed()})
+    buffer.resize_with(len, || unsafe { core::mem::zeroed() })
 }

--- a/src/dynamics/solver/mod.rs
+++ b/src/dynamics/solver/mod.rs
@@ -34,12 +34,7 @@ mod velocity_solver;
 
 // TODO: SAFETY: restrict with bytemuck::Zeroable to make this safe.
 pub unsafe fn reset_buffer<T>(buffer: &mut Vec<T>, len: usize) {
-    buffer.clear();
-    buffer.reserve(len);
+    buffer.clear();   
 
-    unsafe {
-        // NOTE: writing zeros is faster than u8::MAX.
-        buffer.as_mut_ptr().write_bytes(0, len);
-        buffer.set_len(len);
-    }
+    buffer.resize_with(len, || unsafe { core::mem::zeroed()})
 }

--- a/src/utils/index_mut2.rs
+++ b/src/utils/index_mut2.rs
@@ -25,7 +25,7 @@ pub trait IndexMut2<I>: IndexMut<I> {
 impl<T> IndexMut2<usize> for Vec<T> {
     #[inline]
     fn index_mut2(&mut self, i: usize, j: usize) -> (&mut T, &mut T) {
-        <[T]>::index_mut2(self, i,j)
+        <[T]>::index_mut2(self, i, j)
     }
 }
 
@@ -36,7 +36,7 @@ impl<T> IndexMut2<usize> for [T] {
         assert!(i < self.len() && j < self.len(), "Index out of bounds.");
 
         // cannot panic, per the above checks
-        let [a,b] = self.get_disjoint_mut([i,j]).unwrap();
-        (a,b)
+        let [a, b] = self.get_disjoint_mut([i, j]).unwrap();
+        (a, b)
     }
 }

--- a/src/utils/index_mut2.rs
+++ b/src/utils/index_mut2.rs
@@ -25,14 +25,7 @@ pub trait IndexMut2<I>: IndexMut<I> {
 impl<T> IndexMut2<usize> for Vec<T> {
     #[inline]
     fn index_mut2(&mut self, i: usize, j: usize) -> (&mut T, &mut T) {
-        assert!(i != j, "Unable to index the same element twice.");
-        assert!(i < self.len() && j < self.len(), "Index out of bounds.");
-
-        unsafe {
-            let a = &mut *(self.get_unchecked_mut(i) as *mut _);
-            let b = &mut *(self.get_unchecked_mut(j) as *mut _);
-            (a, b)
-        }
+        <[T]>::index_mut2(self, i,j)
     }
 }
 
@@ -42,10 +35,8 @@ impl<T> IndexMut2<usize> for [T] {
         assert!(i != j, "Unable to index the same element twice.");
         assert!(i < self.len() && j < self.len(), "Index out of bounds.");
 
-        unsafe {
-            let a = &mut *(self.get_unchecked_mut(i) as *mut _);
-            let b = &mut *(self.get_unchecked_mut(j) as *mut _);
-            (a, b)
-        }
+        // cannot panic, per the above checks
+        let [a,b] = self.get_disjoint_mut([i,j]).unwrap();
+        (a,b)
     }
 }


### PR DESCRIPTION
the `get_disjoint_mut`-likes are aliasing UB under the current memory model.
for more info, see the internal code of `get_disjoint_mut` and the relevant history.

`as_vector` on `RigidBodyVelocity` is UB because it is not `#[repr(C)]`

`reset_buffer` can cause incorrect initialization UB because it initializes `len` bytes, but it says it has initialized `len * size_of:::<T>` bytes.

the `get_disjoint_mut`-likes have been checked to result in the same assembly after fix : 
- https://godbolt.org/z/5TTfrs4zP
- https://godbolt.org/z/Tdbh75PT9


the asm for `reset_buffer` is slightly different, but it still uses `memset` which is the important part.