### PR TITLE
Fix manually sleeping persistent-island bodies

### DIFF
--- a/src/dynamics/island_manager/manager.rs
+++ b/src/dynamics/island_manager/manager.rs
@@ -174,6 +174,8 @@ impl IslandManager {
             return;
         }
 
+        let manually_slept = rb.changes.contains(RigidBodyChanges::SLEEP) && rb.is_sleeping();
+
         // Check if this is the first time we see this rigid-body.
         if rb.ids.active_island_id == usize::MAX {
             // Check if there is room in the last awake island to add this body.
@@ -205,6 +207,22 @@ impl IslandManager {
                 rb.ids.active_island_id = id;
                 rb.ids.active_set_id = 0;
             }
+        }
+
+        if manually_slept {
+            let active_island_id = bodies[handle].ids.active_island_id;
+            if self.islands[active_island_id].bodies.len() == 1 {
+                if let Some(awake_id) = self.islands[active_island_id].id_in_awake_list.take() {
+                    self.awake_islands.swap_remove(awake_id);
+                    if let Some(moved_id) = self.awake_islands.get(awake_id) {
+                        self.islands[*moved_id].id_in_awake_list = Some(awake_id);
+                    }
+                }
+            } else {
+                let sleeping_island = Island::singleton(handle, &bodies[handle]);
+                self.extract_sub_island(bodies, active_island_id, sleeping_island, true);
+            }
+            return;
         }
 
         // Push the body to the active set if it is not inside the active set yet, and

--- a/src/dynamics/island_manager/sleep.rs
+++ b/src/dynamics/island_manager/sleep.rs
@@ -94,6 +94,14 @@ impl IslandManager {
                 continue;
             }
 
+            if rb.ids.active_island_id != active_island_id {
+                // A body manually put to sleep may still have contacts with its
+                // former awake island until the next narrow-phase update. Treat
+                // that sleeping island as a traversal boundary.
+                assert!(rb.activation.sleeping);
+                continue;
+            }
+
             if rb.ids.active_set_timestamp == self.traversal_timestamp {
                 // We already visited this body and its neighbors.
                 continue;

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -788,6 +788,9 @@ impl RigidBody {
     /// - Connected via joint to a moving body
     /// - Manually woken with `wake_up()`
     pub fn sleep(&mut self) {
+        if !self.activation.sleeping {
+            self.changes.insert(RigidBodyChanges::SLEEP);
+        }
         self.activation.sleep();
         self.vels = RigidBodyVelocity::zero();
     }


### PR DESCRIPTION
## Summary
- mark explicit sleep transitions as body changes
- move manually slept bodies into sleeping islands
- treat their stale contacts as sleep-traversal boundaries until narrow phase updates

## Reproduction
Calling RigidBody::sleep on an active body in a large persistent island panicked in island sleep traversal.

## Validation
- cargo test -p rapier3d --lib
- reproduced and fixed in a 2,001-body Rapier.js world