### PR TITLE
perf: switch back to caching the 3D constraint jacobians + fix sleep issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## Unreleased
+
+### Added
+
+- `DebugRenderStyle::sleep_eligible_color_multiplier`: the debug-renderer now draws bodies that
+  are eligible for sleep but still awake in a distinct color, making it easy to spot what is
+  keeping a pile awake.
+
+### Fixed
+
+- Python: `DynamicRayCastVehicleController.update_vehicle` now excludes the chassis body from
+  the suspension raycasts by default (their origins sit on its own collider).
+
+### Modified
+
+- Sleep eligibility is now judged on the actual per-step pose displacement (measured at the
+  body’s farthest point) instead of the velocities: a body held in place by contacts can sleep
+  even with residual solver velocities, while a body creeping through solver position
+  corrections cannot.
+- With the `block-solver` feature, manifolds whose 2x2 constraint matrix is almost singular
+  (e.g. redundant contact points) are now solved with the sequential solver instead of a
+  degraded one-point solve, removing residual jiggle in piles. The block solver also uses the
+  same lexicographic manifold point ordering as the sequential solver.
+- Improved 3D solver performance by caching the constraints angular jacobians instead of
+  recomputing them at each solver iteration.
+
 ## v0.35.0-beta.0 (02 August 2026)
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ needless_lifetimes = "allow"
 # Core math
 nalgebra = { version = "0.35", default-features = false, features = ["macros"] }
 glamx = { version = "0.3", default-features = false }
-simba = { version = "0.10.1", default-features = false }
+simba = { version = "0.10.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,10 +72,10 @@ num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 
 # Parry (each crate picks its own variant)
-parry2d = { version = "0.30", default-features = false, features = ["required-features"] }
-parry3d = { version = "0.30", default-features = false, features = ["required-features"] }
-parry2d-f64 = { version = "0.30", default-features = false, features = ["required-features"] }
-parry3d-f64 = { version = "0.30", default-features = false, features = ["required-features"] }
+parry2d = { version = "0.30.1", default-features = false, features = ["required-features"] }
+parry3d = { version = "0.30.1", default-features = false, features = ["required-features"] }
+parry2d-f64 = { version = "0.30.1", default-features = false, features = ["required-features"] }
+parry3d-f64 = { version = "0.30.1", default-features = false, features = ["required-features"] }
 
 # Utilities
 arrayvec = { version = "0.7", default-features = false }

--- a/crates/rapier2d/tests/snapshot_portability.rs
+++ b/crates/rapier2d/tests/snapshot_portability.rs
@@ -31,7 +31,7 @@ use rapier2d::prelude::*;
 /// Snapshot size in bytes, and its FNV-1a digest. Both, because the size alone localizes a
 /// failure: a differing size means a container's *encoding* changed, an equal size with a
 /// differing digest means the values did.
-const GOLDEN: (usize, u64) = (88_532, 0xa750_70b5_0fd4_e7f8);
+const GOLDEN: (usize, u64) = (88_532, 0x38c1_e725_5669_8eba);
 
 const STEPS: usize = 60;
 

--- a/crates/rapier3d/tests/parallel_path_parity.rs
+++ b/crates/rapier3d/tests/parallel_path_parity.rs
@@ -26,7 +26,7 @@ use rapier3d::prelude::*;
 
 /// Golden hash of [`run`]. Identical in every build; re-mint (with a note saying why)
 /// only when a change is *meant* to alter the simulation.
-const GOLDEN: u64 = 0x85f5_c0d1_6125_f348;
+const GOLDEN: u64 = 0xa8b2_0bad_6b09_7e3b;
 
 /// FNV-1a.
 struct Fnv(u64);

--- a/crates/rapier3d/tests/simd_backend_determinism.rs
+++ b/crates/rapier3d/tests/simd_backend_determinism.rs
@@ -141,7 +141,7 @@ fn golden_state_hash_is_backend_independent() {
     // Regenerate by running this test on every supported target: they must all
     // print the same value. If they don't, the backends have diverged and
     // `simd_backend_parity` should say on which operation.
-    const GOLDEN: u64 = 0xd9ef_17af_939e_942b;
+    const GOLDEN: u64 = 0xe488_2a11_2d57_d212;
     let hash = run(120);
     assert_eq!(
         hash, GOLDEN,

--- a/crates/rapier3d/tests/sleep_wide_bodies.rs
+++ b/crates/rapier3d/tests/sleep_wide_bodies.rs
@@ -1,0 +1,99 @@
+//! A body that has stopped moving must fall asleep however far its shape reaches.
+//!
+//! Deriving the rotation chord from `sqrt(1 − dot²)` turns dot-product rounding into a drift
+//! floor that scales with `max_extent`, so wide still bodies could never sleep.
+
+use rapier3d::prelude::*;
+
+/// A `U`-shaped compound (a wide bar plus two uprights), as in `stress_tests/compound3`:
+/// `max_extent` is ~4, well past the point where the old floor swamped the allowance.
+fn wide_compound_world() -> (PhysicsWorld, Vec<RigidBodyHandle>) {
+    let mut world = PhysicsWorld::new();
+    world.insert(
+        RigidBodyBuilder::fixed().translation(Vector::new(0.0, -0.1, 0.0)),
+        ColliderBuilder::cuboid(50.0, 0.1, 50.0),
+    );
+
+    let rad = 0.2;
+    let mut handles = Vec::new();
+    // Varied yaws: a single orientation can miss the rounding floor by luck; a spread cannot.
+    for i in 0..8 {
+        for k in 0..8 {
+            let (handle, _) = world.insert(
+                RigidBodyBuilder::dynamic()
+                    .translation(Vector::new(i as f32 * 6.0, rad + 0.01, k as f32 * 6.0))
+                    .rotation(Vector::Y * (i as f32 * 0.11 + k as f32 * 0.037)),
+                ColliderBuilder::cuboid(rad * 10.0, rad, rad),
+            );
+            world.insert_collider(
+                ColliderBuilder::cuboid(rad, rad * 10.0, rad).translation(Vector::new(
+                    rad * 10.0,
+                    rad * 10.0,
+                    0.0,
+                )),
+                Some(handle),
+            );
+            world.insert_collider(
+                ColliderBuilder::cuboid(rad, rad * 10.0, rad).translation(Vector::new(
+                    -rad * 10.0,
+                    rad * 10.0,
+                    0.0,
+                )),
+                Some(handle),
+            );
+            handles.push(handle);
+        }
+    }
+    (world, handles)
+}
+
+#[test]
+fn wide_bodies_at_rest_fall_asleep() {
+    let (mut world, handles) = wide_compound_world();
+    // At rest within a few steps + 30 steps of sleep timer; 300 is a wide margin that still
+    // fails outright when the drift floor scales with `max_extent`.
+    for _ in 0..300 {
+        world.step();
+    }
+
+    let asleep = handles
+        .iter()
+        .filter(|h| world.bodies[**h].is_sleeping())
+        .count();
+    assert_eq!(
+        asleep,
+        handles.len(),
+        "{} of {} wide bodies stayed awake at rest",
+        handles.len() - asleep,
+        handles.len(),
+    );
+}
+
+/// The floor is a property of the drift math, not of any particular scene: a body pinned to one
+/// pose must report a drift of zero no matter how far its shape reaches.
+#[test]
+fn still_wide_body_reports_no_drift() {
+    let mut world = PhysicsWorld::new();
+    world.gravity = Vector::ZERO;
+    let handle = world.insert_body(
+        // An orientation whose pose dot product rounds rather than landing exactly on 1.0.
+        RigidBodyBuilder::dynamic().rotation(Vector::new(0.3, -0.7, 0.15)),
+    );
+    world.insert_collider(ColliderBuilder::cuboid(0.2, 8.0, 0.2), Some(handle));
+
+    let pose = *world.bodies[handle].position();
+    for _ in 0..200 {
+        world.step();
+    }
+
+    let body = &world.bodies[handle];
+    assert_eq!(
+        *body.position(),
+        pose,
+        "a force-free body should not have moved at all"
+    );
+    assert!(
+        body.is_sleeping(),
+        "a motionless body with a far-reaching shape never slept",
+    );
+}

--- a/crates/rapier3d/tests/snapshot_portability.rs
+++ b/crates/rapier3d/tests/snapshot_portability.rs
@@ -31,7 +31,7 @@ use rapier3d::prelude::*;
 /// Snapshot size in bytes, and its FNV-1a digest. Both, because the size alone localizes a
 /// failure: a differing size means a container's *encoding* changed, an equal size with a
 /// differing digest means the values did.
-const GOLDEN: (usize, u64) = (469_140, 0xe588_545e_de4c_5ccf);
+const GOLDEN: (usize, u64) = (481_520, 0x7577_8919_4a52_5a49);
 
 const STEPS: usize = 60;
 

--- a/examples2d/stress_tests/vertical_stacks2.rs
+++ b/examples2d/stress_tests/vertical_stacks2.rs
@@ -25,7 +25,7 @@ pub async fn run(viewer: &mut TestbedViewer) -> anyhow::Result<()> {
      */
 
     let shiftx_centerx = [
-        (rad * 2.0 + 0.0002, -(num as f32) * rad * 2.0 * 1.5),
+        (rad * 2.0, -(num as f32) * rad * 2.0 * 1.5),
         (rad * 2.0 + rad, num as f32 * rad * 2.0 * 1.5),
     ];
 

--- a/examples3d/b3d_large_pyramid.rs
+++ b/examples3d/b3d_large_pyramid.rs
@@ -11,7 +11,7 @@ pub async fn run(viewer: &mut TestbedViewer) -> anyhow::Result<()> {
     let mut world = PhysicsWorld::new();
     world.gravity = Vector::new(0.0, -10.0, 0.0);
 
-    let base_count = 90i32;
+    let base_count = 200i32;
 
     // Ground: b3MakeBoxHull(400, 1, 400) at y = -1.
     world.insert(

--- a/examples3d/keva3.rs
+++ b/examples3d/keva3.rs
@@ -1,9 +1,7 @@
-use kiss3d::color::Color;
 use rapier_testbed3d::TestbedViewer;
 use rapier3d::prelude::*;
 
 pub fn build_block(
-    viewer: &mut TestbedViewer,
     world: &mut PhysicsWorld,
     half_extents: Vector,
     shift: Vector,
@@ -16,8 +14,6 @@ pub fn build_block(
     let block_width = 2.0 * half_extents.z * numx as f32;
     let block_height = 2.0 * half_extents.y * numy as f32;
     let spacing = (half_extents.z * numx as f32 - half_extents.x) / (numz as f32 - 1.0);
-    let mut color0 = Color::new(0.7, 0.5, 0.9, 1.0);
-    let mut color1 = Color::new(0.6, 1.0, 0.6, 1.0);
 
     for i in 0..numy {
         std::mem::swap(&mut numx, &mut numz);
@@ -45,9 +41,7 @@ pub fn build_block(
                     z + dim.z + shift.z,
                 ));
                 let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
-                let (handle, _) = world.insert(rigid_body, collider);
-
-                std::mem::swap(&mut color0, &mut color1);
+                let _ = world.insert(rigid_body, collider);
             }
         }
     }
@@ -64,8 +58,7 @@ pub fn build_block(
                 j as f32 * dim.z * 2.0 + dim.z + shift.z,
             ));
             let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
-            let (handle, _) = world.insert(rigid_body, collider);
-            std::mem::swap(&mut color0, &mut color1);
+            let _ = world.insert(rigid_body, collider);
         }
     }
 }
@@ -102,7 +95,6 @@ pub async fn run(viewer: &mut TestbedViewer) -> anyhow::Result<()> {
         let numz = numx * 3 + 1;
         let block_width = numx as f32 * half_extents.z * 2.0;
         build_block(
-            viewer,
             &mut world,
             half_extents,
             Vector::new(-block_width / 2.0, block_height, -block_width / 2.0),

--- a/examples3d/keva3.rs
+++ b/examples3d/keva3.rs
@@ -47,7 +47,6 @@ pub fn build_block(
                 let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
                 let (handle, _) = world.insert(rigid_body, collider);
 
-                viewer.set_initial_body_color(handle, color0);
                 std::mem::swap(&mut color0, &mut color1);
             }
         }
@@ -66,7 +65,6 @@ pub fn build_block(
             ));
             let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
             let (handle, _) = world.insert(rigid_body, collider);
-            viewer.set_initial_body_color(handle, color0);
             std::mem::swap(&mut color0, &mut color1);
         }
     }

