### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.34.0 (04 July 2026)
 
 ### Added
 
@@ -21,6 +21,15 @@
 - Added a missing coupling term for loop-closing impulse-joint constraints (bodies with a non-zero
   center-of-mass offset).
 - Fixed a crash occurring with the `parallel` feature enabled.
+
+### Modified
+
+- **Breaking (`rapier_testbed` only):** the testbed was reworked to remove the callback-based API.
+  `Harness::add_callback` / `clear_callbacks` and the `HarnessPlugin` trait were removed, and several
+  testbed/harness types (`RunState`, `PhysicsState`, `RapierBroadPhaseType`,
+  `TestbedApp::from_builders` / `set_builders`, etc.) were changed. Simulation setup now drives the
+  physics world directly instead of registering per-step callbacks. The core `rapier2d`/`rapier3d`
+  physics API is unaffected.
 
 ## v0.33.0 (05 June 2026)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 homepage = "https://rapier.rs"
 repository = "https://github.com/dimforge/rapier"
@@ -88,10 +88,52 @@ web-time = "1.1"
 rayon = "1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 
+# Testbed / rendering / tooling
+rand = "0.10"
+rand_pcg = "0.10"
+num_cpus = "1"
+Inflector = "0.11"
+md5 = "0.8"
+egui = "0.34"
+puffin_egui = "0.29"
+indexmap = { version = "2", features = ["serde"] }
+kiss3d = { version = "0.45.0", features = ["egui", "serde"] }
+env_logger = "0.11"
+anyhow = "1"
+
+# Loaders / assets
+urdf-rs = "0.9"
+mesh-loader = "0.1.13"
+roxmltree = "0.20"
+
+# Example-only
+lyon = "0.17"
+dot_vox = "5"
+usvg = "0.14"
+obj-rs = { version = "0.7", default-features = false }
+glam = { version = "0.33", features = ["fast-math"] }
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "0.2"
+
+# Internal crates (paths are relative to the workspace root)
+rapier2d = { version = "0.34.0", path = "crates/rapier2d" }
+rapier2d-f64 = { version = "0.34.0", path = "crates/rapier2d-f64" }
+rapier3d = { version = "0.34.0", path = "crates/rapier3d" }
+rapier3d-f64 = { version = "0.34.0", path = "crates/rapier3d-f64" }
+rapier_testbed2d = { version = "0.34.0", path = "crates/rapier_testbed2d" }
+rapier_testbed2d-f64 = { version = "0.34.0", path = "crates/rapier_testbed2d-f64" }
+rapier_testbed3d = { version = "0.34.0", path = "crates/rapier_testbed3d" }
+rapier_testbed3d-f64 = { version = "0.34.0", path = "crates/rapier_testbed3d-f64" }
+rapier3d-urdf = { version = "0.34.0", path = "crates/rapier3d-urdf" }
+rapier3d-meshloader = { version = "0.34.0", path = "crates/rapier3d-meshloader", default-features = false }
+mjcf-rs = { version = "0.34.0", path = "crates/mjcf-rs" }
+rapier3d-mjcf = { version = "0.34.0", path = "crates/rapier3d-mjcf" }
+
 # Dev
 bincode = "1"
 serde_json = "1"
 oorandom = { version = "11", default-features = false }
+tempfile = "3"
 
 [patch.crates-io]
 #xurdf = { path = "../xurdf/xurdf" }

--- a/crates/mjcf-rs/Cargo.toml
+++ b/crates/mjcf-rs/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "mjcf-rs"
-version = "0.1.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+version.workspace = true
+authors.workspace = true
 description = "Pure-Rust parser for the MuJoCo MJCF XML format."
 documentation = "https://docs.rs/mjcf-rs"
