### PR TITLE
Release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.35.0 (08 August 2026)
 
 ### Added
 
@@ -41,6 +41,34 @@
   including movements exactly orthogonal to the up vector, instead of requiring a downward
   motion larger than an arbitrary epsilon. Purely lateral movement along the ground no longer
   flickers the `grounded` flag when snap-to-ground is enabled (PR #481 by @ChrisJanssens).
+- Restitution is now applied as an end-of-step pass instead of during the velocity solve, so
+  contacts detected speculatively (within the prediction distance) bounce with the requested
+  coefficient instead of being damped away by the prediction distance (issue #974).
+- SIMD joint constraints now build their local frames relative to the body's center of mass,
+  fixing joints on bodies whose center of mass isn't at their origin (PR #953 by @Kyzzsa).
+- The broad phase now filters candidate pairs by collision groups, so colliders that can never
+  interact don't reach the narrow phase at all (issue #288).
+- `ContactForceEvent` sums the pair's *solver* manifolds, so contact clustering no longer
+  makes the reported force and contact point disagree with what the solver applied.
+- Generic (multibody) contact constraints now rebuild their anchors in the same frames the
+  substep update uses, fixing multibodies welded to rigid-bodies never settling (issue #968).
+- `RigidBodyBuilder::additional_mass` on a body whose colliders are all massless (zero density)
+  now derives the angular inertia from the collider shapes instead of leaving it null, so such
+  bodies rotate (issue #666).
+- Joints specified through a subset of their axes now complete the missing frame axes with a
+  twist-consistent minimal rotation, so a prismatic joint whose axis isn't `x` no longer picks
+  an arbitrarily rolled frame (issue #746).
+- `RigidBody::sleep()` is now honored immediately, even when the body was repositioned during
+  the same frame (issue #448).
+- `ImpulseJointSet::joints_between` now yields every joint between the two bodies instead of
+  only the first (issue #866).
+- `CollisionPipeline::step` now clears the rigid-bodies' modified flags, so a collision-only
+  pipeline no longer accumulates stale change tracking (issue #662).
+- Contact impulses are stored with canonicalized signed zeros, removing a source of
+  cross-platform divergence with `enhanced-determinism`.
+- The debug-renderer now draws the border radius of 2D round triangles (issue #634).
+- Testbed: objects no longer flash visible for one frame when the surface rendering is
+  disabled (issue #843).
 
 ### Modified
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ exclude = ["typescript"]
 resolver = "2"
 
 [workspace.package]
-version = "0.35.0-beta.0"
+version = "0.35.0"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 homepage = "https://rapier.rs"
 repository = "https://github.com/dimforge/rapier"
@@ -124,18 +124,18 @@ getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = "0.2"
 
 # Internal crates (paths are relative to the workspace root)
-rapier2d = { version = "0.35.0-beta.0", path = "crates/rapier2d" }
-rapier2d-f64 = { version = "0.35.0-beta.0", path = "crates/rapier2d-f64" }
-rapier3d = { version = "0.35.0-beta.0", path = "crates/rapier3d" }
-rapier3d-f64 = { version = "0.35.0-beta.0", path = "crates/rapier3d-f64" }
-rapier_testbed2d = { version = "0.35.0-beta.0", path = "crates/rapier_testbed2d" }
-rapier_testbed2d-f64 = { version = "0.35.0-beta.0", path = "crates/rapier_testbed2d-f64" }
-rapier_testbed3d = { version = "0.35.0-beta.0", path = "crates/rapier_testbed3d" }
-rapier_testbed3d-f64 = { version = "0.35.0-beta.0", path = "crates/rapier_testbed3d-f64" }
-rapier3d-urdf = { version = "0.35.0-beta.0", path = "crates/rapier3d-urdf" }
-rapier3d-meshloader = { version = "0.35.0-beta.0", path = "crates/rapier3d-meshloader", default-features = false }
-mjcf-rs = { version = "0.35.0-beta.0", path = "crates/mjcf-rs" }
-rapier3d-mjcf = { version = "0.35.0-beta.0", path = "crates/rapier3d-mjcf" }
+rapier2d = { version = "0.35.0", path = "crates/rapier2d" }
+rapier2d-f64 = { version = "0.35.0", path = "crates/rapier2d-f64" }
+rapier3d = { version = "0.35.0", path = "crates/rapier3d" }
+rapier3d-f64 = { version = "0.35.0", path = "crates/rapier3d-f64" }
+rapier_testbed2d = { version = "0.35.0", path = "crates/rapier_testbed2d" }
+rapier_testbed2d-f64 = { version = "0.35.0", path = "crates/rapier_testbed2d-f64" }
+rapier_testbed3d = { version = "0.35.0", path = "crates/rapier_testbed3d" }
+rapier_testbed3d-f64 = { version = "0.35.0", path = "crates/rapier_testbed3d-f64" }
+rapier3d-urdf = { version = "0.35.0", path = "crates/rapier3d-urdf" }
+rapier3d-meshloader = { version = "0.35.0", path = "crates/rapier3d-meshloader", default-features = false }
+mjcf-rs = { version = "0.35.0", path = "crates/mjcf-rs" }
+rapier3d-mjcf = { version = "0.35.0", path = "crates/rapier3d-mjcf" }
 
 # Dev
 bincode = "1"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.35.0-beta.0"
+version = "0.35.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.35.0-beta.0"
+version = "0.35.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.35.0-beta.0"
+version = "0.35.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.35.0-beta.0"
+version = "0.35.0"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/python/rapier-testbed/pyproject.toml
+++ b/python/rapier-testbed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapier-testbed"
-version = "0.35.0b0"
+version = "0.35.0"
 description = "Panda3D-based visual testbed and example gallery for the Rapier Python bindings."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.20.0 (08 August 2026)
 
 ### Breaking changes
 
@@ -18,6 +18,28 @@
 - `TempContactManifold.solverContactFriction` and `solverContactRestitution` became
   `friction()` and `restitution()`, without a contact index: friction and restitution are
   now combined once per manifold, so every solver contact of a manifold shares them.
+
+### Added
+
+- `SphericalImpulseJoint` motors are now exposed (they were commented out as "unsupported"):
+  `configureMotorModel`, `setMotorMaxForce`, `configureMotorVelocity`, `configureMotorPosition`
+  and `configureMotor`. They are all per-axis and take a new `JointAxis` enum as their first
+  argument (issue #791).
+
+### Fixed
+
+- The `-compat` packages now pass the embedded wasm module to `init()` as an object, fixing
+  initialization with recent `wasm-bindgen` output (issues #977, #811).
+- The `-compat` `raw.d.ts` now points at the wasm module matching the built feature variant
+  (deterministic/simd), instead of always the default one (PR #964).
+
+### Modified
+
+- Update to Rapier 0.35.0: rewritten sleeping (persistent islands), a sweep-based CCD that is
+  now enabled by default against fixed colliders, a reworked narrow-phase/solver and a broad
+  phase tuned for large mostly-static worlds. Several contact and sleeping defaults changed —
+  see [rapier's changelog](https://github.com/dimforge/rapier/blob/master/CHANGELOG.md#v0350-08-august-2026)
+  for the full list.
 
 ## 0.19.3 (05 Nov. 2025)
 

--- a/typescript/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/typescript/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.19.3"
+version = "0.20.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"
@@ -30,7 +30,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 # `rapier{2,3}d` is patched to the in-repo crate (see the workspace
 # `[patch.crates-io]` in ../../Cargo.toml); this version requirement must stay
 # semver-compatible with that crate's version for the patch to take effect.
-rapier{{ dimension }}d = { version = "0.35.0-beta.0", features = [
+rapier{{ dimension }}d = { version = "0.35.0", features = [
     "serde-serialize",
     "debug-render",
     "profiler",


### PR DESCRIPTION
## v0.35.0 (08 August 2026)

### Added

- `ContactForceEvent::first_tick`: `true` on the step a pair's total contact force first
  exceeds its `contact_force_event_threshold` (coming from below it, or from separation),
  `false` while it stays above on consecutive steps — the analogue of PhysX's
  "threshold force found" vs "persists" report. The status resets when the force drops
  back below the threshold or the colliders separate.

- `CoefficientCombineRule::GeometricMean`: combines friction/restitution as
  `sqrt(c1 * c2)`, the convention used by several other engines. It has the highest
  rule priority, and clamps negative coefficients to zero before the square root.
- `DebugRenderStyle::sleep_eligible_color_multiplier`: the debug-renderer now draws bodies that
  are eligible for sleep but still awake in a distinct color, making it easy to spot what is
  keeping a pile awake.

### Fixed

- `Wheel::rotation` now accumulates from the wheel's own rolling direction on the
  contact plane (`contact normal × axle`, the same forward direction used by the
  friction update) instead of the chassis' `index_forward_axis`, so wheels visually
  spin whenever the vehicle actually rolls (adapted from PR #950 by @tomo0613).
- `DynamicRayCastVehicleController` no longer has unlimited braking friction when a
  wheel's side impulse is exactly zero (e.g. braking in a straight line): the skid
  clamp now applies to the forward impulse as well, so braking strength is bounded by
  `friction_slip` (adapted from PR #947 by @tomo0613).
- Angular joint limits are no longer restricted to `(-π, π)`: the limit rows now measure the
  wrapped joint angle from the middle of the allowed range (with the joint axis as the row's
  jacobian, like the angular motor rows), so a range may sit anywhere on the circle
  (`[0, 3π/2]` stops the joint at 3π/2 instead of π/2, and ranges crossing the ±π seam like
  `[3π/4, 5π/4]` work at all). A range wider than a full turn is indistinguishable from "no
  limit" for an angle read off a relative rotation, so it now leaves the axis free instead of
  clamping it at some folded-back angle.
- Joint limit rows (linear and angular) now cap their position-correction bias by
  `IntegrationParameters::max_corrective_velocity`, like contacts always did: a deep limit
  violation recovers over a few steps instead of catapulting the bodies.
- Python: `DynamicRayCastVehicleController.update_vehicle` now excludes the chassis body from
  the suspension raycasts by default (their origins sit on its own collider).
- The character controller's snap-to-ground now triggers on any movement that isn't upwards,
  including movements exactly orthogonal to the up vector, instead of requiring a downward
  motion larger than an arbitrary epsilon. Purely lateral movement along the ground no longer
  flickers the `grounded` flag when snap-to-ground is enabled (PR #481 by @ChrisJanssens).
- Restitution is now applied as an end-of-step pass instead of during the velocity solve, so
  contacts detected speculatively (within the prediction distance) bounce with the requested
  coefficient instead of being damped away by the prediction distance (issue #974).
- SIMD joint constraints now build their local frames relative to the body's center of mass,
  fixing joints on bodies whose center of mass isn't at their origin (PR #953 by @Kyzzsa).
- The broad phase now filters candidate pairs by collision groups, so colliders that can never
  interact don't reach the narrow phase at all (issue #288).
- `ContactForceEvent` sums the pair's *solver* manifolds, so contact clustering no longer
  makes the reported force and contact point disagree with what the solver applied.
- Generic (multibody) contact constraints now rebuild their anchors in the same frames the
  substep update uses, fixing multibodies welded to rigid-bodies never settling (issue #968).
- `RigidBodyBuilder::additional_mass` on a body whose colliders are all massless (zero density)
  now derives the angular inertia from the collider shapes instead of leaving it null, so such
  bodies rotate (issue #666).
- Joints specified through a subset of their axes now complete the missing frame axes with a
  twist-consistent minimal rotation, so a prismatic joint whose axis isn't `x` no longer picks
  an arbitrarily rolled frame (issue #746).
- `RigidBody::sleep()` is now honored immediately, even when the body was repositioned during
  the same frame (issue #448).
- `ImpulseJointSet::joints_between` now yields every joint between the two bodies instead of
  only the first (issue #866).
- `CollisionPipeline::step` now clears the rigid-bodies' modified flags, so a collision-only
  pipeline no longer accumulates stale change tracking (issue #662).
- Contact impulses are stored with canonicalized signed zeros, removing a source of
  cross-platform divergence with `enhanced-determinism`.
- The debug-renderer now draws the border radius of 2D round triangles (issue #634).
- Testbed: objects no longer flash visible for one frame when the surface rendering is
  disabled (issue #843).

### Modified

- The broad phase no longer creates pairs between colliders attached to the same
  rigid-body (they can never collide). A single awake body carrying thousands of
  mutually-overlapping colliders previously flooded the pair map and contact graph with
  pairs the narrow phase re-discarded every step; the issue #970 scene (2,210 convex
  colliders on one always-awake body) steps ~90x faster while stationary and ~18x
  faster while moving. Note that `NarrowPhase::contact_pair` now returns `None` for
  same-parent colliders instead of a manifold-less pair.
- Sleep eligibility is now judged on the actual per-step pose displacement (measured at the
  body’s farthest point) instead of the velocities: a body held in place by contacts can sleep
  even with residual solver velocities, while a body creeping through solver position
  corrections cannot.
- With the `block-solver` feature, manifolds whose 2x2 constraint matrix is almost singular
  (e.g. redundant contact points) are now solved with the sequential solver instead of a
  degraded one-point solve, removing residual jiggle in piles. The block solver also uses the
  same lexicographic manifold point ordering as the sequential solver.
- Improved 3D solver performance by caching the constraints angular jacobians instead of
  recomputing them at each solver iteration.