--- a/examples3d/stress_tests/keva3.rs
+++ b/examples3d/stress_tests/keva3.rs
@@ -1,10 +1,8 @@
-use kiss3d::color::Color;
 use rapier_testbed3d::TestbedViewer;
 use rapier3d::glamx::Vec3Swizzles;
 use rapier3d::prelude::*;
 
 pub fn build_block(
-    viewer: &mut TestbedViewer,
     bodies: &mut RigidBodySet,
     colliders: &mut ColliderSet,
     half_extents: Vec3,
@@ -15,8 +13,6 @@ pub fn build_block(
     let block_width = 2.0 * half_extents.z * numx as f32;
     let block_height = 2.0 * half_extents.y * numy as f32;
     let spacing = (half_extents.z * numx as f32 - half_extents.x) / (numz as f32 - 1.0);
-    let mut color0 = Color::new(0.7, 0.5, 0.9, 1.0);
-    let mut color1 = Color::new(0.6, 1.0, 0.6, 1.0);
 
     for i in 0..numy {
         std::mem::swap(&mut numx, &mut numz);
@@ -46,8 +42,6 @@ pub fn build_block(
                 let handle = bodies.insert(rigid_body);
                 let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
                 colliders.insert_with_parent(collider, handle, bodies);
-
-                std::mem::swap(&mut color0, &mut color1);
             }
         }
     }
@@ -66,7 +60,6 @@ pub fn build_block(
             let handle = bodies.insert(rigid_body);
             let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
             colliders.insert_with_parent(collider, handle, bodies);
-            std::mem::swap(&mut color0, &mut color1);
         }
     }
 }
@@ -102,7 +95,6 @@ pub async fn run(viewer: &mut TestbedViewer) -> anyhow::Result<()> {
         let numz = numx * 3 + 1;
         let block_width = numx as f32 * half_extents.z * 2.0;
         build_block(
-            viewer,
             &mut world.bodies,
             &mut world.colliders,
             half_extents,

--- a/examples3d/stress_tests/keva3.rs
+++ b/examples3d/stress_tests/keva3.rs
@@ -47,7 +47,6 @@ pub fn build_block(
                 let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
                 colliders.insert_with_parent(collider, handle, bodies);
 
-                viewer.set_initial_body_color(handle, color0);
                 std::mem::swap(&mut color0, &mut color1);
             }
         }
@@ -67,7 +66,6 @@ pub fn build_block(
             let handle = bodies.insert(rigid_body);
             let collider = ColliderBuilder::cuboid(dim.x, dim.y, dim.z);
             colliders.insert_with_parent(collider, handle, bodies);
-            viewer.set_initial_body_color(handle, color0);
             std::mem::swap(&mut color0, &mut color1);
         }
     }
