### PR TITLE
Release v0.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v0.35.2 (15 August 2026)
+
+### Fixed
+
+- Multibody: guard against the instabilities the semi-implicit coriolis term can introduce when
+  the mass matrix is near-singular. The free-velocity update is re-solved with the plain mass
+  matrix whenever it injects more energy than the applied forces’ work.
+- Motors and limits of multibody joints now honor their compliance (the CFM term was left out of
+  the row’s effective mass), so their gains may need to be stiffer to settle as fast as before.
+- Generic (multibody) joint constraints now reserve the exact number of jacobian rows they emit:
+  an axis carrying both a motor and a limit produces two, exceeding the previous allocation.
+- The impulses reported on contacts (and the contact-force events derived from them) are now the
+  total impulse applied during the step, instead of one substep too many: they drop by
+  `1 / (num_solver_iterations + 1)` and no longer vary with `warmstart_coefficient`.
+- MJCF: a geom’s `margin` is no longer loaded as a `contact_skin`, which made geoms rest that far
+  apart. It is ignored below rapier’s speculative-contact distance, and becomes the body’s
+  soft-CCD prediction above it (`PairOverride::margin` is removed).
+- MJCF: actuators now load as `MotorModel::ForceBased`, matching MuJoCo gains, which are absolute
+  generalized forces rather than accelerations.
+
 ## v0.35.1 (08 August 2026)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ exclude = ["typescript"]
 resolver = "2"
 
 [workspace.package]
-version = "0.35.1"
+version = "0.35.2"
 authors = ["Sébastien Crozet <sebcrozet@dimforge.com>"]
 homepage = "https://rapier.rs"
 repository = "https://github.com/dimforge/rapier"
@@ -100,7 +100,7 @@ libc = "0.2"
 Inflector = "0.11"
 md5 = "0.8"
 egui = "0.34"
-puffin_egui = "0.29"
+puffin_egui = "0.30"
 indexmap = { version = "2", features = ["serde"] }
 kiss3d = { version = "0.45.0", features = ["egui", "serde"] }
 env_logger = "0.11"
@@ -124,18 +124,18 @@ getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = "0.2"
 
 # Internal crates (paths are relative to the workspace root)
-rapier2d = { version = "0.35.1", path = "crates/rapier2d" }
-rapier2d-f64 = { version = "0.35.1", path = "crates/rapier2d-f64" }
-rapier3d = { version = "0.35.1", path = "crates/rapier3d" }
-rapier3d-f64 = { version = "0.35.1", path = "crates/rapier3d-f64" }
-rapier_testbed2d = { version = "0.35.1", path = "crates/rapier_testbed2d" }
-rapier_testbed2d-f64 = { version = "0.35.1", path = "crates/rapier_testbed2d-f64" }
-rapier_testbed3d = { version = "0.35.1", path = "crates/rapier_testbed3d" }
-rapier_testbed3d-f64 = { version = "0.35.1", path = "crates/rapier_testbed3d-f64" }
-rapier3d-urdf = { version = "0.35.1", path = "crates/rapier3d-urdf" }
-rapier3d-meshloader = { version = "0.35.1", path = "crates/rapier3d-meshloader", default-features = false }
-mjcf-rs = { version = "0.35.1", path = "crates/mjcf-rs" }
-rapier3d-mjcf = { version = "0.35.1", path = "crates/rapier3d-mjcf" }
+rapier2d = { version = "0.35.2", path = "crates/rapier2d" }
+rapier2d-f64 = { version = "0.35.2", path = "crates/rapier2d-f64" }
+rapier3d = { version = "0.35.2", path = "crates/rapier3d" }
+rapier3d-f64 = { version = "0.35.2", path = "crates/rapier3d-f64" }
+rapier_testbed2d = { version = "0.35.2", path = "crates/rapier_testbed2d" }
+rapier_testbed2d-f64 = { version = "0.35.2", path = "crates/rapier_testbed2d-f64" }
+rapier_testbed3d = { version = "0.35.2", path = "crates/rapier_testbed3d" }
+rapier_testbed3d-f64 = { version = "0.35.2", path = "crates/rapier_testbed3d-f64" }
+rapier3d-urdf = { version = "0.35.2", path = "crates/rapier3d-urdf" }
+rapier3d-meshloader = { version = "0.35.2", path = "crates/rapier3d-meshloader", default-features = false }
+mjcf-rs = { version = "0.35.2", path = "crates/mjcf-rs" }
+rapier3d-mjcf = { version = "0.35.2", path = "crates/rapier3d-mjcf" }
 
 # Dev
 bincode = "1"

