### PR TITLE
fix wheel impulse scaling

### DIFF
--- a/src/control/ray_cast_vehicle_controller.rs
+++ b/src/control/ray_cast_vehicle_controller.rs
@@ -659,7 +659,7 @@ impl DynamicRayCastVehicleController {
 
         if sliding {
             for wheel in &mut self.wheels {
-                if wheel.side_impulse != 0.0 && wheel.skid_info < 1.0 {
+                if wheel.skid_info < 1.0 {
                     wheel.forward_impulse *= wheel.skid_info;
                     wheel.side_impulse *= wheel.skid_info;
                 }


### PR DESCRIPTION
https://github.com/dimforge/rapier/issues/946

explanation by Claude:

The Bug: A misplaced gate in updateFriction

In `update_friction()`, after determining that `sliding == true` (the combined forward+side impulse exceeds the friction circle), there's a correction loop that scales both impulses down by `skid_info`. ...

```
// before
if wheel.side_impulse != 0.0 && wheel.skid_info < 1.0 {

// after
if wheel.skid_info < 1.0 {
```
The `wheel.side_impulse != 0.0` guard is the whole problem. It was presumably written as a micro-optimisation ("skip wheels with no lateral load"), but it incorrectly prevents `forward_impulse` from being scaled down when braking straight — since `side_impulse` is exactly `0.0` in that case, the entire body of the if is skipped, and the braking impulse is applied without any friction-circle capping.
The `skid_info < 1.0 `check alone is the correct and sufficient guard — it's only `< 1.0` when the friction circle is actually exceeded, so there's no wasted work. Multiplying `side_impulse` (which is already 0.0) by `skid_info` is a no-op, so removing the outer guard has zero downside.

This bug exists in the original Bullet source (lines 675–682 of `btRaycastVehicle.cpp`) and was presumably never caught because most demos and tutorials involve some steering before heavy braking — the exact scenario that masks it.