### PR TITLE
Move `rapier-compat` build artifacts into `pkg/dist`

### DIFF
--- a/.github/workflows/typescript-bindings.yml
+++ b/.github/workflows/typescript-bindings.yml
@@ -148,12 +148,12 @@ jobs:
             # Check simd for compat builds
             - name: Check 2d simd compat build
               run: |
-                  if ! wasm-objdump -d rapier-compat/builds/2d-simd/pkg/rapier_wasm2d_bg.wasm | grep :\\sfd ; then
+                  if ! wasm-objdump -d rapier-compat/builds/2d-simd/pkg/dist/rapier_wasm2d_bg.wasm | grep :\\sfd ; then
                     >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1;
                   fi
             - name: Check 3d simd compat build
               run: |
-                  if ! wasm-objdump -d rapier-compat/builds/3d-simd/pkg/rapier_wasm3d_bg.wasm | grep :\\sfd ; then
+                  if ! wasm-objdump -d rapier-compat/builds/3d-simd/pkg/dist/rapier_wasm3d_bg.wasm | grep :\\sfd ; then
                     >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1;
                   fi
             # Upload

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Breaking changes
 
+- The files of the `-compat` packages moved from the package root into `dist/`
+  (`dist/rapier.mjs`, `dist/rapier.cjs`, `dist/rapier.d.ts`). Imports resolved through
+  the package entry (bundlers, `+esm` CDN URLs) are unaffected; pinned CDN URLs or deep
+  imports referencing the old root-level files must add the `dist/` segment.
+
 - Removed `IntegrationParameters.minIslandSize`: awake bodies are now solved as a single
   active set, so there is no island size to tune.
 - `NarrowPhase.contactPair` takes the `RigidBodySet` as its third argument. Solver

--- a/typescript/rapier-compat/build-rust.sh
+++ b/typescript/rapier-compat/build-rust.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 
 help()
@@ -17,14 +17,14 @@ do
     esac
 done
 
-if [[ -z "$dimension" ]]; then
+if [ -z "$dimension" ]; then
     help; exit 2;
 fi
-if [[ -z "$feature" ]]; then
+if [ -z "$feature" ]; then
     help; exit 3;
 fi
 
-if [[ $feature == "non-deterministic" ]]; then
+if [ "$feature" = "non-deterministic" ]; then
     feature_postfix=""
 else
     feature_postfix="-${feature}"
@@ -41,7 +41,7 @@ fi
 
 # Working dir in wasm-pack is the project root so we need that "../../"
 
-if [[ $feature == "simd" ]]; then
+if [ "$feature" = "simd" ]; then
     export additional_rustflags='-C target-feature=+simd128'
 else
     export additional_rustflags=''

--- a/typescript/rapier-compat/fix_raw_file.sh
+++ b/typescript/rapier-compat/fix_raw_file.sh
@@ -9,6 +9,6 @@ do
 # whatever the feature variant (-deterministic/-simd) of the build.
 dimension="${feature%%-*}"
 
-echo 'export * from "'"./rapier_wasm$dimension"'"' > builds/${feature}/pkg/raw.d.ts
+echo "export * from \"./rapier_wasm${dimension}\";" > "builds/${feature}/pkg/dist/raw.d.ts"
 
 done;

--- a/typescript/rapier-compat/gen_src.sh
+++ b/typescript/rapier-compat/gen_src.sh
@@ -40,19 +40,22 @@ do
     feature="${1}d-${2}";
   fi
 
-  mkdir -p ./builds/${feature}/pkg/
+  pkg_dir="./builds/${feature}/pkg"
+  dist_dir="${pkg_dir}/dist"
 
-  cp ./builds/${feature}/wasm-build/rapier_wasm* ./builds/${feature}/pkg/
-  cp -r ./gen${dimension}d ./builds/${feature}/
+  mkdir -p "${dist_dir}"
+
+  cp ./builds/${feature}/wasm-build/rapier_wasm* "${dist_dir}/"
+  cp -r "./gen${dimension}d" "./builds/${feature}/"
 
   # copy tsconfig, as they contain paths
-  cp ./tsconfig.common.json ./tsconfig.json ./builds/${feature}/
-  cp ./tsconfig.pkg${dimension}d.json ./builds/${feature}/tsconfig.pkg.json
+  cp ./tsconfig.common.json ./tsconfig.json "./builds/${feature}/"
+  cp "./tsconfig.pkg${dimension}d.json" "./builds/${feature}/tsconfig.pkg.json"
 
   # "import.meta" causes Babel to choke, but the code path is never taken so just remove it.
-  sed -i.bak 's/import.meta.url/"<deleted>"/g' ./builds/${feature}/pkg/rapier_wasm${dimension}d.js
+  sed -i.bak 's/import.meta.url/"<deleted>"/g' "${dist_dir}/rapier_wasm${dimension}d.js"
 
   # Clean up backup files.