-homepage = "https://rapier.rs"
-repository = "https://github.com/dimforge/rapier"
+homepage.workspace = true
+repository.workspace = true
 readme = "README.md"
 categories = [
     "parser-implementations",
@@ -13,8 +13,9 @@ categories = [
     "simulation",
 ]
 keywords = ["mjcf", "mujoco", "robotics", "parser", "xml"]
-license = "Apache-2.0"
-edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [features]
 default = []
@@ -22,11 +23,11 @@ default = []
 msh = ["dep:byteorder"]
 
 [dependencies]
-roxmltree = "0.20"
-thiserror = "2"
-log = "0.4"
+roxmltree.workspace = true
+thiserror = { workspace = true, features = ["std"] }
+log.workspace = true
 byteorder = { version = "1", optional = true }
 glamx = { workspace = true, features = ["std", "f64"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -101,5 +101,5 @@ glamx = { workspace = true, features = ["nalgebra"] }
 [dev-dependencies]
 bincode.workspace = true
 serde_json.workspace = true
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true, features = ["std"] }
 oorandom.workspace = true

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -102,5 +102,5 @@ glamx = { workspace = true, features = ["nalgebra"] }
 [dev-dependencies]
 bincode.workspace = true
 serde_json.workspace = true
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true, features = ["std"] }
 oorandom.workspace = true

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -105,5 +105,5 @@ glamx = { workspace = true, features = ["nalgebra"] }
 [dev-dependencies]
 bincode.workspace = true
 serde_json.workspace = true
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true, features = ["std"] }
 oorandom.workspace = true

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -1,21 +1,16 @@
 [package]
 name = "rapier3d-meshloader"
 version.workspace = true
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+authors.workspace = true
 description = "STL file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-meshloader"
 homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+categories.workspace = true
 keywords = ["physics", "joints", "multibody", "robotics", "urdf"]
 license.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 
 [features]
@@ -25,8 +20,8 @@ collada = ["mesh-loader/collada"]
 wavefront = ["mesh-loader/obj"]
 
 [dependencies]
-thiserror = "2"
-profiling = "1.0"
-mesh-loader = "0.1.13"
+thiserror = { workspace = true, features = ["std"] }
+profiling.workspace = true
+mesh-loader.workspace = true
 
-rapier3d = { version = "0.33.0", path = "../rapier3d" }
+rapier3d.workspace = true

--- a/crates/rapier3d-mjcf/Cargo.toml
+++ b/crates/rapier3d-mjcf/Cargo.toml
@@ -1,21 +1,16 @@
 [package]
 name = "rapier3d-mjcf"
 version.workspace = true
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+authors.workspace = true
 description = "MuJoCo MJCF loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-mjcf"
 homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+categories.workspace = true
 keywords = ["physics", "joints", "multibody", "robotics", "mjcf"]
 license.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 
 [features]
@@ -29,13 +24,13 @@ msh = ["mjcf-rs/msh"]
 __meshloader_is_enabled = []
 
 [dependencies]
-log = "0.4"
-anyhow = "1"
-bitflags = "2"
+log.workspace = true
+anyhow.workspace = true
+bitflags.workspace = true
 
