### PR TITLE
Specialize twist friction accumulation for small contact counts

### DIFF
--- a/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
@@ -428,16 +428,32 @@ impl ContactWithTwistFriction<SimdReal> {
             #[cfg(feature = "dim2")]
             let tangents1 = [&self.dir1.orthonormal_vector()];
 
-            let mut tangent_limit = SimdReal::zero();
-            let mut twist_limit = SimdReal::zero();
-            for (normal_part, dist) in normal_parts.iter().zip(self.twist_dists.iter()) {
-                tangent_limit += normal_part.impulse;
-                // The twist limit is computed as the sum of impulses multiplied by the
-                // lever-arm length relative to the friction center. The rational is that
-                // the further the point is from the friction center, the stronger angular
-                // resistance it can offer.
-                twist_limit += normal_part.impulse * *dist;
-            }
+            // Most contact manifolds have only one or two contacts, so avoid
+            // setting up an iterator for those common cases.
+            let (mut tangent_limit, mut twist_limit) = match normal_parts {
+                [normal_part] => (
+                    normal_part.impulse,
+                    normal_part.impulse * self.twist_dists[0],
+                ),
+                [normal_part0, normal_part1] => (
+                    normal_part0.impulse + normal_part1.impulse,
+                    normal_part0.impulse * self.twist_dists[0]
+                        + normal_part1.impulse * self.twist_dists[1],
+                ),
+                _ => {
+                    let mut tangent_limit = SimdReal::zero();
+                    let mut twist_limit = SimdReal::zero();
+                    for (normal_part, dist) in normal_parts.iter().zip(self.twist_dists.iter()) {
+                        tangent_limit += normal_part.impulse;
+                        // The twist limit is computed as the sum of impulses multiplied by the
+                        // lever-arm length relative to the friction center. The rational is that
+                        // the further the point is from the friction center, the stronger angular
+                        // resistance it can offer.
+                        twist_limit += normal_part.impulse * *dist;
+                    }
+                    (tangent_limit, twist_limit)
+                }
+            };
 
             // Multiply by the friction coefficient.
             tangent_limit *= self.limit;


### PR DESCRIPTION
## Summary

This specializes twist-friction tangent impulse accumulation for constraints with one or two normal contact parts, while keeping the existing loop as the fallback for other counts.

## Why this can improve performance

Contact constraints commonly have a very small number of normal parts. Handling the one- and two-part cases directly reduces loop overhead and repeated indexing on that solver path without changing the arithmetic performed for each tangent impulse.

## Validation

- `git diff --check`
- `cargo check -p rapier3d`

## Benchmark

Current machine, release microbenchmark, 7 samples, median:

| Benchmark | Base | This change | Delta |
|---|---:|---:|---:|
| 30 physics pipeline steps with contact constraints | 638,331.425 ns | 632,754.625 ns | 0.87% faster |