-  find ./builds/${feature}/pkg/ -type f -name '*.bak' | xargs rm
+  find "${dist_dir}" -type f -name '*.bak' -delete
 
 done

--- a/typescript/rapier-compat/rollup.config.js
+++ b/typescript/rapier-compat/rollup.config.js
@@ -7,73 +7,76 @@ import {base64} from "rollup-plugin-base64";
 import copy from "rollup-plugin-copy";
 import filesize from "rollup-plugin-filesize";
 
-const config = (dim, features_postfix) => ({
-    input: `builds/${features_postfix}/gen${dim}/rapier.ts`,
-    output: [
-        {
-            file: `builds/${features_postfix}/pkg/rapier.mjs`,
-            format: "es",
-            sourcemap: true,
-            exports: "named",
-        },
-        {
-            file: `builds/${features_postfix}/pkg/rapier.cjs`,
-            format: "cjs",
-            sourcemap: true,
-            exports: "named",
-        },
-    ],
-    plugins: [
-        copy({
-            targets: [
-                {
-                    src: `builds/${features_postfix}/wasm-build/package.json`,
-                    dest: `builds/${features_postfix}/pkg/`,
-                    transform(content) {
-                        let config = JSON.parse(content.toString());
-                        config.name = `@dimforge/rapier${features_postfix}-compat`;
-                        config.description +=
-                            " Compatibility package with inlined webassembly as base64.";
-                        config.types = "rapier.d.ts";
-                        config.main = "rapier.cjs";
-                        config.module = "rapier.mjs";
-                        config.exports = {
-                            ".": {
-                                types: "./rapier.d.ts",
-                                require: "./rapier.cjs",
-                                import: "./rapier.mjs",
-                            },
-                        };
-                        // delete config.module;
-                        config.files = ["*"];
-                        return JSON.stringify(config, undefined, 2);
+const config = (dim, features_postfix) => {
+    const pkgDir = `builds/${features_postfix}/pkg`;
+    const distDir = `${pkgDir}/dist`;
+    return {
+        input: `builds/${features_postfix}/gen${dim}/rapier.ts`,
+        output: [
+            {
+                file: `${distDir}/rapier.mjs`,
+                format: "es",
+                sourcemap: true,
+                exports: "named",
+            },
+            {
+                file: `${distDir}/rapier.cjs`,
+                format: "cjs",
+                sourcemap: true,
+                exports: "named",
+            },
+        ],
+        plugins: [
+            copy({
+                targets: [
+                    {
+                        src: `builds/${features_postfix}/wasm-build/package.json`,
+                        dest: pkgDir,
+                        transform(content) {
+                            let config = JSON.parse(content.toString());
+                            config.name = `@dimforge/rapier${features_postfix}-compat`;
+                            config.description +=
+                                " Compatibility package with inlined webassembly as base64.";
+                            config.types = "dist/rapier.d.ts";
+                            config.main = "dist/rapier.cjs";
+                            config.module = "dist/rapier.mjs";
+                            config.exports = {
+                                ".": {
+                                    types: "./dist/rapier.d.ts",
+                                    require: "./dist/rapier.cjs",
+                                    import: "./dist/rapier.mjs",
+                                },
+                            };
+                            // delete config.module;
+                            config.files = ["dist"];
+                            return JSON.stringify(config, undefined, 2);
+                        },
                     },
-                },
-                {
-                    src: `../rapier${features_postfix}/LICENSE`,
-                    dest: `builds/${features_postfix}/pkg`,
-                },
-                {
-                    src: `../rapier${features_postfix}/README.md`,
-                    dest: `builds/${features_postfix}/pkg`,
-                },
-            ],
-        }),
-        base64({include: "**/*.wasm"}),
-        terser(),
-        nodeResolve(),
-        commonjs(),
-        typescript({
-            tsconfig: path.resolve(
-                __dirname,
-                `builds/${features_postfix}/tsconfig.pkg.json`,
-            ),
-            sourceMap: true,
-            inlineSources: true,
-        }),
-        filesize(),
-    ],
-});
+                    {
+                        src: `../rapier${features_postfix}/LICENSE`,
+                        dest: pkgDir,
+                    },
+                    {
+                        src: `../rapier${features_postfix}/README.md`,
+                        dest: pkgDir,
+                    },
+                ],
+            }),
+            base64({include: "**/*.wasm"}),
+            nodeResolve(),
+            commonjs(),
+            typescript({
+                tsconfig: path.resolve(
+                    __dirname,
+                    `builds/${features_postfix}/tsconfig.pkg.json`,
+                ),
+                sourceMap: true,
+                inlineSources: true,
+            }),
+            filesize(),
+        ],
+    };
+};
 
 export default [
     config("2d", "2d"),

--- a/typescript/rapier-compat/rollup.config.js
+++ b/typescript/rapier-compat/rollup.config.js
@@ -49,20 +49,25 @@ const config = (dim, features_postfix) => {
                             };
                             // delete config.module;
                             config.files = ["dist"];
+                            // The base manifest's `sideEffects: ["./*.js"]` matches
+                            // nothing (the bundles are .cjs/.mjs), which bundlers already
+                            // treat as "no side effects"; say so explicitly.
+                            config.sideEffects = false;
                             return JSON.stringify(config, undefined, 2);
                         },
                     },
                     {
-                        src: `../rapier${features_postfix}/LICENSE`,
+                        src: `../builds/rapier${features_postfix}/LICENSE`,
                         dest: pkgDir,
                     },
                     {
-                        src: `../rapier${features_postfix}/README.md`,
+                        src: `../builds/rapier${features_postfix}/README.md`,
                         dest: pkgDir,
                     },
                 ],
             }),
             base64({include: "**/*.wasm"}),