-mjcf-rs = { version = "0.1.0", path = "../mjcf-rs" }
-rapier3d = { version = "0.33.0", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.33.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+mjcf-rs.workspace = true
+rapier3d.workspace = true
+rapier3d-meshloader = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -1,21 +1,16 @@
 [package]
 name = "rapier3d-urdf"
 version.workspace = true
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+authors.workspace = true
 description = "URDF file loader for the 3D rapier physics engine."
 documentation = "https://docs.rs/rapier3d-urdf"
 homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+categories.workspace = true
 keywords = ["physics", "joints", "multibody", "robotics", "urdf"]
 license.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 
 [features]
@@ -26,10 +21,10 @@ wavefront = ["dep:rapier3d-meshloader", "rapier3d-meshloader/wavefront", "__mesh
 __meshloader_is_enabled = []
 
 [dependencies]
-log = "0.4"
-anyhow = "1"
-bitflags = "2"
-urdf-rs = "0.9"
+log.workspace = true
+anyhow.workspace = true
+bitflags.workspace = true
+urdf-rs.workspace = true
 
-rapier3d = { version = "0.33.0", path = "../rapier3d" }
-rapier3d-meshloader = { version = "0.33.0", path = "../rapier3d-meshloader", default-features = false, optional = true }
+rapier3d.workspace = true
+rapier3d-meshloader = { workspace = true, optional = true }

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -105,5 +105,5 @@ glamx = { workspace = true, features = ["nalgebra"] }
 [dev-dependencies]
 bincode.workspace = true
 serde_json.workspace = true
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true, features = ["std"] }
 oorandom.workspace = true

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -1,20 +1,15 @@
 [package]
 name = "rapier_testbed2d-f64"
-version = "0.33.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+version.workspace = true
+authors.workspace = true
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
-homepage = "http://rapier.rs"
-repository = "https://github.com/dimforge/rapier"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
 keywords = ["physics", "dynamics", "rigid", "real-time", "impulse_joints"]
-license = "Apache-2.0"
-edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -42,28 +37,28 @@ unstable-puffin-pr-235 = []
 features = ["parallel", "profiler_ui"]
 
 [dependencies]
-nalgebra = { version = "0.35", features = ["rand"] }
-glamx = "0.3"
-rand = "0.10"
-rand_pcg = "0.10"
-web-time = { version = "1.1" }
-bitflags = "2"
-num_cpus = { version = "1", optional = true }
-bincode = "1"
-Inflector = "0.11"
-md5 = "0.8"
-egui = "0.34"
-profiling = "1.0"
-puffin_egui = { version = "0.29", optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-indexmap = { version = "2", features = ["serde"] }
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
-log = "0.4"
-env_logger = "0.11"
+nalgebra = { workspace = true, features = ["rand", "std"] }
+glamx = { workspace = true, features = ["std", "all-types"] }
+rand.workspace = true
+rand_pcg.workspace = true
+web-time.workspace = true
+bitflags.workspace = true
+num_cpus = { workspace = true, optional = true }
+bincode.workspace = true
+Inflector.workspace = true
+md5.workspace = true
+egui.workspace = true
+profiling.workspace = true
+puffin_egui = { workspace = true, optional = true }
+serde = { workspace = true, features = ["std"] }
+serde_json.workspace = true
+indexmap.workspace = true
+kiss3d.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.33.0"
+version = "0.34.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -1,20 +1,15 @@
 [package]
 name = "rapier_testbed2d"
-version = "0.33.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+version.workspace = true
+authors.workspace = true
 description = "Testbed for the Rapier 2-dimensional physics engine in Rust."
-homepage = "http://rapier.rs"
-repository = "https://github.com/dimforge/rapier"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
 keywords = ["physics", "dynamics", "rigid", "real-time", "impulse_joints"]
-license = "Apache-2.0"
-edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -42,28 +37,28 @@ unstable-puffin-pr-235 = []
 features = ["parallel", "profiler_ui"]
 
 [dependencies]
-nalgebra = { version = "0.35", features = ["rand"] }
-glamx = "0.3"
-rand = "0.10"
-rand_pcg = "0.10"
-web-time = { version = "1.1" }
-bitflags = "2"
-num_cpus = { version = "1", optional = true }
-bincode = "1"
-Inflector = "0.11"
-md5 = "0.8"
-egui = "0.34"
-profiling = "1.0"
-puffin_egui = { version = "0.29", optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-indexmap = { version = "2", features = ["serde"] }
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
-log = "0.4"
-env_logger = "0.11"
+nalgebra = { workspace = true, features = ["rand", "std"] }
+glamx = { workspace = true, features = ["std", "all-types"] }
+rand.workspace = true
+rand_pcg.workspace = true
+web-time.workspace = true
+bitflags.workspace = true
+num_cpus = { workspace = true, optional = true }
+bincode.workspace = true
+Inflector.workspace = true
+md5.workspace = true
+egui.workspace = true
+profiling.workspace = true
+puffin_egui = { workspace = true, optional = true }
+serde = { workspace = true, features = ["std"] }
+serde_json.workspace = true
+indexmap.workspace = true
+kiss3d.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.33.0"
+version = "0.34.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -1,20 +1,15 @@
 [package]
 name = "rapier_testbed3d-f64"
-version = "0.33.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+version.workspace = true
+authors.workspace = true
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
-homepage = "http://rapier.rs"
-repository = "https://github.com/dimforge/rapier"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
 keywords = ["physics", "dynamics", "rigid", "real-time", "impulse_joints"]
-license = "Apache-2.0"
-edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -42,28 +37,28 @@ unstable-puffin-pr-235 = []
 features = ["parallel", "profiler_ui"]
 
 [dependencies]
-nalgebra = { version = "0.35", features = ["rand"] }
-glamx = "0.3"
-rand = "0.10"
-rand_pcg = "0.10"
-web-time = { version = "1.1" }
-bitflags = "2"
-num_cpus = { version = "1", optional = true }
-bincode = "1"
-md5 = "0.8"
-Inflector = "0.11"
-egui = "0.34"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-profiling = "1.0"
-puffin_egui = { version = "0.29", optional = true }
-indexmap = { version = "2", features = ["serde"] }
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
-log = "0.4"
-env_logger = "0.11"
+nalgebra = { workspace = true, features = ["rand", "std"] }
+glamx = { workspace = true, features = ["std", "all-types"] }
+rand.workspace = true
+rand_pcg.workspace = true
+web-time.workspace = true
+bitflags.workspace = true
+num_cpus = { workspace = true, optional = true }
+bincode.workspace = true
+md5.workspace = true
+Inflector.workspace = true
+egui.workspace = true
+serde = { workspace = true, features = ["std"] }
+serde_json.workspace = true
+profiling.workspace = true
+puffin_egui = { workspace = true, optional = true }
+indexmap.workspace = true
+kiss3d.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.33.0"
+version = "0.34.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -1,20 +1,15 @@
 [package]
 name = "rapier_testbed3d"
-version = "0.33.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
+version.workspace = true
+authors.workspace = true
 description = "Testbed for the Rapier 3-dimensional physics engine in Rust."
-homepage = "http://rapier.rs"
-repository = "https://github.com/dimforge/rapier"
-categories = [
-    "science",
-    "game-development",
-    "mathematics",
-    "simulation",
-    "wasm",
-]
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
 keywords = ["physics", "dynamics", "rigid", "real-time", "impulse_joints"]
-license = "Apache-2.0"
-edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+edition.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -42,28 +37,28 @@ unstable-puffin-pr-235 = []
 features = ["parallel", "profiler_ui"]
 
 [dependencies]
-nalgebra = { version = "0.35", features = ["rand"] }
-glamx = "0.3"
-rand = "0.10"
-rand_pcg = "0.10"
-web-time = { version = "1.1" }
-bitflags = "2"
-num_cpus = { version = "1", optional = true }
-bincode = "1"
-md5 = "0.8"
-Inflector = "0.11"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-egui = "0.34"
-profiling = "1.0"
-puffin_egui = { version = "0.29", optional = true }
-indexmap = { version = "2", features = ["serde"] }
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
-log = "0.4"
-env_logger = "0.11"
+nalgebra = { workspace = true, features = ["rand", "std"] }
+glamx = { workspace = true, features = ["std", "all-types"] }
+rand.workspace = true
+rand_pcg.workspace = true
+web-time.workspace = true
+bitflags.workspace = true
+num_cpus = { workspace = true, optional = true }
+bincode.workspace = true
+md5.workspace = true
+Inflector.workspace = true
+serde = { workspace = true, features = ["std"] }
+serde_json.workspace = true
+egui.workspace = true
+profiling.workspace = true
+puffin_egui = { workspace = true, optional = true }
+indexmap.workspace = true
+kiss3d.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.33.0"
+version = "0.34.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rapier-examples-2d"
-version = "0.1.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
-edition = "2024"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 default-run = "all_examples2"
 publish = false
 
@@ -13,21 +13,21 @@ simd-nightly = ["rapier2d/simd-nightly"]
 enhanced-determinism = ["rapier2d/enhanced-determinism"]
 
 [dependencies]
-anyhow = "1"
-rand = "0.10"
-lyon = "0.17"
-dot_vox = "5"
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
+anyhow.workspace = true
+rand.workspace = true
+lyon.workspace = true
+dot_vox.workspace = true
+kiss3d.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-usvg = "0.14"
+usvg.workspace = true
 
 [dependencies.rapier_testbed2d]
-path = "../crates/rapier_testbed2d"
+workspace = true
 #features = ["profiler_ui"]
 
 [dependencies.rapier2d]
-path = "../crates/rapier2d"
+workspace = true
 
 [[bin]]
 name = "all_examples2"

--- a/examples3d-f64/Cargo.toml
+++ b/examples3d-f64/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rapier-examples-3d-f64"
-version = "0.1.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
-edition = "2024"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 default-run = "all_examples3-f64"
 publish = false
 
@@ -13,20 +13,20 @@ parallel = ["rapier3d-f64/parallel", "rapier_testbed3d-f64/parallel"]
 enhanced-determinism = ["rapier3d-f64/enhanced-determinism"]
 
 [dependencies]
-anyhow = "1"
-rand = "0.10"
-getrandom = { version = "0.2", features = ["js"] }
-wasm-bindgen = "0.2"
-obj-rs = { version = "0.7", default-features = false }
-bincode = "1"
-serde = "1"
-kiss3d = { version = "0.44.0", features = ["egui", "serde"] }
+anyhow.workspace = true
+rand.workspace = true
+getrandom.workspace = true
+wasm-bindgen.workspace = true
+obj-rs.workspace = true
+bincode.workspace = true
+serde = { workspace = true, features = ["std"] }
+kiss3d.workspace = true
 
 [dependencies.rapier_testbed3d-f64]
-path = "../crates/rapier_testbed3d-f64"
+workspace = true
 
 [dependencies.rapier3d-f64]
-path = "../crates/rapier3d-f64"
+workspace = true
 
 [[bin]]
 name = "all_examples3-f64"
@@ -35,4 +35,3 @@ path = "./all_examples3-f64.rs"
 #[lib]
 #crate-type = ["cdylib", "rlib"]
 #path = "./all_examples3_wasm.rs"
-

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rapier-examples-3d"
-version = "0.1.0"
-authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
-edition = "2024"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 default-run = "all_examples3"
 publish = false
 
@@ -13,31 +13,31 @@ simd-nightly = ["rapier3d/simd-nightly"]
 enhanced-determinism = ["rapier3d/enhanced-determinism"]
 
 [dependencies]
-anyhow = "1"
-rand = "0.10"
-getrandom = { version = "0.2", features = ["js"] }
-wasm-bindgen = "0.2"
-obj-rs = { version = "0.7", default-features = false }
-serde = "1"
-bincode = "1"
-serde_json = "1"
-dot_vox = "5"
-glam = { version = "0.33", features = ["fast-math"] }
-kiss3d = { version = "0.44.0", features = ["egui", "serde", "rt_switcher"] }
+anyhow.workspace = true
+rand.workspace = true
+getrandom.workspace = true
+wasm-bindgen.workspace = true
+obj-rs.workspace = true
+serde = { workspace = true, features = ["std"] }
+bincode.workspace = true
+serde_json.workspace = true
+dot_vox.workspace = true
+glam.workspace = true
+kiss3d = { workspace = true, features = ["rt_switcher"] }
 
 [dependencies.rapier_testbed3d]
-path = "../crates/rapier_testbed3d"
+workspace = true
 #features = ["profiler_ui"]
 
 [dependencies.rapier3d]
-path = "../crates/rapier3d"
+workspace = true
 
 [dependencies.rapier3d-urdf]
-path = "../crates/rapier3d-urdf"
+workspace = true
 features = ["stl"]
 
 [dependencies.rapier3d-mjcf]
-path = "../crates/rapier3d-mjcf"
+workspace = true
 features = ["stl", "wavefront"]
 
 [[bin]]

--- a/python/rapier-py-3d/Cargo.toml
+++ b/python/rapier-py-3d/Cargo.toml
@@ -36,15 +36,15 @@ pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39", "multipl
 numpy = "0.22"
 nalgebra.workspace = true
 thiserror.workspace = true
-rapier3d = { path = "../../crates/rapier3d", features = ["serde-serialize", "debug-render", "simd-stable"] }
+rapier3d = { workspace = true, features = ["serde-serialize", "debug-render", "simd-stable"] }
 # Phase 09 — Loaders. URDF + MJCF + mesh. Mesh-loader features are
 # explicitly enabled so .stl / .obj / .dae meshes referenced from URDF /
 # MJCF files work out of the box.
-rapier3d-urdf = { path = "../../crates/rapier3d-urdf", features = ["stl", "collada", "wavefront"] }
-rapier3d-mjcf = { path = "../../crates/rapier3d-mjcf", features = ["stl", "wavefront", "msh"] }
-rapier3d-meshloader = { path = "../../crates/rapier3d-meshloader", features = ["stl", "collada", "wavefront"] }
-mesh-loader = "0.1.12"
-urdf-rs = "0.9"
+rapier3d-urdf = { workspace = true, features = ["stl", "collada", "wavefront"] }
+rapier3d-mjcf = { workspace = true, features = ["stl", "wavefront", "msh"] }
+rapier3d-meshloader = { workspace = true, features = ["stl", "collada", "wavefront"] }
+mesh-loader.workspace = true
+urdf-rs.workspace = true
 # Phase 11 — Serialization, snapshots.
 serde = { workspace = true, features = ["derive", "std"] }
 bincode = { workspace = true }

--- a/python/rapier-testbed/pyproject.toml
+++ b/python/rapier-testbed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapier-testbed"
-version = "0.33.0"
+version = "0.34.0"
 description = "Panda3D-based visual testbed and example gallery for the Rapier Python bindings."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## v0.34.0 (04 July 2026)

### Added

- Multibody joints now support a per-DoF **armature** (reflected rotor inertia, matching MuJoCo's
  concept), exposed via `Multibody::armature()` / `armature_mut()`. The related
  `Multibody::dof_inverse_inertia()` returns the articulated DoF inverse inertia including armature.
- Multibody joints now support passive **per-DoF springs** (MuJoCo-style spring/damper) via
  `MultibodyJoint::set_spring()` / `spring()`, integrated implicitly.
- Multibody joints now support **holonomic DoF coupling**: constrain one generalized coordinate to
  another via `MultibodyDofCoupling` and `Multibody::add_dof_coupling()` / `couplings()`.
- `MultibodyLink::assembly_id()` exposes the offset of a link's DoFs in the multibody's generalized
  coordinate/velocity vectors.
- `rapier3d-mjcf`: support for tendons, equality constraints, materials (including visual-mesh
  materials), actuator max-force, joint DoF coupling, armature, per-DoF spring/damper, and control.
- Testbed: the ability to specify a material.

### Fixed

- Corrected the local frame of impulse joints attached to multibodies.
- Added a missing coupling term for loop-closing impulse-joint constraints (bodies with a non-zero
  center-of-mass offset).
- Fixed a crash occurring with the `parallel` feature enabled.

### Modified

- **Breaking (`rapier_testbed` only):** the testbed was reworked to remove the callback-based API.
  `Harness::add_callback` / `clear_callbacks` and the `HarnessPlugin` trait were removed, and several
  testbed/harness types (`RunState`, `PhysicsState`, `RapierBroadPhaseType`,
  `TestbedApp::from_builders` / `set_builders`, etc.) were changed. Simulation setup now drives the
  physics world directly instead of registering per-step callbacks. The core `rapier2d`/`rapier3d`
  physics API is unaffected.