--- a/crates/rapier2d/tests/snapshot_portability.rs
+++ b/crates/rapier2d/tests/snapshot_portability.rs
@@ -31,7 +31,7 @@ use rapier2d::prelude::*;
 /// Snapshot size in bytes, and its FNV-1a digest. Both, because the size alone localizes a
 /// failure: a differing size means a container's *encoding* changed, an equal size with a
 /// differing digest means the values did.
-const GOLDEN: (usize, u64) = (88_532, 0x6b31_7afb_d1fa_bf95);
+const GOLDEN: (usize, u64) = (88_532, 0xccad_c968_4d93_9348);
 
 const STEPS: usize = 60;
 

--- a/crates/rapier3d/tests/issue_372_trimesh_sleep.rs
+++ b/crates/rapier3d/tests/issue_372_trimesh_sleep.rs
@@ -119,7 +119,7 @@ fn capsule_on_trimesh_falls_asleep() {
     let capsule = h.bodies.insert(
         RigidBodyBuilder::dynamic()
             .translation(Vector::new(-5.0, 1.0, 5.0))
-            .rotation(Vector::new(std::f32::consts::FRAC_PI_2 as Real, 0.0, 0.0))
+            .rotation(Vector::new(std::f32::consts::FRAC_PI_2, 0.0, 0.0))
             .linvel(Vector::new(0.012, 0.0, 0.0)),
     );
     h.colliders

--- a/crates/rapier3d/tests/issue_836_physics_world.rs
+++ b/crates/rapier3d/tests/issue_836_physics_world.rs
@@ -34,10 +34,7 @@ fn physics_world_builds_steps_and_queries_a_scene() {
     );
 
     // Queries work directly through the world.
-    let ray = Ray::new(
-        Vector::new(0.0, 20.0, 0.0).into(),
-        Vector::new(0.0, -1.0, 0.0),
-    );
+    let ray = Ray::new(Vector::new(0.0, 20.0, 0.0), Vector::new(0.0, -1.0, 0.0));
     let hit = world.cast_ray(&ray, 100.0, true, QueryFilter::default());
     assert!(hit.is_some(), "raycast through PhysicsWorld found no hit");
 }

--- a/crates/rapier3d/tests/parallel_path_parity.rs
+++ b/crates/rapier3d/tests/parallel_path_parity.rs
@@ -26,7 +26,7 @@ use rapier3d::prelude::*;
 
 /// Golden hash of [`run`]. Identical in every build; re-mint (with a note saying why)
 /// only when a change is *meant* to alter the simulation.
-const GOLDEN: u64 = 0x0c46_183e_4fbf_cfbb;
+const GOLDEN: u64 = 0x7c57_2d38_0b87_2d4c;
 
 /// FNV-1a.
 struct Fnv(u64);

--- a/crates/rapier3d/tests/snapshot_portability.rs
+++ b/crates/rapier3d/tests/snapshot_portability.rs
@@ -31,7 +31,7 @@ use rapier3d::prelude::*;
 /// Snapshot size in bytes, and its FNV-1a digest. Both, because the size alone localizes a
 /// failure: a differing size means a container's *encoding* changed, an equal size with a
 /// differing digest means the values did.
-const GOLDEN: (usize, u64) = (481_520, 0x506f_f44e_db9a_7b9b);
+const GOLDEN: (usize, u64) = (481_520, 0xe06b_d263_cd02_7324);
 
 const STEPS: usize = 60;
 

