### PR TITLE
Clean Cargo artifacts between WASM variants

### DIFF
--- a/typescript/rapier-compat/build-rust.sh
+++ b/typescript/rapier-compat/build-rust.sh
@@ -47,4 +47,13 @@ else
     export additional_rustflags=''
 fi
 
-RUSTFLAGS="${additional_rustflags}" wasm-pack --verbose build --target web --out-dir "../../rapier-compat/builds/${dimension}d${feature_postfix}/wasm-build" "$rust_source_directory"
+# The generated variants share the typescript Cargo workspace target directory.
+# Clean it because SIMD and non-SIMD builds use different RUSTFLAGS.
+cargo clean --manifest-path ../Cargo.toml
+
+RUSTFLAGS="${additional_rustflags}" wasm-pack \
+    --verbose \
+    build \
+    --target web \
+    --out-dir "../../rapier-compat/builds/${dimension}d${feature_postfix}/wasm-build" \
+    "$rust_source_directory"


### PR DESCRIPTION
This PR adds a `cargo clean` step before each `wasm-pack` build in `rapier-compat`.

The build variants share the same Cargo target directory but use different `RUSTFLAGS`, particularly for SIMD and non-SIMD builds. Without cleaning, for me, Cargo reuses artifacts compiled with incompatible target features, causing non-SIMD builds to contain SIMD instructions and fail during `wasm-opt` validation.

Cleaning before each variant ensures every WASM package is rebuilt with the correct compiler flags.