+            terser(),
             nodeResolve(),
             commonjs(),
             typescript({

--- a/typescript/rapier-compat/src2d/init.ts
+++ b/typescript/rapier-compat/src2d/init.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
-import wasmBase64 from "../pkg/rapier_wasm2d_bg.wasm";
-import wasmInit from "../pkg/rapier_wasm2d";
+import wasmBase64 from "../pkg/dist/rapier_wasm2d_bg.wasm";
+import wasmInit from "../pkg/dist/rapier_wasm2d";
 import base64 from "base64-js";
 
 /**

--- a/typescript/rapier-compat/src2d/raw.ts
+++ b/typescript/rapier-compat/src2d/raw.ts
@@ -1,1 +1,1 @@
-export * from "../pkg/rapier_wasm2d";
+export * from "../pkg/dist/rapier_wasm2d";

--- a/typescript/rapier-compat/src3d/init.ts
+++ b/typescript/rapier-compat/src3d/init.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
-import wasmBase64 from "../pkg/rapier_wasm3d_bg.wasm";
-import wasmInit from "../pkg/rapier_wasm3d";
+import wasmBase64 from "../pkg/dist/rapier_wasm3d_bg.wasm";
+import wasmInit from "../pkg/dist/rapier_wasm3d";
 import base64 from "base64-js";
 
 /**

--- a/typescript/rapier-compat/src3d/raw.ts
+++ b/typescript/rapier-compat/src3d/raw.ts
@@ -1,1 +1,1 @@
-export * from "../pkg/rapier_wasm3d";
+export * from "../pkg/dist/rapier_wasm3d";

--- a/typescript/rapier-compat/tsconfig.pkg2d.json
+++ b/typescript/rapier-compat/tsconfig.pkg2d.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.common.json",
     "compilerOptions": {
         "rootDir": "./gen2d",
-        "outDir": "./2d"
+        "outDir": "./pkg/dist",
+        "declarationDir": "./pkg/dist"
     },
     "files": ["./gen2d/rapier.ts"]
 }

--- a/typescript/rapier-compat/tsconfig.pkg3d.json
+++ b/typescript/rapier-compat/tsconfig.pkg3d.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.common.json",
     "compilerOptions": {
         "rootDir": "./gen3d",
-        "outDir": "."
+        "outDir": "./pkg/dist",
+        "declarationDir": "./pkg/dist"
     },
     "files": ["./gen3d/rapier.ts"]
 }


### PR DESCRIPTION
This PR moves generated `rapier-compat` artifacts into a dedicated `pkg/dist` directory instead of placing them alongside `package.json`.

Having `rapier.mjs` in the same folder as `package.json` was causing problems in WebStorm when Rapier is used as an NPM workspace. It was interfering with WebStorm's type analysis.

---

It updates:

* Rollup bundle output paths
* TypeScript declaration output paths
* WASM and generated binding destinations
* Generated source imports
* `package.json` entry points and exports
* `raw.d.ts` generation

The change applies to all 2D, 3D, deterministic, and SIMD variants.

Package-level imports remain unchanged:

```js
import RAPIER from "@dimforge/rapier3d-compat";
```

### Before

```
pkg/
├── package.json
├── rapier.mjs
├── rapier.mjs.map
├── rapier.cjs
├── rapier.cjs.map
├── rapier.d.ts
├── raw.d.ts
├── rapier_wasm3d.js
├── rapier_wasm3d.d.ts
├── rapier_wasm3d_bg.wasm
└── rapier_wasm3d_bg.wasm.d.ts
```

### After

```
pkg/
├── package.json
└── dist/
    ├── rapier.mjs
    ├── rapier.mjs.map
    ├── rapier.cjs
    ├── rapier.cjs.map
    ├── rapier.d.ts
    ├── raw.d.ts
    ├── rapier_wasm3d.js
    ├── rapier_wasm3d.d.ts
    ├── rapier_wasm3d_bg.wasm
    └── rapier_wasm3d_bg.wasm.d.ts
```