--- a/crates/rapier3d/tests/total_contact_impulse.rs
+++ b/crates/rapier3d/tests/total_contact_impulse.rs
@@ -1,0 +1,75 @@
+//! The impulse reported on a contact must be the total impulse the solver applied during the
+//! step (warm-start impulses included), whatever `IntegrationParameters::warmstart_coefficient`
+//! is set to. A body resting under gravity pins that value exactly: its velocity is unchanged
+//! over the step, so the contacts must have countered gravity with `m * g * dt`.
+
+use rapier3d::pipeline::PhysicsWorld;
+use rapier3d::prelude::*;
+
+const GRAVITY: Real = 9.81;
+const MASS: Real = 1.0;
+
+/// Reported contact impulse magnitude after the body has come to rest.
+fn resting_impulse(warmstart_coefficient: Real, multibody: bool, cuboid: bool) -> Real {
+    let mut world = PhysicsWorld::new();
+    world.integration_parameters.warmstart_coefficient = warmstart_coefficient;
+    world.insert_collider(
+        ColliderBuilder::cuboid(10.0, 0.5, 10.0).translation(Vector::new(0.0, -0.5, 0.0)),
+        None,
+    );
+
+    let shape = if cuboid {
+        ColliderBuilder::cuboid(0.5, 0.5, 0.5)
+    } else {
+        ColliderBuilder::ball(0.5)
+    };
+    let (body, _) = world.insert(
+        RigidBodyBuilder::dynamic()
+            .translation(Vector::new(0.0, 0.5, 0.0))
+            .additional_mass(MASS)
+            .can_sleep(false),
+        shape.density(0.0),
+    );
+
+    if multibody {
+        // Attach the body to the ground through a multibody joint so its contacts go through
+        // the generic (multibody) constraint path instead of the SIMD one.
+        let anchor =
+            world.insert_body(RigidBodyBuilder::fixed().translation(Vector::new(0.0, 10.0, 0.0)));
+        let joint = PrismaticJointBuilder::new(Vector::Y)
+            .local_anchor1(Vector::ZERO)
+            .local_anchor2(Vector::ZERO);
+        world
+            .multibody_joints
+            .insert(anchor, body, joint, true)
+            .unwrap();
+    }
+
+    for _ in 0..300 {
+        world.step();
+    }
+
+    world
+        .narrow_phase
+        .contact_pairs()
+        .map(|p| p.total_impulse_magnitude())
+        .sum()
+}
+
+#[test]
+fn resting_impulse_matches_gravity_for_any_warmstart_coefficient() {
+    let expected = MASS * GRAVITY / 60.0; // m * g * dt, with the default 60 Hz timestep.
+
+    for &multibody in &[false, true] {
+        for &cuboid in &[false, true] {
+            for &coeff in &[1.0, 0.5, 0.0] {
+                let impulse = resting_impulse(coeff, multibody, cuboid);
+                assert!(
+                    (impulse - expected).abs() <= expected * 1.0e-2,
+                    "warmstart_coefficient = {coeff} (multibody: {multibody}, cuboid: {cuboid}): \
+                     reported {impulse}, expected {expected}"
+                );
+            }
+        }
+    }
+}

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier2d-f64"
 path = "../rapier2d-f64"
-version = "0.35.1"
+version = "0.35.2"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier2d"
 path = "../rapier2d"
-version = "0.35.1"
+version = "0.35.2"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier3d-f64"
 path = "../rapier3d-f64"
-version = "0.35.1"
+version = "0.35.2"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -60,5 +60,5 @@ env_logger.workspace = true
 [dependencies.rapier]
 package = "rapier3d"
 path = "../rapier3d"
-version = "0.35.1"
+version = "0.35.2"
 features = ["serde-serialize", "debug-render", "profiler"]

--- a/python/rapier-testbed/pyproject.toml
+++ b/python/rapier-testbed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapier-testbed"
-version = "0.35.1"
+version = "0.35.2"
 description = "Panda3D-based visual testbed and example gallery for the Rapier Python bindings."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/dynamics/joint/multibody_joint/multibody_ik.rs
