### PR TITLE
Inline inv helper

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -102,6 +102,7 @@ pub fn mat_to_na(m: Matrix) -> Matrix3<Real> {
 const INV_EPSILON: Real = 1.0e-20;
 
 #[allow(dead_code)]
+#[inline]
 pub(crate) fn inv(val: Real) -> Real {
     if (-INV_EPSILON..=INV_EPSILON).contains(&val) {
         0.0


### PR DESCRIPTION
## Summary

This adds `#[inline]` to the small `inv` helper.

## Why this can improve performance

`inv` is a tiny arithmetic helper used to return zero near `INV_EPSILON` and otherwise compute the reciprocal. Inlining lets callers avoid a helper call around the small threshold check and division.

## Validation

- `git diff --check`
- `cargo check --manifest-path crates/rapier3d/Cargo.toml --lib`

## Benchmark

Draft note: this is a small inline hint for a tiny math helper. I am submitting it as a draft for maintainer feedback rather than claiming a broad physics-pipeline benchmark speedup.