@@ -96,10 +94,10 @@ pub async fn run(viewer: &mut TestbedViewer) -> anyhow::Result<()> {
     let mut block_height = 0.0;
     // These should only be set to odd values otherwise
     // the blocks won't align in the nicest way.
-    let numy = [0, 9, 13, 17, 21, 41];
+    let numy = [0, 13, 17, 21, 41, 83];
 
     for i in (1..=5).rev() {
-        let numx = i;
+        let numx = i * 2;
         let numy = numy[i];
         let numz = numx * 3 + 1;
         let block_width = numx as f32 * half_extents.z * 2.0;

--- a/python/examples/vehicle/drive.py
+++ b/python/examples/vehicle/drive.py
@@ -48,17 +48,21 @@ def main() -> None:
         world.update_query_pipeline()
         veh.update_vehicle(1.0 / 60.0, world.rigid_bodies, world.colliders, world.query_pipeline)
 
-    # Accelerate via the rear wheels.
-    veh.apply_engine_force(2, 100.0)
-    veh.apply_engine_force(3, 100.0)
+    # Accelerate via the rear wheels. 30N matches the Rust demo's arrow-key
+    # force; more would drive off the edge of the ground before step 240.
+    veh.apply_engine_force(2, 30.0)
+    veh.apply_engine_force(3, 30.0)
     for _ in range(240):
         world.step()
         world.update_query_pipeline()
         veh.update_vehicle(1.0 / 60.0, world.rigid_bodies, world.colliders, world.query_pipeline)
 
     speed = veh.current_speed_km_hour()
-    vx = world.rigid_bodies[chassis].linvel.x
-    print(f"vehicle: speed={speed:+.1f} km/h vx={vx:+.2f}")
+    body = world.rigid_bodies[chassis]
+    vx = body.linvel.x
+    # Ride height: half-height + rest length + wheel radius, minus suspension sag.
+    y = body.translation.y
+    print(f"vehicle: speed={speed:+.1f} km/h vx={vx:+.2f} y={y:+.2f}")
 
 
 if __name__ == "__main__":

--- a/python/rapier-py-3d/python/rapier3d/_rapier3d.pyi
+++ b/python/rapier-py-3d/python/rapier3d/_rapier3d.pyi
@@ -2002,6 +2002,7 @@ class DebugRenderStyle:
     multibody_joint_anchor_color: DebugColor
     multibody_joint_separation_color: DebugColor
     sleep_color_multiplier: DebugColor
+    sleep_eligible_color_multiplier: DebugColor
     disabled_color_multiplier: DebugColor
     rigid_body_axes_length: float
     contact_depth_color: DebugColor

--- a/python/rapier-py-3d/src/controllers.rs
+++ b/python/rapier-py-3d/src/controllers.rs
@@ -1745,6 +1745,9 @@ impl DynamicRayCastVehicleController {
     /// Requires a fresh :class:`QueryPipeline` — typically call
     /// ``world.update_query_pipeline()`` first.
     ///
+    /// The chassis body is excluded from the suspension raycasts (their origins
+    /// sit on its own collider), unless ``filter`` already excludes a body.
+    ///
     /// :param dt: Time step in seconds.
     /// :param bodies: Rigid-body set (mutated).
     /// :param colliders: Collider set (mutated).
@@ -1764,7 +1767,8 @@ impl DynamicRayCastVehicleController {
         let np = queries.narrow_phase.borrow(py);
         let mut bodies_ref = bodies.borrow_mut(py);
         let mut colliders_ref = colliders.borrow_mut(py);
-        let qf = filter.map(|f| f.as_rapier(None)).unwrap_or_default();
+        let mut qf = filter.map(|f| f.as_rapier(None)).unwrap_or_default();
+        qf.exclude_rigid_body = qf.exclude_rigid_body.or(Some(self.0.chassis));
         let qpmut = bp.0.as_query_pipeline_mut(
             np.0.query_dispatcher(),
             &mut bodies_ref.0,

--- a/python/rapier-py-3d/src/debug_render.rs
+++ b/python/rapier-py-3d/src/debug_render.rs
@@ -609,6 +609,19 @@ impl DebugRenderStyle {
         self.0.sleep_color_multiplier = DebugColor::extract_from(v)?;
         Ok(())
     }
+    /// Multiplier applied to base colors of awake bodies that are eligible for sleep:
+    /// the plain awake color then marks whatever is holding the pile up.
+    #[getter]
+    fn sleep_eligible_color_multiplier(&self) -> DebugColor {
+        DebugColor(self.0.sleep_eligible_color_multiplier)
+    }
+    #[setter]
+    /// Set the HSLA multiplier applied to sleep-eligible (but awake) body colors,
+    /// from a :class:`DebugColor` or a 4-tuple HSLA.
+    fn set_sleep_eligible_color_multiplier(&mut self, v: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.0.sleep_eligible_color_multiplier = DebugColor::extract_from(v)?;
+        Ok(())
+    }
     /// Multiplier applied to base colors of disabled bodies.
     #[getter]
     fn disabled_color_multiplier(&self) -> DebugColor {

--- a/python/tests/test_controllers.py
+++ b/python/tests/test_controllers.py
@@ -362,6 +362,31 @@ def test_vehicle_construction_and_wheels(ns):
         assert wheel.brake == 0.0
 
 
+def test_vehicle_settles_on_its_suspension(ns):
+    """The vehicle comes to rest on the ground, not in the air.
+
+    Regression test: without excluding the chassis from its own suspension
+    raycasts, every wheel hits the vehicle itself and it flies off.
+    """
+    w = ns.PhysicsWorld(gravity=(0, -9.81, 0), auto_update_query=True)
+    w.add_body(
+        ns.RigidBody.fixed(translation=(0, -0.1, 0)),
+        colliders=[ns.Collider.cuboid(50, 0.1, 50)],
+    )
+    h, veh = _build_vehicle(ns, w)
+    for _ in range(120):
+        w.step()
+        w.update_query_pipeline()
+        veh.update_vehicle(1.0 / 60.0, w.rigid_bodies, w.colliders, w.query_pipeline)
+
+    body = w.rigid_bodies[h]
+    # Half-height + suspension rest length + wheel radius, minus spring sag.
+    assert 0.25 < body.translation.y < 0.34, (
+        f"chassis is not riding on its suspension: y={body.translation.y}"
+    )
+    assert abs(body.linvel.y) < 0.5, f"chassis is still moving: vy={body.linvel.y}"
+
+
 def test_vehicle_accelerates_with_engine_force(ns):
     """Applying engine force makes the vehicle gain forward speed (in m/s,
     measured via the chassis linvel along its forward axis)."""
@@ -390,6 +415,8 @@ def test_vehicle_accelerates_with_engine_force(ns):
     assert abs(forward_after) > abs(forward_before), (
         f"engine force did not accelerate (before={forward_before}, after={forward_after})"
     )
+    # ...by driving on the ground, not by taking off.
+    assert 0.25 < w.rigid_bodies[h].translation.y < 0.34
     # Sanity check the km/h converter agrees with the chassis linvel.
     assert veh.current_speed_km_hour() != 0.0
 

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -30,8 +30,11 @@ EXPECTED: dict[str, str | re.Pattern[str]] = {
     "character/stairs.py": "climbed: x=13.50 y=0.28",
     # The vehicle controller's exact speed depends on per-architecture floating
     # point (rapier is not bit-reproducible across arches without
-    # enhanced-determinism). Assert it drove backward at a real speed instead.
-    "vehicle/drive.py": re.compile(r"^vehicle: speed=-\d+\.\d+ km/h vx=[-+]\d+\.\d+$"),
+    # enhanced-determinism), so assert the shape instead: it drove forward at a
+    # real speed, riding on its suspension (y=0.31) the whole way.
+    "vehicle/drive.py": re.compile(
+        r"^vehicle: speed=\+[1-9]\d*\.\d km/h vx=\+[1-9]\d*\.\d\d y=\+0\.31$"
+    ),
     "urdf/load_simple.py": "urdf: name=two_link links=2 joints=1",
     "render/matplotlib_animation.py": "matplotlib: segments=27000 frames=120",
     # The snapshot's byte count tracks the engine's stored state, which changes

--- a/run-ci-checks.sh
+++ b/run-ci-checks.sh
@@ -183,11 +183,15 @@ print_step "Checking rapier_testbed3d with parallel..."
 (cd crates/rapier_testbed3d && RUSTFLAGS="-D warnings" cargo check --verbose --features parallel) || print_error "Check rapier_testbed3d parallel"
 print_success "Check rapier_testbed3d parallel"
 
-# Glam backend golden hashes: must produce identical bits on every platform this
+# SIMD backend golden hashes: must produce identical bits on every platform this
 # runs on (the cross-platform determinism contract).
-print_step "Running glam backend determinism test..."
-(cd crates/rapier3d && cargo test --features enhanced-determinism --test glam_backend_determinism) || print_error "Glam backend determinism test"
-print_success "Glam backend determinism test"
+print_step "Running SIMD backend determinism test..."
+(cd crates/rapier3d && cargo test --release --features enhanced-determinism --test simd_backend_determinism) || print_error "SIMD backend determinism test"
+print_success "SIMD backend determinism test"
+
+print_step "Running SIMD backend op-level parity test..."
+(cd crates/rapier3d && cargo test --release --features enhanced-determinism --test simd_backend_parity) || print_error "SIMD backend parity test"
+print_success "SIMD backend parity test"
 
 # Check enhanced-determinism feature
 print_step "Checking rapier2d with enhanced-determinism..."

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -16,8 +16,6 @@ use crate::utils::{
 use num::Zero;
 #[cfg(feature = "dim2")]
 use parry::math::Rot2;
-#[cfg(not(feature = "std"))]
-use simba::scalar::ComplexField as _;
 
 /// The type of a body, governing the way it is affected by external forces.
 #[deprecated(note = "renamed as RigidBodyType")]
@@ -1409,7 +1407,8 @@ impl RigidBodyActivation {
                     // The position-based criteria will be more restrictive, but we keep
                     // this for the rare case where the orientation’s periodicity would
                     // make the pose drift estimate too approximate.
-                    self.angular_threshold >= 0.0 && sq_angvel < Real::FRAC_PI_2() * Real::FRAC_PI_2()
+                    self.angular_threshold >= 0.0
+                        && sq_angvel < Real::FRAC_PI_2() * Real::FRAC_PI_2()
                 } else {
                     // Collider-less bodies have `max_extent == 0` so we need to take its
                     // angular velocity into account since the pose delta cannot take its

--- a/src/dynamics/rigid_body_components.rs
+++ b/src/dynamics/rigid_body_components.rs
@@ -1260,11 +1260,6 @@ impl RigidBodyDominance {
 /// - Automatically woken when disturbed (hit by moving object, connected via joint)
 /// - Woken manually with `body.wake_up()` or `islands.wake_up()`
 ///
-/// ## How sleeping works
-///
-/// A body sleeps after its linear AND angular velocities stay below thresholds for
-/// `time_until_sleep` seconds (default: 1 second). Set thresholds to negative to disable sleeping.
-///
 /// ## When to disable sleeping
 ///
 /// Most bodies should sleep! Only disable if the body needs to stay active despite being still:
@@ -1300,10 +1295,9 @@ pub struct RigidBodyActivation {
     /// Is this body currently sleeping?
     pub sleeping: bool,
 
-    /// Pose when the sleep timer last started (re-anchored on every timer reset). Farthest-point
-    /// displacement since this anchor gates sleep: secular creep from solver corrections (invisible
-    /// in velocities) blocks it, bounded oscillatory jitter doesn't (a raw per-step correction term would).
-    pub(crate) sleep_drift_anchor: Pose,
+    /// Pose at the previous step: the sleep check measures actual per-step displacement,
+    /// solver position corrections included (those never show up in the velocities).
+    pub(crate) sleep_prev_pose: Pose,
 }
 
 impl Default for RigidBodyActivation {
@@ -1341,7 +1335,7 @@ impl RigidBodyActivation {
             time_until_sleep: Self::default_time_until_sleep(),
             time_since_can_sleep: 0.0,
             sleeping: false,
-            sleep_drift_anchor: Pose::IDENTITY,
+            sleep_prev_pose: Pose::IDENTITY,
         }
     }
 
@@ -1353,7 +1347,7 @@ impl RigidBodyActivation {
             time_until_sleep: Self::default_time_until_sleep(),
             time_since_can_sleep: Self::default_time_until_sleep(),
             sleeping: true,
-            sleep_drift_anchor: Pose::IDENTITY,
+            sleep_prev_pose: Pose::IDENTITY,
         }
     }
 
@@ -1407,35 +1401,24 @@ impl RigidBodyActivation {
     ) {
         let can_sleep = match body_type {
             RigidBodyType::Dynamic => {
-                // Sleep metric: farthest-point speed (|v| + |ω|·max_extent) below the linear
-                // threshold, AND drift since the timer started below threshold·sleep_delay — drift catches
-                // bias creep invisible in velocities; anchoring (rather than measuring per step) lets oscillatory jitter rest.
                 let linear_threshold = self.normalized_linear_threshold * length_unit;
-                let max_point_vel = sq_linvel.sqrt() + sq_angvel.sqrt() * max_extent;
+                let prev_pose = core::mem::replace(&mut self.sleep_prev_pose, *pose);
                 let angular_ok = if max_extent > 0.0 {
-                    self.angular_threshold >= 0.0
+                    use crate::num::FloatConst;
+                    // Use a fixed angular threshold that unambiguously imply movement.
+                    // The position-based criteria will be more restrictive, but we keep
+                    // this for the rare case where the orientation’s periodicity would
+                    // make the pose drift estimate too approximate.
+                    self.angular_threshold >= 0.0 && sq_angvel < Real::FRAC_PI_2() * Real::FRAC_PI_2()
                 } else {
+                    // Collider-less bodies have `max_extent == 0` so we need to take its
+                    // angular velocity into account since the pose delta cannot take its
+                    // rotation into account.
                     sq_angvel < self.angular_threshold * self.angular_threshold.abs()
                 };
-                let vel_ok = max_point_vel * max_point_vel
-                    < linear_threshold * linear_threshold.abs()
-                    && angular_ok;
-                // Only bodies passing the velocity gate pay for the drift check (chord math +
-                // anchor writes); the anchor is (re)set when a stillness period starts, i.e. when
-                // the gate passes with a zeroed timer.
-                if vel_ok {
-                    if self.time_since_can_sleep == 0.0 {
-                        self.sleep_drift_anchor = *pose;
-                    }
-                    let drift = crate::geometry::relative_pose_drift(
-                        &self.sleep_drift_anchor,
-                        pose,
-                        max_extent,
-                    );
-                    drift <= linear_threshold.max(0.0) * self.time_until_sleep.max(0.0)
-                } else {
-                    false
-                }
+
+                let drift = crate::geometry::relative_pose_drift(&prev_pose, pose, max_extent);
+                angular_ok && drift * 0.5 < linear_threshold * dt
             }
             RigidBodyType::KinematicPositionBased | RigidBodyType::KinematicVelocityBased => {
                 // Platforms only sleep if both velocities are exactly zero. If it’s not exactly
@@ -1504,5 +1487,67 @@ mod tests {
             let interp_pos = vel.integrate(dt, &curr_pos, &local_com);
             approx::assert_relative_eq!(interp_pos, next_pos, epsilon = 1.0e-5);
         }
+    }
+
+    /// Runs `steps` of `update_energy` on a body that only ever moves by `shift_per_step`
+    /// (zero velocity: the motion stands for solver position corrections).
+    fn creep(shift_per_step: Real, steps: usize, dt: Real) -> RigidBodyActivation {
+        let mut activation = RigidBodyActivation::active();
+        let mut shift = 0.0;
+
+        for _ in 0..steps {
+            shift += shift_per_step;
+            let pose = Pose::from_translation(Vector::X * shift);
+            activation.update_energy(RigidBodyType::Dynamic, 1.0, 0.0, 0.0, 1.0, &pose, dt);
+        }
+
+        activation
+    }
+
+    /// Runs `steps` of `update_energy` on a body pinned to one pose while reporting `linvel`,
+    /// like a body in a loaded stack whose contacts cancel its velocity again every step.
+    fn pinned_with_velocity(linvel: Real, steps: usize, dt: Real) -> RigidBodyActivation {
+        let mut activation = RigidBodyActivation::active();
+        let pose = Pose::from_translation(Vector::X * 3.0);
+
+        for _ in 0..steps {
+            activation.update_energy(
+                RigidBodyType::Dynamic,
+                1.0,
+                linvel * linvel,
+                0.0,
+                1.0,
+                &pose,
+                dt,
+            );
+        }
+
+        activation
+    }
+
+    #[test]
+    fn test_sleep_allows_pinned_body_with_residual_velocity() {
+        let dt = 1.0 / 60.0;
+        let threshold = RigidBodyActivation::default_normalized_linear_threshold();
+        let steps = (10.0 * RigidBodyActivation::default_time_until_sleep() / dt) as usize;
+
+        // A still body sleeps even while its velocity reads several times the threshold:
+        // that residual is the solver cancelling itself, not motion.
+        assert!(pinned_with_velocity(threshold * 5.0, steps, dt).is_eligible_for_sleep());
+    }
+
+    #[test]
+    fn test_sleep_gates_position_corrections() {
+        let dt = 1.0 / 60.0;
+        // The per-step displacement the sleep metric tolerates: the threshold, halved.
+        let budget = 2.0 * RigidBodyActivation::default_normalized_linear_threshold() * dt;
+        let steps = (10.0 * RigidBodyActivation::default_time_until_sleep() / dt) as usize;
+
+        // Creeping faster than the budget blocks sleep, however small the velocities are.
+        assert!(!creep(budget * 1.5, steps, dt).is_eligible_for_sleep());
+
+        // Creeping below it doesn't, no matter how long the body has been still.
+        assert!(creep(budget * 0.5, steps, dt).is_eligible_for_sleep());
+        assert!(creep(0.0, steps, dt).is_eligible_for_sleep());
     }
 }

--- a/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
+++ b/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
@@ -8,6 +8,11 @@ use na::Vector2;
 #[cfg(feature = "block-solver")]
 use simba::simd::SimdValue;
 
+/// How well-conditioned a manifold's 2x2 matrix `K` must be for the block solver to take it
+/// (`det(K) > BLOCK_SOLVER_MIN_CONDITION * k11 * k22`): near-singular pairs go to the sequential path.
+#[cfg(feature = "block-solver")]
+pub(crate) const BLOCK_SOLVER_MIN_CONDITION: crate::math::Real = 0.01;
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ContactConstraintTangentPart<N: ScalarType> {
     pub torque_dir1: [N::AngVector; DIM - 1],
@@ -312,15 +317,17 @@ impl<N: ScalarType> ContactConstraintNormalPart<N> {
         let block_result = new_impulse0.select(keep0, selected1);
 
         // Degraded lanes (`block_flag` = 0: manifold lacks both points, or the pair matrix
-        // wasn't invertible at build time).
+        // wasn't invertible at build time): solve the two points one after the other, exactly
+        // as the feature-off build does, with `k12` carrying the first solve's velocity change.
         // Use `degraded_dvel_a` rather than `dvel.x` so that this case matches the non-mlcp
         // solve exactly.
         // TODO: measure if using `degraded_dvel_a` instead of `dvel.x` has any performance
         //       impact.
-        let degraded = Vector2::new(
-            cfm_factor.x * (prev_impulse.x - r_a * degraded_dvel_a).simd_max(zero),
-            zero,
-        );
+        let degraded_a = cfm_factor.x * (prev_impulse.x - r_a * degraded_dvel_a).simd_max(zero);
+        let degraded_b = cfm_factor.y
+            * (prev_impulse.y - r_b * (dvel.y + k12 * (degraded_a - prev_impulse.x)))
+                .simd_max(zero);
+        let degraded = Vector2::new(degraded_a, degraded_b);
         let use_block = block_flag.simd_gt(N::splat(0.5));
         block_result.select(use_block, degraded)
     }

--- a/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
+++ b/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
@@ -378,19 +378,19 @@ impl<N: ScalarType> ContactConstraintNormalPart<N> {
 }
 
 /*
- * "Slim" variants for the twist-friction (Simplified) model: store only the world-space lever
- * arms and recompute the angular jacobians per use from the constraint-wide directions and
- * inverse inertia — bit-equivalent (poses refresh only in the builder, never inside velocity
- * iterations) for ~40% less memory streamed per sweep, the solver's bound on large scenes.
+ * "Slim" variants for the twist-friction (Simplified) model.
  */
-
 #[cfg(feature = "dim3")]
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ContactConstraintNormalPartSlim<N: ScalarType> {
-    /// World-space lever arm of the contact point wrt the first body's center of mass.
-    pub dp1: N::Vector,
-    /// World-space lever arm of the contact point wrt the second body's center of mass.
-    pub dp2: N::Vector,
+    /// Angular jacobian wrt the first body.
+    pub torque_dir1: N::AngVector,
+    /// Angular jacobian wrt the second body.
+    pub torque_dir2: N::AngVector,
+    /// Equals to `ii1 * torque_dir1`.
+    pub ii_torque_dir1: N::AngVector,
+    /// Equals to `ii2 * torque_dir2`.
+    pub ii_torque_dir2: N::AngVector,
     pub rhs: N,
     pub rhs_wo_bias: N,
     pub impulse: N,
@@ -423,19 +423,14 @@ where
         dir1: &N::Vector,
         im1: &N::Vector,
         im2: &N::Vector,
-        ii1: &N::AngInertia,
-        ii2: &N::AngInertia,
         solver_vel1: &mut SolverVel<N>,
         solver_vel2: &mut SolverVel<N>,
     ) {
-        let ii_torque_dir1 = ii1.transform_vector(self.dp1.gcross(*dir1));
-        let ii_torque_dir2 = ii2.transform_vector(self.dp2.gcross(-*dir1));
-
         solver_vel1.linear += dir1.component_mul(im1) * self.impulse;
-        solver_vel1.angular += ii_torque_dir1 * self.impulse;
+        solver_vel1.angular += self.ii_torque_dir1 * self.impulse;
 
         solver_vel2.linear += dir1.component_mul(im2) * -self.impulse;
-        solver_vel2.angular += ii_torque_dir2 * self.impulse;
+        solver_vel2.angular += self.ii_torque_dir2 * self.impulse;
     }
 
     #[inline]
@@ -444,31 +439,24 @@ where
         dir1: &N::Vector,
         im1: &N::Vector,
         im2: &N::Vector,
-        ii1: &N::AngInertia,
-        ii2: &N::AngInertia,
         solver_vel1: &mut SolverVel<N>,
         solver_vel2: &mut SolverVel<N>,
     ) where
         N::AngVector: DotProduct<N::AngVector, Result = N>,
     {
-        let torque_dir1 = self.dp1.gcross(*dir1);
-        let torque_dir2 = self.dp2.gcross(-*dir1);
-        let ii_torque_dir1 = ii1.transform_vector(torque_dir1);
-        let ii_torque_dir2 = ii2.transform_vector(torque_dir2);
-
-        let dvel = dir1.gdot(solver_vel1.linear) + torque_dir1.gdot(solver_vel1.angular)
+        let dvel = dir1.gdot(solver_vel1.linear) + self.torque_dir1.gdot(solver_vel1.angular)
             - dir1.gdot(solver_vel2.linear)
-            + torque_dir2.gdot(solver_vel2.angular)
+            + self.torque_dir2.gdot(solver_vel2.angular)
             + self.rhs;
         let new_impulse = self.cfm_factor * (self.impulse - self.r * dvel).simd_max(N::zero());
         let dlambda = new_impulse - self.impulse;
         self.impulse = new_impulse;
 
         solver_vel1.linear += dir1.component_mul(im1) * dlambda;
-        solver_vel1.angular += ii_torque_dir1 * dlambda;
+        solver_vel1.angular += self.ii_torque_dir1 * dlambda;
 
         solver_vel2.linear += dir1.component_mul(im2) * -dlambda;
-        solver_vel2.angular += ii_torque_dir2 * dlambda;
+        solver_vel2.angular += self.ii_torque_dir2 * dlambda;
     }
 
     /// See [`ContactConstraintNormalPart::solve_pair`]: solves two coupled
@@ -483,21 +471,19 @@ where
         dir1: &N::Vector,
         im1: &N::Vector,
         im2: &N::Vector,
-        ii1: &N::AngInertia,
-        ii2: &N::AngInertia,
         solver_vel1: &mut SolverVel<N>,
         solver_vel2: &mut SolverVel<N>,
     ) where
         N::AngVector: DotProduct<N::AngVector, Result = N>,
     {
-        let torque_dir1_a = constraint_a.dp1.gcross(*dir1);
-        let torque_dir2_a = constraint_a.dp2.gcross(-*dir1);
-        let torque_dir1_b = constraint_b.dp1.gcross(*dir1);
-        let torque_dir2_b = constraint_b.dp2.gcross(-*dir1);
-        let ii_torque_dir1_a = ii1.transform_vector(torque_dir1_a);
-        let ii_torque_dir2_a = ii2.transform_vector(torque_dir2_a);
-        let ii_torque_dir1_b = ii1.transform_vector(torque_dir1_b);
-        let ii_torque_dir2_b = ii2.transform_vector(torque_dir2_b);
+        let torque_dir1_a = constraint_a.torque_dir1;
+        let torque_dir2_a = constraint_a.torque_dir2;
+        let torque_dir1_b = constraint_b.torque_dir1;
+        let torque_dir2_b = constraint_b.torque_dir2;
+        let ii_torque_dir1_a = constraint_a.ii_torque_dir1;
+        let ii_torque_dir2_a = constraint_a.ii_torque_dir2;
+        let ii_torque_dir1_b = constraint_b.ii_torque_dir1;
+        let ii_torque_dir2_b = constraint_b.ii_torque_dir2;
 
         let dvel_lin1 = dir1.gdot(solver_vel1.linear);
         let dvel_lin2 = dir1.gdot(solver_vel2.linear);
@@ -543,6 +529,14 @@ pub(crate) struct ContactConstraintTangentPartSlim<N: ScalarType> {
     pub dp1: N::Vector,
     /// World-space lever arm of the friction center wrt the second body's center of mass.
     pub dp2: N::Vector,
+    /// Angular jacobians wrt the first body (one per tangent), cached at build time.
+    pub torque_dir1: [N::AngVector; 2],
+    /// Angular jacobians wrt the second body (one per tangent), cached at build time.
+    pub torque_dir2: [N::AngVector; 2],
+    /// `ii1 * torque_dir1[j]`, cached at build time.
+    pub ii_torque_dir1: [N::AngVector; 2],
+    /// `ii2 * torque_dir2[j]`, cached at build time.
+    pub ii_torque_dir2: [N::AngVector; 2],
     pub rhs: [N; 2],
     pub rhs_wo_bias: [N; 2],
     pub impulse: na::Vector2<N>,
@@ -561,15 +555,11 @@ where
         tangents1: [&N::Vector; 2],
         im1: &N::Vector,
         im2: &N::Vector,
-        ii1: &N::AngInertia,
-        ii2: &N::AngInertia,
         solver_vel1: &mut SolverVel<N>,
         solver_vel2: &mut SolverVel<N>,
     ) {
-        let ii_torque_dir1_0 = ii1.transform_vector(self.dp1.gcross(*tangents1[0]));
-        let ii_torque_dir1_1 = ii1.transform_vector(self.dp1.gcross(*tangents1[1]));
-        let ii_torque_dir2_0 = ii2.transform_vector(self.dp2.gcross(-*tangents1[0]));
-        let ii_torque_dir2_1 = ii2.transform_vector(self.dp2.gcross(-*tangents1[1]));
+        let (ii_torque_dir1_0, ii_torque_dir1_1) = (self.ii_torque_dir1[0], self.ii_torque_dir1[1]);
+        let (ii_torque_dir2_0, ii_torque_dir2_1) = (self.ii_torque_dir2[0], self.ii_torque_dir2[1]);
 
         solver_vel1.linear +=
             (*tangents1[0] * self.impulse[0] + *tangents1[1] * self.impulse[1]).component_mul(im1);
@@ -588,22 +578,16 @@ where
         tangents1: [&N::Vector; 2],
         im1: &N::Vector,
         im2: &N::Vector,
-        ii1: &N::AngInertia,
-        ii2: &N::AngInertia,
         limit: N,
         solver_vel1: &mut SolverVel<N>,
         solver_vel2: &mut SolverVel<N>,
     ) where
         N::AngVector: DotProduct<N::AngVector, Result = N>,
     {
-        let torque_dir1_0 = self.dp1.gcross(*tangents1[0]);
-        let torque_dir1_1 = self.dp1.gcross(*tangents1[1]);
-        let torque_dir2_0 = self.dp2.gcross(-*tangents1[0]);
-        let torque_dir2_1 = self.dp2.gcross(-*tangents1[1]);
-        let ii_torque_dir1_0 = ii1.transform_vector(torque_dir1_0);
-        let ii_torque_dir1_1 = ii1.transform_vector(torque_dir1_1);
-        let ii_torque_dir2_0 = ii2.transform_vector(torque_dir2_0);
-        let ii_torque_dir2_1 = ii2.transform_vector(torque_dir2_1);
+        let (torque_dir1_0, torque_dir1_1) = (self.torque_dir1[0], self.torque_dir1[1]);
+        let (torque_dir2_0, torque_dir2_1) = (self.torque_dir2[0], self.torque_dir2[1]);
+        let (ii_torque_dir1_0, ii_torque_dir1_1) = (self.ii_torque_dir1[0], self.ii_torque_dir1[1]);
+        let (ii_torque_dir2_0, ii_torque_dir2_1) = (self.ii_torque_dir2[0], self.ii_torque_dir2[1]);
 
         let dvel_0 = tangents1[0].gdot(solver_vel1.linear)
             + torque_dir1_0.gdot(solver_vel1.angular)

--- a/src/dynamics/solver/contact_constraint/contact_with_coulomb_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_coulomb_friction.rs
@@ -1,4 +1,6 @@
 use super::{ContactConstraintNormalPart, ContactConstraintTangentPart};
+#[cfg(feature = "block-solver")]
+use crate::dynamics::solver::contact_constraint::BLOCK_SOLVER_MIN_CONDITION;
 use crate::dynamics::solver::manifold_store::ManifoldStore;
 use crate::dynamics::solver::solver_body::SolverBodies;
 use crate::dynamics::solver::solver_contact_graph::ContactRef;
@@ -332,19 +334,18 @@ impl ContactWithCoulombFrictionBuilder {
                         .ii_torque_dir2
                         .gdot(out_constraint.normal_part[k1].torque_dir2);
                 let (k11, k22) = (utils::simd_inv(r0), utils::simd_inv(r1));
-                // Physical-K invertibility is a conservative proxy for the
-                // compliant K' the solve inverts per iteration (its diagonals
-                // are only ever stiffer: k'_ii = k_ii / ms_i >= k_ii).
-                let is_invertible = (k11 * k22 - k12 * k12).simd_gt(SimdReal::zero());
+                // Conditioning check on the physical K: a bare `det > 0` also admits
+                // near-singular pairs, and block-solving those keeps piles jiggling.
+                let is_invertible = (k11 * k22 - k12 * k12)
+                    .simd_gt(SimdReal::splat(BLOCK_SOLVER_MIN_CONDITION) * k11 * k22);
 
-                // Degenerate (redundant contacts) or partially-active lanes store `[0, 0]`:
-                // `solve_pair` then degrades to the scalar soft solve of point k0 (itself a
-                // no-op if k0 is inactive — its `r` lane was zero-selected above).
+                // Degenerate (redundant contacts) or partially-active lanes clear the block
+                // flag: `solve_pair` then solves the two points sequentially instead.
                 let block = is_invertible & pair_active;
-                out_constraint.normal_part[k0].r_mat_elts = [
-                    k12.select(block, SimdReal::zero()),
-                    SimdReal::splat(1.0).select(block, SimdReal::zero()),
-                ];
+                // `k12` stays on every lane: the degraded path carries the first point's
+                // impulse change over to the second.
+                out_constraint.normal_part[k0].r_mat_elts =
+                    [k12, SimdReal::splat(1.0).select(block, SimdReal::zero())];
                 out_constraint.normal_part[k1].r_mat_elts = [SimdReal::zero(); 2];
             }
         }

--- a/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
@@ -270,8 +270,10 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                 let projected_velocity = (vel1 - vel2).gdot(force_dir1);
                 normal_rhs_wo_bias = is_bouncy * restitution * projected_velocity;
 
-                out_constraint.normal_part[k].dp1 = dp1;
-                out_constraint.normal_part[k].dp2 = dp2;
+                out_constraint.normal_part[k].torque_dir1 = torque_dir1;
+                out_constraint.normal_part[k].torque_dir2 = torque_dir2;
+                out_constraint.normal_part[k].ii_torque_dir1 = ii_torque_dir1;
+                out_constraint.normal_part[k].ii_torque_dir2 = ii_torque_dir2;
                 // Inactive slots: zero warm-start impulse and effective mass ⇒
                 // the scalar normal solve is an exact no-op.
                 out_constraint.normal_part[k].impulse =
@@ -361,6 +363,11 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
             out_constraint.tangent_part.r[j] = r;
         }
 
+        out_constraint.tangent_part.torque_dir1 = torque_dirs1;
+        out_constraint.tangent_part.torque_dir2 = torque_dirs2;
+        out_constraint.tangent_part.ii_torque_dir1 = ii_torque_dirs1;
+        out_constraint.tangent_part.ii_torque_dir2 = ii_torque_dirs2;
+
         out_constraint.tangent_part.r[2] = SimdReal::splat(2.0)
             * (ii_torque_dirs1[0].gdot(torque_dirs1[1]) + ii_torque_dirs2[0].gdot(torque_dirs2[1]));
 
@@ -378,10 +385,10 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                 let r0 = out_constraint.normal_part[k0].r;
                 let r1 = out_constraint.normal_part[k1].r;
 
-                let torque_dir1_0 = out_constraint.normal_part[k0].dp1.gcross(force_dir1);
-                let torque_dir2_0 = out_constraint.normal_part[k0].dp2.gcross(-force_dir1);
-                let torque_dir1_1 = out_constraint.normal_part[k1].dp1.gcross(force_dir1);
-                let torque_dir2_1 = out_constraint.normal_part[k1].dp2.gcross(-force_dir1);
+                let torque_dir1_0 = out_constraint.normal_part[k0].torque_dir1;
+                let torque_dir2_0 = out_constraint.normal_part[k0].torque_dir2;
+                let torque_dir1_1 = out_constraint.normal_part[k1].torque_dir1;
+                let torque_dir2_1 = out_constraint.normal_part[k1].torque_dir2;
 
                 let k12 = force_dir1.gdot(imsum.component_mul(&force_dir1))
                     + poses1
@@ -581,8 +588,6 @@ impl ContactWithTwistFriction<SimdReal> {
                 &self.dir1,
                 &self.im1,
                 &self.im2,
-                &self.ii1,
-                &self.ii2,
                 &mut solver_vel1,
                 &mut solver_vel2,
             );
@@ -597,8 +602,6 @@ impl ContactWithTwistFriction<SimdReal> {
             tangents1,
             &self.im1,
             &self.im2,
-            &self.ii1,
-            &self.ii2,
             &mut solver_vel1,
             &mut solver_vel2,
         );
@@ -645,8 +648,6 @@ impl ContactWithTwistFriction<SimdReal> {
                         &self.dir1,
                         &self.im1,
                         &self.im2,
-                        &self.ii1,
-                        &self.ii2,
                         &mut solver_vel1,
                         &mut solver_vel2,
                     );
@@ -657,8 +658,6 @@ impl ContactWithTwistFriction<SimdReal> {
                         &self.dir1,
                         &self.im1,
                         &self.im2,
-                        &self.ii1,
-                        &self.ii2,
                         &mut solver_vel1,
                         &mut solver_vel2,
                     );
@@ -670,8 +669,6 @@ impl ContactWithTwistFriction<SimdReal> {
                     &self.dir1,
                     &self.im1,
                     &self.im2,
-                    &self.ii1,
-                    &self.ii2,
                     &mut solver_vel1,
                     &mut solver_vel2,
                 );
@@ -717,8 +714,6 @@ impl ContactWithTwistFriction<SimdReal> {
                 tangents1,
                 &self.im1,
                 &self.im2,
-                &self.ii1,
-                &self.ii2,
                 tangent_limit,
                 &mut solver_vel1,
                 &mut solver_vel2,

--- a/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
@@ -2,6 +2,8 @@ use super::{
     ContactConstraintNormalPartSlim, ContactConstraintTangentPartSlim,
     ContactConstraintTwistPartSlim,
 };
+#[cfg(feature = "block-solver")]
+use crate::dynamics::solver::contact_constraint::BLOCK_SOLVER_MIN_CONDITION;
 use crate::dynamics::solver::manifold_store::ManifoldStore;
 use crate::dynamics::solver::solver_body::SolverBodies;
 use crate::dynamics::solver::solver_contact_graph::ContactRef;
@@ -400,17 +402,17 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                         .transform_vector(torque_dir2_0)
                         .gdot(torque_dir2_1);
                 let (k11, k22) = (utils::simd_inv(r0), utils::simd_inv(r1));
-                // See the coulomb builder: physical-K invertibility is a
-                // conservative proxy for the compliant K'.
-                let is_invertible = (k11 * k22 - k12 * k12).simd_gt(SimdReal::zero());
+                // See the coulomb builder: near-singular pairs fall back to the sequential path.
+                let is_invertible = (k11 * k22 - k12 * k12)
+                    .simd_gt(SimdReal::splat(BLOCK_SOLVER_MIN_CONDITION) * k11 * k22);
 
                 // Degenerate or partially-active lanes store `[0, 0]`:
                 // `solve_pair` degrades to the scalar soft solve of point k0.
                 let block = is_invertible & pair_active;
-                out_constraint.normal_part[k0].r_mat_elts = [
-                    k12.select(block, SimdReal::zero()),
-                    SimdReal::splat(1.0).select(block, SimdReal::zero()),
-                ];
+                // `k12` stays on every lane: the degraded path carries the first point's
+                // impulse change over to the second.
+                out_constraint.normal_part[k0].r_mat_elts =
+                    [k12, SimdReal::splat(1.0).select(block, SimdReal::zero())];
                 out_constraint.normal_part[k1].r_mat_elts = [SimdReal::zero(); 2];
             }
         }

--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -275,21 +275,28 @@ pub(crate) fn relative_rot_cos(base: &crate::math::Rotation, cur: &crate::math::
 
 /// Straight-line bound on how far any point within `max_extent` of the origin moved
 /// between poses `base` and `cur`: translation delta + rotation *chord* `2·max_extent·sin(Δθ/2)`.
-/// One rotation dot + one `sqrt` (no `atan2`/`acos`); tighter than the arc length `max_extent·Δθ`.
+/// Tighter than the arc length `max_extent·Δθ`, and no `atan2`/`acos`.
 #[inline]
 pub(crate) fn relative_pose_drift(base: &Pose, cur: &Pose, max_extent: Real) -> Real {
     let trans = (cur.translation - base.translation).length();
+    let delta_rot = cur.rotation * base.rotation.inverse();
     #[cfg(feature = "dim2")]
     let rot_chord = {
-        // `dot` = cos(Δθ); chord = 2·sin(Δθ/2)·max_extent = sqrt(2(1−cos Δθ))·max_extent.
-        let c = base.rotation.dot(cur.rotation);
-        (2.0 * (1.0 - c)).max(0.0).sqrt() * max_extent
+        // To avoid explicit trigonometric functions, use the identity:
+        // `sin(Δθ/2) = |sin Δθ| / sqrt(2(1 + cos Δθ))`
+        let (sin, cos) = (delta_rot.sin(), delta_rot.cos());
+        let denom = 2.0 * (1.0 + cos);
+        let half_sin = if denom > 1.0e-6 {
+            sin.abs() / denom.sqrt()
+        } else {
+            1.0
+        };
+        2.0 * half_sin * max_extent
     };
     #[cfg(feature = "dim3")]
     let rot_chord = {
-        // quaternion `dot` = cos(Δθ/2); chord = 2·sin(Δθ/2)·max_extent.
-        let c = base.rotation.dot(cur.rotation);
-        2.0 * (1.0 - c * c).max(0.0).sqrt() * max_extent
+        // A unit quaternion's vector part is already `sin(Δθ/2)` about its axis.
+        2.0 * Vector::new(delta_rot.x, delta_rot.y, delta_rot.z).length() * max_extent
     };
     trans + rot_chord
 }
@@ -821,5 +828,42 @@ pub trait ContactManifoldExt {
 impl ContactManifoldExt for ContactManifold {
     fn total_impulse(&self) -> Real {
         self.points.iter().map(|pt| pt.data.impulse).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relative_pose_drift;
+    use crate::math::{Pose, Real, Vector};
+
+    /// A pose compared against *itself* must report exactly no drift, whatever the orientation
+    /// and however far the shape reaches.
+    #[test]
+    fn same_pose_never_drifts() {
+        // The sleep gate's per-step allowance at the default threshold and 60 Hz.
+        let allowance = 0.05 * (1.0 / 60.0) * 2.0;
+        let max_extent = 4.0;
+
+        let mut worst: Real = 0.0;
+        let mut n = 0;
+        for i in 0..40 {
+            for j in 0..10 {
+                let angle = i as Real * 0.157;
+                #[cfg(feature = "dim2")]
+                let pose = Pose::new(Vector::new(j as Real * 3.7, 1.0), angle);
+                #[cfg(feature = "dim3")]
+                let pose = Pose::new(
+                    Vector::new(j as Real * 3.7, 1.0, -2.0),
+                    Vector::new(0.3, -0.7, 0.15).normalize() * angle,
+                );
+                worst = worst.max(relative_pose_drift(&pose, &pose, max_extent));
+                n += 1;
+            }
+        }
+        assert_eq!(
+            worst, 0.0,
+            "an unmoved pose drifted by up to {worst} over {n} orientations \
+             (the sleep gate allows {allowance} per step)"
+        );
     }
 }

--- a/src/geometry/contact_pair.rs
+++ b/src/geometry/contact_pair.rs
@@ -9,7 +9,8 @@ use crate::utils::ScalarType;
 use crate::utils::SolverBlock;
 use parry::math::{SIMD_WIDTH, SimdReal};
 use parry::query::ContactManifoldsWorkspace;
-#[cfg(not(feature = "std"))]
+// Only `relative_pose_drift`’s 2D branch needs the no-std float methods.
+#[cfg(all(not(feature = "std"), feature = "dim2"))]
 use simba::scalar::ComplexField as _;
 
 bitflags::bitflags! {
@@ -291,6 +292,7 @@ pub(crate) fn relative_pose_drift(base: &Pose, cur: &Pose, max_extent: Real) -> 
         } else {
             1.0
         };
+
         2.0 * half_sin * max_extent
     };
     #[cfg(feature = "dim3")]
@@ -836,8 +838,9 @@ mod tests {
     use super::relative_pose_drift;
     use crate::math::{Pose, Real, Vector};
 
-    /// A pose compared against *itself* must report exactly no drift, whatever the orientation
-    /// and however far the shape reaches.
+    /// A pose compared against *itself* must report no drift beyond rounding noise (the
+    /// `cur ∘ base⁻¹` product is not exactly the identity), whatever the orientation and
+    /// however far the shape reaches: it must never eat into the sleep gate's allowance.
     #[test]
     fn same_pose_never_drifts() {
         // The sleep gate's per-step allowance at the default threshold and 60 Hz.
@@ -860,10 +863,11 @@ mod tests {
                 n += 1;
             }
         }
-        assert_eq!(
-            worst, 0.0,
+        let rounding_noise = 8.0 * Real::EPSILON * max_extent;
+        assert!(
+            worst <= rounding_noise,
             "an unmoved pose drifted by up to {worst} over {n} orientations \
-             (the sleep gate allows {allowance} per step)"
+             (rounding noise is {rounding_noise}, the sleep gate allows {allowance} per step)"
         );
     }
 }

--- a/src/geometry/narrow_phase/pair_update.rs
+++ b/src/geometry/narrow_phase/pair_update.rs
@@ -427,28 +427,9 @@ pub(super) fn process_pair(
                 prediction_distance,
             );
 
-            // Order a 4-point manifold as two DIAGONAL pairs: the block solver couples
-            // ((0,1),(2,3)), and a diagonal spans the face in both directions so rocking
-            // stays inside a 2x2 LCP block — load-bearing for tall-stack stability.
-            #[cfg(all(feature = "dim3", feature = "block-solver"))]
-            if num_selected == 4 {
-                let p = |i: usize| manifold.points[selected[i]].local_p1;
-                let d2 = |a, b| (p(a) - p(b)).length_squared();
-                // Partner of point 0 = farthest of the remaining three.
-                let far = if d2(0, 1) >= d2(0, 2) && d2(0, 1) >= d2(0, 3) {
-                    1
-                } else if d2(0, 2) >= d2(0, 3) {
-                    2
-                } else {
-                    3
-                };
-                selected.swap(1, far);
-            }
-
-            // GS point order is a real solver DOF: sort lexicographically in the contact plane
-            // (basis from `local_n1`, frame-invariant; normal excluded) — stack-30 sleeping 2/8 -> 8/8.
-            // Do NOT reverse `selected`: the native cycle preserves x<->z symmetry; reversed breaks it (0/8).
-            #[cfg(all(feature = "dim3", not(feature = "block-solver")))]
+            // Sort points lexicographically on the contact plane (in `local_n1`'s orthonormal-
+            // basis frame): picked empirically for pyramid stability over the alternatives.
+            #[cfg(all(feature = "dim3"))]
             if num_selected > 1 {
                 use crate::utils::OrthonormalBasis;
                 let basis = manifold.local_n1.orthonormal_basis();
@@ -458,9 +439,7 @@ pub(super) fn process_pair(
                     let p = manifold.points[*sel].local_p1;
                     keyed[i] = (p.dot(basis[0]), p.dot(basis[1]), *sel);
                 }
-                // Insertion sort with direct float compares: at most 4 elements,
-                // and this runs on every manifold of every full update, so the
-                // generic `sort_unstable_by` + `partial_cmp` costs real time here.
+                // Manual insertion sort: much faster than `sort_unstable_by` for 4 elements.
                 for i in 1..num_selected {
                     let k = keyed[i];
                     let mut j = i;

--- a/src/geometry/narrow_phase/pair_update.rs
+++ b/src/geometry/narrow_phase/pair_update.rs
@@ -429,7 +429,7 @@ pub(super) fn process_pair(
 
             // Sort points lexicographically on the contact plane (in `local_n1`'s orthonormal-
             // basis frame): picked empirically for pyramid stability over the alternatives.
-            #[cfg(all(feature = "dim3"))]
+            #[cfg(feature = "dim3")]
             if num_selected > 1 {
                 use crate::utils::OrthonormalBasis;
                 let basis = manifold.local_n1.orthonormal_basis();

--- a/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_pipeline.rs
@@ -1,7 +1,7 @@
 use super::{DebugColor, DebugRenderBackend, outlines};
 use crate::alloc_prelude::*;
 use crate::dynamics::{
-    GenericJoint, ImpulseJointSet, MultibodyJointSet, RigidBodySet, RigidBodyType,
+    GenericJoint, ImpulseJointSet, MultibodyJointSet, RigidBody, RigidBodySet, RigidBodyType,
 };
 use crate::geometry::{Ball, ColliderSet, Cuboid, NarrowPhase, Shape, TypedShape};
 #[cfg(feature = "dim3")]
@@ -76,6 +76,25 @@ impl DebugRenderPipeline {
             instances: outlines::instances(style.subdivisions),
             style,
             mode,
+        }
+    }
+
+    /// The color multiplier for one body's attached entities: disabled, asleep, sleep-eligible,
+    /// or plain awake. `eligible_tint` opts out for entities whose hue already carries meaning.
+    fn body_color_multiplier(
+        &self,
+        rb: &RigidBody,
+        co_enabled: bool,
+        eligible_tint: bool,
+    ) -> DebugColor {
+        if !rb.is_enabled() || !co_enabled {
+            self.style.disabled_color_multiplier
+        } else if rb.is_sleeping() {
+            self.style.sleep_color_multiplier
+        } else if eligible_tint && !rb.is_fixed() && rb.activation().is_eligible_for_sleep() {
+            self.style.sleep_eligible_color_multiplier
+        } else {
+            [1.0; 4]
         }
     }
 
@@ -202,12 +221,15 @@ impl DebugRenderPipeline {
             }
 
             if let (Some(rb1), Some(rb2)) = (bodies.get(body1), bodies.get(body2)) {
+                let settled = |rb: &RigidBody| rb.is_fixed() || rb.is_sleeping();
+                let eligible =
+                    |rb: &RigidBody| settled(rb) || rb.activation().is_eligible_for_sleep();
                 let coeff = if !data.is_enabled() || !rb1.is_enabled() || !rb2.is_enabled() {
                     self.style.disabled_color_multiplier
-                } else if (rb1.is_fixed() || rb1.is_sleeping())
-                    && (rb2.is_fixed() || rb2.is_sleeping())
-                {
+                } else if settled(rb1) && settled(rb2) {
                     self.style.sleep_color_multiplier
+                } else if eligible(rb1) && eligible(rb2) {
+                    self.style.sleep_eligible_color_multiplier
                 } else {
                     [1.0; 4]
                 };
@@ -283,13 +305,7 @@ impl DebugRenderPipeline {
                 let basis = Matrix::from_angle(rb.rotation().angle());
                 #[cfg(feature = "dim3")]
                 let basis = Matrix::from_quat(*rb.rotation());
-                let coeff = if !rb.is_enabled() {
-                    self.style.disabled_color_multiplier
-                } else if rb.is_sleeping() {
-                    self.style.sleep_color_multiplier
-                } else {
-                    [1.0; 4]
-                };
+                let coeff = self.body_color_multiplier(rb, true, false);
                 let colors = [
                     [0.0 * coeff[0], 1.0 * coeff[1], 0.25 * coeff[2], coeff[3]],
                     [120.0 * coeff[0], 1.0 * coeff[1], 0.1 * coeff[2], coeff[3]],
@@ -320,13 +336,7 @@ impl DebugRenderPipeline {
 
                 if backend.filter_object(object) {
                     let color = if let Some(parent) = co.parent().and_then(|p| bodies.get(p)) {
-                        let coeff = if !parent.is_enabled() || !co.is_enabled() {
-                            self.style.disabled_color_multiplier
-                        } else if parent.is_sleeping() {
-                            self.style.sleep_color_multiplier
-                        } else {
-                            [1.0; 4]
-                        };
+                        let coeff = self.body_color_multiplier(parent, co.is_enabled(), true);
                         let c = match parent.body_type {
                             RigidBodyType::Fixed => self.style.collider_fixed_color,
                             RigidBodyType::Dynamic => self.style.collider_dynamic_color,

--- a/src/pipeline/debug_render_pipeline/debug_render_style.rs
+++ b/src/pipeline/debug_render_pipeline/debug_render_style.rs
@@ -36,6 +36,9 @@ pub struct DebugRenderStyle {
     /// multiplied by this array. (For a joint, both attached rigid-bodies must be sleeping
     /// or non-dynamic for this multiplier to be applied).
     pub sleep_color_multiplier: DebugColor,
+    /// If a rigid-body is awake but eligible for sleep, its attached entities will have their
+    /// colors multiplied by this array: the plain awake color then marks what holds a pile awake.
+    pub sleep_eligible_color_multiplier: DebugColor,
     /// If a rigid-body is disabled, its attached entities will have their colors
     /// multiplied by this array. (For a joint, both attached rigid-bodies must be disabled
     /// for this multiplier to be applied).
@@ -66,6 +69,9 @@ impl Default for DebugRenderStyle {
             multibody_joint_anchor_color: [300.0, 1.0, 0.4, 1.0],
             multibody_joint_separation_color: [0.0, 1.0, 0.4, 1.0],
             sleep_color_multiplier: [1.0, 1.0, 0.2, 1.0],
+            // A hue rotation, not a dimming: the three sleep states must be told apart at a
+            // glance, and lightness steps of one hue are not enough.
+            sleep_eligible_color_multiplier: [0.35, 1.0, 1.4, 1.0],
             disabled_color_multiplier: [0.0, 0.0, 1.0, 1.0],
             rigid_body_axes_length: 0.5,
             contact_depth_color: [120.0, 1.0, 0.4, 1.0],

--- a/src_testbed/graphics.rs
+++ b/src_testbed/graphics.rs
@@ -2,7 +2,6 @@
 
 use crate::testbed::TestbedStateFlags;
 use kiss3d::prelude::*;
-use rand_pcg::Pcg32;
 use rapier::dynamics::{RigidBodyHandle, RigidBodySet};
 use rapier::geometry::{ColliderHandle, ColliderSet, Shape, ShapeType, SharedShape};
 use std::collections::HashMap;
@@ -161,7 +160,7 @@ pub enum NodeLocation {
 
 pub struct GraphicsManager {
     scene: SceneNode,
-    rand: Pcg32,
+    curr_color_index: usize,
     /// Template nodes for instanced primitives
     templates: HashMap<ShapeTemplateType, ShapeTemplate>,
     /// Individual nodes for complex shapes (trimesh, heightfield, etc.)
@@ -240,7 +239,7 @@ impl GraphicsManager {
     pub fn new() -> GraphicsManager {
         GraphicsManager {
             scene: Default::default(),
-            rand: Pcg32::new(0, 1),
+            curr_color_index: 0,
             templates: HashMap::new(),
             individual_nodes: Vec::new(),
             body_attached_nodes: Vec::new(),
@@ -276,7 +275,6 @@ impl GraphicsManager {
         self.c2color.clear();
         self.b2color.clear();
         self.b2wireframe.clear();
-        self.rand = Pcg32::new(0, 1);
         // Per-channel visibility is also reset so example A doesn't leak
         // its rendering choices into example B after a swap.
         self.colliders_visible = true;
@@ -741,13 +739,18 @@ impl GraphicsManager {
     }
 
     pub fn next_color(&mut self) -> Rgba<f32> {
-        Self::gen_color(&mut self.rand)
+        Self::gen_color(&mut self.curr_color_index)
     }
 
-    fn gen_color(rng: &mut Pcg32) -> Rgba<f32> {
-        use rand::RngExt;
-        let [r, g, b]: [f32; 3] = rng.random();
-        [r, g, b, 1.0].into()
+    fn gen_color(curr_color_index: &mut usize) -> Rgba<f32> {
+        let palette = [
+            [0.02, 0.44, 0.19, 1.0],
+            [0.36, 0.13, 0.66, 1.0],
+            [0.44, 0.94, 0.23, 1.0],
+            [0.85, 0.51, 0.98, 1.0],
+        ];
+        *curr_color_index += 1;
+        palette[*curr_color_index % palette.len()].into()
     }
 
     fn alloc_color(&mut self, handle: RigidBodyHandle, is_fixed: bool) -> Color {
@@ -756,7 +759,7 @@ impl GraphicsManager {
         if !is_fixed {
             match self.b2color.get(&handle).cloned() {
                 Some(c) => color = c,
-                None => color = Self::gen_color(&mut self.rand),
+                None => color = Self::gen_color(&mut self.curr_color_index),
             }
         }
 


### PR DESCRIPTION
The overhead of the recalculations appears to be measurable on smaller scenes, while the benefit of larger scenes is negligible.

This also fixes the python bindings CI failures that were ignored in https://github.com/dimforge/rapier/pull/973
This also fixes issues that cause some visually-still stacks to not fall asleep. 