+++ b/src/dynamics/joint/multibody_joint/multibody_ik.rs
@@ -210,8 +210,8 @@ mod test {
             #[cfg(feature = "dim3")]
             let builder = RevoluteJointBuilder::new(Vector::Z);
             let link_ab = builder
-                .local_anchor1((Vector::Y * (0.5 / num_segments as Real)).into())
-                .local_anchor2((Vector::Y * (-0.5 / num_segments as Real)).into());
+                .local_anchor1(Vector::Y * (0.5 / num_segments as Real))
+                .local_anchor2(Vector::Y * (-0.5 / num_segments as Real));
             last_link = multibodies
                 .insert(last_body, new_body, link_ab, true)
                 .unwrap();

--- a/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
+++ b/src/dynamics/solver/contact_constraint/contact_constraint_element.rs
@@ -53,7 +53,8 @@ impl<N: ScalarType> ContactConstraintTangentPart<N> {
         }
     }
 
-    /// Total impulse applied across all the solver substeps.
+    /// Total impulse applied during the step: the sum, over every solver substep, of the
+    /// impulse that substep ended on (the warm-start impulse it re-applied included).
     #[inline]
     pub fn total_impulse(&self) -> TangentImpulse<N> {
         self.impulse_accumulator + self.impulse
@@ -214,7 +215,8 @@ impl<N: ScalarType> ContactConstraintNormalPart<N> {
         }
     }
 
-    /// Total impulse applied across all the solver substeps.
+    /// Total impulse applied during the step: the sum, over every solver substep, of the
+    /// impulse that substep ended on (the warm-start impulse it re-applied included).
     #[inline]
     pub fn total_impulse(&self) -> N {
         self.impulse_accumulator + self.impulse
@@ -452,7 +454,8 @@ impl<N: ScalarType> ContactConstraintNormalPartSlim<N>
 where
     N::Vector: CrossProduct<N::Vector, Result = N::AngVector>,
 {
-    /// Total impulse applied across all the solver substeps.
+    /// Total impulse applied during the step: the sum, over every solver substep, of the
+    /// impulse that substep ended on (the warm-start impulse it re-applied included).
     #[inline]
     pub fn total_impulse(&self) -> N {
         self.impulse_accumulator + self.impulse

--- a/src/dynamics/solver/contact_constraint/contact_with_coulomb_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_coulomb_friction.rs
@@ -243,10 +243,12 @@ impl ContactWithCoulombFrictionBuilder {
                 out_constraint.normal_part[k].ii_torque_dir1 = ii_torque_dir1;
                 out_constraint.normal_part[k].ii_torque_dir2 = ii_torque_dir2;
                 out_constraint.normal_part[k].impulse = warmstart_impulse;
-                // The accumulator must start at zero every step: the constraint buffers are
+                // The accumulator is written explicitly every step: the constraint buffers are
                 // reused without zeroing (`reset_buffer_reusing`), so stale bytes survive in
-                // fields `generate` doesn't write.
-                out_constraint.normal_part[k].impulse_accumulator = SimdReal::zero();
+                // fields `generate` doesn't write. It starts at minus the warm-start impulse so
+                // that the first substep's `update` (which folds in whatever `impulse` holds)
+                // cancels it out: that value was applied by the previous step, not this one.
+                out_constraint.normal_part[k].impulse_accumulator = -warmstart_impulse;
                 // Zero effective mass on inactive slots: the scalar normal solve
                 // is then an exact no-op (impulse stays at its zeroed warm-start).
                 out_constraint.normal_part[k].r = projected_mass.select(active, SimdReal::zero());
@@ -254,8 +256,8 @@ impl ContactWithCoulombFrictionBuilder {
 
             // tangent parts.
             out_constraint.tangent_part[k].impulse = warmstart_tangent_impulse;
-            // See the normal part: explicit zero, the buffers are not zeroed.
-            out_constraint.tangent_part[k].impulse_accumulator = na::zero();
+            // See the normal part: explicit write, the buffers are not zeroed.
+            out_constraint.tangent_part[k].impulse_accumulator = -warmstart_tangent_impulse;
 
             for j in 0..DIM - 1 {
                 let torque_dir1 = dp1.gcross(tangents1[j]);
@@ -430,14 +432,17 @@ impl ContactWithCoulombFrictionBuilder {
                 // the twist-friction `update`).
                 normal_part.cfm_factor =
                     cfm_factor.select(dist.simd_le(SimdReal::zero()), SimdReal::splat(1.0));
-                normal_part.impulse *= warmstart_coeff;
+                // Bank the previous substep's impulse before the warm-start scaling: that full
+                // value is what the substep applied (its warm-start included), whereas the
+                // scaling only sets what this substep starts from.
                 normal_part.impulse_accumulator += normal_part.impulse;
+                normal_part.impulse *= warmstart_coeff;
             }
 
             // tangent parts.
             {
-                tangent_part.impulse *= warmstart_coeff;
                 tangent_part.impulse_accumulator += tangent_part.impulse;
+                tangent_part.impulse *= warmstart_coeff;
 
                 for j in 0..DIM - 1 {
                     let bias = (p1 - p2).gdot(tangents1[j]) * inv_dt;

--- a/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
+++ b/src/dynamics/solver/contact_constraint/contact_with_twist_friction.rs
@@ -281,7 +281,11 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                 // the scalar normal solve is an exact no-op.
                 out_constraint.normal_part[k].impulse =
                     warmstart_impulse.select(active, SimdReal::zero());
-                out_constraint.normal_part[k].impulse_accumulator = SimdReal::zero();
+                // Minus the warm-start impulse, so the first substep's `update` cancels it when
+                // it folds `impulse` in: that value belongs to the previous step (see the
+                // coulomb-friction `generate`).
+                out_constraint.normal_part[k].impulse_accumulator =
+                    -out_constraint.normal_part[k].impulse;
                 out_constraint.normal_part[k].r = projected_mass.select(active, SimdReal::zero());
             }
 
@@ -298,13 +302,13 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
          * Tangent/twist part
          */
         out_constraint.tangent_part.impulse = tangent_warmstart;
-        out_constraint.tangent_part.impulse_accumulator = na::zero();
+        out_constraint.tangent_part.impulse_accumulator = -tangent_warmstart;
         // The twist part only acts on lanes with more than one point (a single point offers no
         // lever arm): zero the warm-start of single-point lanes so a lane whose count just
         // dropped to one can't kick with its stale stored twist impulse.
         out_constraint.twist_part.impulse =
             twist_warmstart.select(counts_simd.simd_gt(SimdReal::splat(1.0)), SimdReal::zero());
-        out_constraint.twist_part.impulse_accumulator = SimdReal::zero();
+        out_constraint.twist_part.impulse_accumulator = -out_constraint.twist_part.impulse;
 
         out_builder.local_friction_center1 = poses1.inverse_transform_point(friction_center);
         out_builder.local_friction_center2 = poses2.inverse_transform_point(friction_center2);
@@ -492,8 +496,10 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                 // rocking. Only penetrating points get the soft treatment.
                 normal_part.cfm_factor =
                     cfm_factor.select(dist.simd_le(SimdReal::zero()), SimdReal::splat(1.0));
-                normal_part.impulse *= warmstart_coeff;
+                // Bank the previous substep's impulse before the warm-start scaling (see the
+                // coulomb-friction `update`).
                 normal_part.impulse_accumulator += normal_part.impulse;
+                normal_part.impulse *= warmstart_coeff;
             }
         }
 
@@ -506,10 +512,10 @@ impl ContactWithTwistFrictionBuilder<SimdReal> {
                 let bias = (p1 - p2).gdot(tangents1[j]) * inv_dt;
                 tangent_part.rhs[j] = tangent_part.rhs_wo_bias[j] + bias;
             }
-            tangent_part.impulse *= warmstart_coeff;
             tangent_part.impulse_accumulator += tangent_part.impulse;
-            twist_part.impulse *= warmstart_coeff;
+            tangent_part.impulse *= warmstart_coeff;
             twist_part.impulse_accumulator += twist_part.impulse;
+            twist_part.impulse *= warmstart_coeff;
         }
 
         constraint.cfm_factor = cfm_factor;

--- a/src/dynamics/solver/contact_constraint/generic_contact_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/generic_contact_constraint.rs
@@ -236,7 +236,10 @@ impl GenericContactConstraintBuilder {
                     rhs: Default::default(),
                     rhs_wo_bias: Default::default(),
                     cfm_factor: Default::default(),
-                    impulse_accumulator: Default::default(),
+                    // Minus the warm-start impulse, so the first substep's `update` cancels it
+                    // when it folds `impulse` in: that value belongs to the previous step (see
+                    // the coulomb-friction `generate`).
+                    impulse_accumulator: -pt_data.warmstart_impulse,
                     impulse: pt_data.warmstart_impulse,
                     r,
                     #[cfg(feature = "block-solver")]
@@ -258,6 +261,10 @@ impl GenericContactConstraintBuilder {
                 {
                     out_constraint.tangent_part[k].impulse = pt_data.warmstart_tangent_impulse;
                 }
+
+                // See the normal part.
+                out_constraint.tangent_part[k].impulse_accumulator =
+                    -out_constraint.tangent_part[k].impulse;
 
                 for j in 0..DIM - 1 {
                     let torque_dir1 = dp1.gcross(tangents1[j]);
@@ -469,14 +476,16 @@ impl GenericContactConstraintBuilder {
 
                 normal_part.rhs_wo_bias = rhs_wo_bias;
                 normal_part.rhs = new_rhs;
-                normal_part.impulse *= params.warmstart_coefficient;
+                // Bank the previous substep's impulse before the warm-start scaling (see the
+                // coulomb-friction `update`).
                 normal_part.impulse_accumulator += normal_part.impulse;
+                normal_part.impulse *= params.warmstart_coefficient;
             }
 
             // Tangent part.
             {
-                tangent_part.impulse *= params.warmstart_coefficient;
                 tangent_part.impulse_accumulator += tangent_part.impulse;
+                tangent_part.impulse *= params.warmstart_coefficient;
 
                 for j in 0..DIM - 1 {
                     let bias = (p1 - p2).gdot(tangents1[j]) * inv_dt;

--- a/src/dynamics/solver/joint_constraint/joint_constraint_helper.rs
+++ b/src/dynamics/solver/joint_constraint/joint_constraint_helper.rs
@@ -823,7 +823,7 @@ mod test {
             let at_max =
                 helper_at((center_deg as Real + 45.0).to_radians()).recentered_angle(0, &limit);
             assert!(
-                (at_max - (45.0 as Real).to_radians()).abs() < 1.0e-4,
+                (at_max - Real::to_radians(45.0)).abs() < 1.0e-4,
                 "center {center_deg}: at_max {at_max}"
             );
 


### PR DESCRIPTION
## v0.35.2 (15 August 2026)

### Fixed

- Multibody: guard against the instabilities the semi-implicit coriolis term can introduce when
  the mass matrix is near-singular. The free-velocity update is re-solved with the plain mass
  matrix whenever it injects more energy than the applied forces’ work.
- Motors and limits of multibody joints now honor their compliance (the CFM term was left out of
  the row’s effective mass), so their gains may need to be stiffer to settle as fast as before.
- Generic (multibody) joint constraints now reserve the exact number of jacobian rows they emit:
  an axis carrying both a motor and a limit produces two, exceeding the previous allocation.
- The impulses reported on contacts (and the contact-force events derived from them) are now the
  total impulse applied during the step, instead of one substep too many: they drop by
  `1 / (num_solver_iterations + 1)` and no longer vary with `warmstart_coefficient`.
- MJCF: a geom’s `margin` is no longer loaded as a `contact_skin`, which made geoms rest that far
  apart. It is ignored below rapier’s speculative-contact distance, and becomes the body’s
  soft-CCD prediction above it (`PairOverride::margin` is removed).
- MJCF: actuators now load as `MotorModel::ForceBased`, matching MuJoCo gains, which are absolute
  generalized forces rather than accelerations.